### PR TITLE
Add tracks integration

### DIFF
--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -1,0 +1,56 @@
+<?php
+
+// No direct access please
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
+
+	class WC_Connect_Tracks {
+		static $product_name = 'woocommerceconnect';
+
+		/**
+		 * @var WC_Connect_Logger
+		 */
+		protected $logger;
+
+		public function __construct( WC_Connect_Logger $logger ) {
+			$this->logger = $logger;
+		}
+
+		public function opted_in() {
+			return $this->record_user_event( 'opted_in' );
+		}
+
+		public function opted_out() {
+			return $this->record_user_event( 'opted_out' );
+		}
+
+		public function record_user_event( $event_type, $data = array() ) {
+			if ( ! function_exists( 'jetpack_tracks_record_event' ) ) {
+				$this->logger->log( 'Error. jetpack_tracks_record_event is not defined.' );
+				return;
+			}
+
+			$user = wp_get_current_user();
+			$site_url = get_option( 'siteurl' );
+
+			$data['_via_ua'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
+			$data['_via_ip'] = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '';
+			$data['_lg'] = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
+			$data['blog_url'] = $site_url;
+			$data['blog_id'] = Jetpack_Options::get_option( 'id' );
+			$data['jetpack_version'] = JETPACK__VERSION;
+			$data['wc_version'] = WC()->version;
+			$data['wp_version'] = get_bloginfo( 'version' );
+
+			$event_type = self::$product_name . '_' . $event_type;
+
+			$this->logger->log( 'Tracked the following event: ' . $event_type );
+			return jetpack_tracks_record_event( $user, $event_type, $data );
+		}
+
+	}
+
+}

--- a/tests/php/mocks/jetpack.php
+++ b/tests/php/mocks/jetpack.php
@@ -1,0 +1,20 @@
+<?php
+
+// mocks of various Jetpack functions/classes we need for our tests
+
+define( 'JETPACK__VERSION', '4.0' );
+
+function jetpack_tracks_record_event() {
+    return func_get_args();
+}
+
+class Jetpack_Options {
+    static function get_option( $option ){
+        switch( $option ) {
+            case 'id':
+                return 12345;
+            default:
+                return false;
+        }
+    }
+}

--- a/tests/php/test_woocommerce-connect-tracks.php
+++ b/tests/php/test_woocommerce-connect-tracks.php
@@ -1,0 +1,116 @@
+<?php
+
+abstract class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
+	protected $tracks;
+	protected $logger;
+
+	public static function setupBeforeClass() {
+		$loader = new WC_Connect_Loader();
+		$loader->load_dependencies();
+	}
+
+	public function setUp() {
+		$this->logger = $this->getMockBuilder( 'WC_Connect_Logger' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'log' ) )
+			->getMock();
+
+		$this->tracks = new WC_Connect_Tracks( $this->logger );
+	}
+}
+
+class WP_Test_WC_Connect_Tracks_No_Jetpack extends WP_Test_WC_Connect_Tracks {
+
+	public function test_no_jetpack() {
+		$this->logger->expects( $this->once() )
+			->method( 'log' )
+			->with(
+				$this->stringContains( 'Error' ),
+				$this->anything()
+		);
+		$record = $this->tracks->opted_out();
+		$this->assertNull( $record );
+	}
+
+}
+
+class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
+
+	public static function setupBeforeClass() {
+		parent::setupBeforeClass();
+		require_once( dirname( __FILE__ ) . '/mocks/jetpack.php' );
+	}
+
+	public function test_record_user_event() {
+		// $record will contain the args received by jetpack_tracks_record_event
+
+		$this->logger->expects( $this->once() )
+			->method( 'log' )
+			->with(
+				$this->stringContains( 'woocommerceconnect_test' ),
+				$this->anything()
+			);
+
+		$record = $this->tracks->record_user_event( 'test' );
+		$this->assertInstanceOf( 'WP_User', $record[0] );
+		$this->assertEquals( 'woocommerceconnect_test', $record[1] );
+		$this->assertInternalType( 'array', $record[2] );
+		$this->assertArrayHasKey( '_via_ua', $record[2] );
+		$this->assertArrayHasKey( '_via_ip', $record[2] );
+		$this->assertArrayHasKey( '_lg', $record[2] );
+		$this->assertArrayHasKey( 'blog_url', $record[2] );
+		$this->assertArrayHasKey( 'blog_id', $record[2] );
+		$this->assertArrayHasKey( 'jetpack_version', $record[2] );
+		$this->assertArrayHasKey( 'wc_version', $record[2] );
+		$this->assertArrayHasKey( 'wp_version', $record[2] );
+	}
+
+	public function test_opted_in() {
+
+		$this->logger->expects( $this->once() )
+			->method( 'log' )
+			->with(
+				$this->stringContains( 'woocommerceconnect_opted_in' ),
+				$this->anything()
+			);
+
+		// $record will contain the args received by jetpack_tracks_record_event
+		$record = $this->tracks->opted_in();
+		$this->assertInstanceOf( 'WP_User', $record[0] );
+		$this->assertEquals( 'woocommerceconnect_opted_in', $record[1] );
+		$this->assertInternalType( 'array', $record[2] );
+		$this->assertArrayHasKey( '_via_ua', $record[2] );
+		$this->assertArrayHasKey( '_via_ip', $record[2] );
+		$this->assertArrayHasKey( '_lg', $record[2] );
+		$this->assertArrayHasKey( 'blog_url', $record[2] );
+		$this->assertArrayHasKey( 'blog_id', $record[2] );
+		$this->assertArrayHasKey( 'jetpack_version', $record[2] );
+		$this->assertArrayHasKey( 'wc_version', $record[2] );
+		$this->assertArrayHasKey( 'wp_version', $record[2] );
+	}
+
+	public function test_opted_out() {
+
+		$this->logger->expects( $this->once() )
+			->method( 'log' )
+			->with(
+				$this->stringContains( 'woocommerceconnect_opted_out' ),
+				$this->anything()
+			);
+
+		// $record will contain the args received by jetpack_tracks_record_event
+		$record = $this->tracks->opted_out();
+		$this->assertInstanceOf( 'WP_User', $record[0] );
+		$this->assertEquals( 'woocommerceconnect_opted_out', $record[1] );
+		$this->assertInternalType( 'array', $record[2] );
+		$this->assertArrayHasKey( '_via_ua', $record[2] );
+		$this->assertArrayHasKey( '_via_ip', $record[2] );
+		$this->assertArrayHasKey( '_lg', $record[2] );
+		$this->assertArrayHasKey( 'blog_url', $record[2] );
+		$this->assertArrayHasKey( 'blog_id', $record[2] );
+		$this->assertArrayHasKey( 'jetpack_version', $record[2] );
+		$this->assertArrayHasKey( 'wc_version', $record[2] );
+		$this->assertArrayHasKey( 'wp_version', $record[2] );
+	}
+
+}


### PR DESCRIPTION
This PR seeks to introduce integrations with the Automattic Tracks metrics system. Specifically it:

* Adds a new Tracks class, and integrates it into our plugin
* Uses Jetpack's existing tracks integration to record events
* Adds the first two events which track opting in and opting out of WooCommerce Connect (activating/deactivating the plugin -- we'll need to adjust that when we merge into WC Core, noted for #131)
* Adds phpunit tests accordinglt

To test:

* You'll need a site that is actually connected via Jetpack, no fakes (but localhost works as long as it was once connected)
* Checkout this branch
* Run phpunit tests -- make sure they pass
* Deactivate the WooCommerce Connect plugin, verify that the following is added to your debug file:
`Tracked the following event: woocommerceconnect_opted_out`
* Re-activate the WooCommerce Connect plugin, verify that the following is added to your debug file:
`Tracked the following event: woocommerceconnect_opted_in`
* Wait approximately 5 minutes (enjoy a good cup of coffee!) -- there is an expected lag before the events are added to Tracks
* Visit the Tracks live event page (ping me if you need help finding it)
* Type in `woocommerceconnect_opted_out` and/or `woocommerceconnect_opted_in` into the `Event Name` box
* Ensure events with your username were recorded appropriately