### PR TITLE
City isn’t required to get a shipping quote.

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -191,13 +191,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 		 */
 		public function is_valid_package_destination( $package ) {
 
-			$city     = isset( $package['destination']['city'] ) ? $package['destination']['city'] : '';
 			$country  = isset( $package['destination']['country'] ) ? $package['destination']['country'] : '';
 			$postcode = isset( $package['destination']['postcode'] ) ? $package['destination']['postcode'] : '';
 			$state    = isset( $package['destination']['state'] ) ? $package['destination']['state'] : '';
 
-			// Ensure that Country and City are specified
-			if ( empty( $country ) || empty( $city ) ) {
+			// Ensure that Country is specified
+			if ( empty( $country ) ) {
 				return false;
 			}
 

--- a/tests/php/test_class-wc-connect-shipping-method.php
+++ b/tests/php/test_class-wc-connect-shipping-method.php
@@ -12,7 +12,7 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 					'state'    => 'UT',
 					'postcode' => '84068',
 				)
-			), false ),
+			), true ),
 			'empty country' => array( array(
 				'destination' => array(
 					'city'     => 'Park City',


### PR DESCRIPTION
Fixes #222.

Only Country, State, and Postcode are sent from the Cart page.

To test:
* Check out https://github.com/Automattic/woocommerce-connect-server/tree/fix/247-fetch-rates-without-city-or-address and start local server
* Add item to cart
* View cart
* Click "calculate shipping"
* Enter valid Country/State/Postcode combo
* Verify rates are displayed