### PR TITLE
Don’t clear package name, weights, or dimensions when toggling package type.

### DIFF
--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -92,11 +92,6 @@ class AddPackageDialog extends React.Component {
 	useDefaultField( value ) {
 		this.props.updatePackagesField( {
 			index: null,
-			name: '',
-			inner_dimensions: '',
-			outer_dimensions: '',
-			box_weight: '',
-			max_weight: '',
 			is_letter: 'envelope' === value ? true : false,
 		} );
 	}


### PR DESCRIPTION
Fixes #285.

To test:
* Open "add package" dialog
* Enter values for name and dimensions
* Change package type from "Box" to "Envelope"
* Verify that your entered values remain