### PR TITLE
Modals: Clean up layout

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -122,7 +122,7 @@
     }
 
     .dialog__content {
-        padding: 24px 24px 0;
+        padding: 32px 32px 8px;
     }
 
     .dialog__action-buttons {

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -151,6 +151,7 @@
     .wp-admin & {
         select {
             height: auto;
+            box-shadow: none;
         }
     }
 

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -70,6 +70,11 @@
     }
 }
 
+#package_type {
+    display: block;
+    width: 100%;
+}
+
 .wcc-shipping-add-package-weight-group {
     .form-setting-explanation {
         margin-top: 68px;

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -58,8 +58,10 @@
 }
 
 .wcc-shipping-add-package-weight {
-    width: 200px;
-    float: left;
+    margin-bottom: 8px;
+    @include breakpoint( '>480px' ) {
+        float:left;
+    }
 
     .form-text-input {
         width: 88%;
@@ -77,7 +79,9 @@
 
 .wcc-shipping-add-package-weight-group {
     .form-setting-explanation {
-        margin-top: 68px;
+        @include breakpoint( '>480px' ) {
+            margin-top: 68px;
+        }
     }
 }
 


### PR DESCRIPTION
Cleaning up the Add a Package modal.

Before:

Small screen:
<img width="396" alt="before - small" src="https://cloud.githubusercontent.com/assets/5835847/14937533/7567a89e-0ec7-11e6-9c7d-93fd56152939.png">

Larger screen:
<img width="526" alt="before- large" src="https://cloud.githubusercontent.com/assets/5835847/14937534/7568b036-0ec7-11e6-93a5-5f26f693577c.png">

After:
<img width="413" alt="after - small" src="https://cloud.githubusercontent.com/assets/5835847/14937540/a0df5e90-0ec7-11e6-9450-d922604f20a6.png">

<img width="535" alt="screen shot 2016-04-30 at 11 35 02 am" src="https://cloud.githubusercontent.com/assets/5835847/14937541/a0e087f2-0ec7-11e6-9759-e6363a3efe26.png">

@jkudish or @jeffstieler for review. 