### PR TITLE
Add release npm task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 .idea
 dist
 .tmp
+npm-debug.log
+release

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "scripts": {
     "start": "cross-env NODE_ENV=development webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
     "dist": "cross-env NODE_ENV=production webpack -p --config webpack.production.config.js",
-    "eslint": "eslint client/",
-    "test": "mocha-webpack --webpack-config webpack.test.config.js client/**/test/*.js && npm run eslint"
+    "eslint": "eslint tasks/ client/",
+    "test": "mocha-webpack --webpack-config webpack.test.config.js client/**/test/*.js && npm run eslint",
+    "release": "node tasks/release.js"
   },
   "repository": {
     "type": "git",
@@ -14,11 +15,14 @@
   "license": "GPL-2.0",
   "description": "Connect allthethings",
   "devDependencies": {
+    "archiver": "^1.0.0",
     "autoprefixer": "^6.3.3",
     "babel-eslint": "^6.0.3",
     "babel-plugin-add-module-exports": "^0.1.3",
     "babel-polyfill": "^6.7.4",
     "chai": "3.5.0",
+    "colors": "^1.1.2",
+    "confirm-simple": "^1.0.3",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",
     "eslint": "2.2.0",
@@ -37,6 +41,7 @@
     "react-addons-test-utils": "0.14.7",
     "redbox-react": "^1.2.2",
     "sass-loader": "^3.1.2",
+    "shelljs": "^0.7.0",
     "style-loader": "^0.13.0",
     "tcomb": "2.7.0",
     "tcomb-form": "0.8.1",

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -1,0 +1,59 @@
+/*eslint no-process-exit: 0, no-undef: 0 */
+require( 'shelljs/global' );
+const colors = require( 'colors' );
+const confirm = require( 'confirm-simple' );
+const archiver = require( 'archiver' );
+const fs = require( 'fs' );
+
+// some config
+const releaseFolder = 'release';
+const targetFolder = 'release/wocommerce-connect';
+const dirsToCopy = [
+	'assets',
+	'classes',
+	'dist',
+	'vendor',
+];
+
+confirm( colors.cyan( 'Howdy! This script is going to create a release folder with a compiled ' +
+	'zipped up plugin ready for release. This script assumes you\'ve already checked out the correct branch, ' +
+	'are running the latest code, and have run tests as needed. You good with that?' ), ( ok ) => {
+	if ( ! ok ) {
+		console.log( 'OK. Abandoning ship'.magenta );
+		process.exit( 0 );
+	}
+
+	// run npm dist
+	exec( 'npm run dist' );
+
+	// start with a clean release folder
+	rm( '-rf', releaseFolder );
+	mkdir( releaseFolder );
+	mkdir( targetFolder );
+
+	// copy all markdown information files
+	cp( '*.md', targetFolder );
+
+	// copy the main php file
+	cp( 'woocommerce-connect-client.php', targetFolder );
+
+	// copy the directories to the release folder
+	cp( '-Rf', dirsToCopy, targetFolder );
+
+	const output = fs.createWriteStream( releaseFolder + '/woocommerce-connect.zip' );
+	const archive = archiver( 'zip' );
+
+	output.on( 'close', () => {
+		console.log( colors.green( 'All done: Release is built in the ' + releaseFolder + ' folder.' ) );
+	} );
+
+	archive.on( 'error', ( err ) => {
+		console.error( colors.red( 'An error occured while creating the zip: ' + err + '\nYou can still probably create the zip manually from the ' + targetFolder + ' folder.' ) );
+	} );
+
+	archive.pipe( output );
+
+	archive.directory( targetFolder, '' );
+
+	archive.finalize();
+} );


### PR DESCRIPTION
This PR seeks to add a new `npm run release` task that can be used to package up the plugin for future releases. It performs the following steps:

* Clear out the `release` folder from previous task completions
* Runs `npm run dist` to compile the plugin's Javascript files for production 
* Create `release/woocommerce-connect` with a copy of the plugin's markdown files, php files and the compiled js
* Zip that folder up

This produces a final `release` folder (which is git ignored) with the plugin files as a folder and as a zip ready for distribution.

To test:

* Checkout this branch
* Run `npm run release` -- verify that you get a warning about needing to `npm install`
* Run `npm install`
* Run `npm run release` -- at the prompt, type `no` or something else that's not `yes` -- verify that script abandons ship
* Run `npm run release` -- at the prompt, type `yes` -- verify that script runs as expected and produces a `release` folder that is complete as per the description above
* Upload the produced zip to a test site and make sure that the plugin works correctly

cc @allendav 