### PR TITLE
Don't request rates if settings are empty.

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -228,13 +228,27 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 			}
 
+			$service_settings = $this->get_service_settings();
+			$settings_keys    = get_object_vars( $service_settings );
+
+			if ( empty( $settings_keys ) ) {
+				return $this->log(
+					sprintf(
+						'Service settings empty. Skipping %s rate request (instance id %d).',
+						$this->id,
+						$this->instance_id
+					),
+					__FUNCTION__
+				);
+			}
+
 			// TODO: Request rates for all WooCommerce Connect powered methods in
 			// the current shipping zone to avoid each method making an independent request
 			$services = array(
 				array(
 					'id'               => $this->id,
 					'instance'         => $this->instance_id,
-					'service_settings' => $this->get_service_settings(),
+					'service_settings' => $service_settings,
 				),
 			);
 

--- a/tests/php/test_class-wc-connect-shipping-method.php
+++ b/tests/php/test_class-wc-connect-shipping-method.php
@@ -127,4 +127,36 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @covers WC_Connect_Shipping_Method::calculate_shipping
+	 */
+	public function test_invalid_service_settings_calculate_shipping() {
+
+		$loader = new WC_Connect_Loader();
+		$loader->load_dependencies();
+
+		$shipping_method = $this->getMockBuilder( 'WC_Connect_Shipping_Method' )
+			->setConstructorArgs( array( 1 ) )
+			->setMethods( array( 'is_valid_package_destination', 'get_service_settings', 'log' ) )
+			->getMock();
+
+		$shipping_method->expects( $this->any() )
+			->method( 'is_valid_package_destination' )
+			->will( $this->returnValue( true ) );
+
+		$shipping_method->expects( $this->any() )
+			->method( 'get_service_settings' )
+			->will( $this->returnValue( new stdClass() ) );
+
+		$shipping_method->expects( $this->once() )
+			->method( 'log' )
+			->with(
+				$this->stringContains( 'Service settings empty.' ),
+				$this->anything()
+			);
+
+		$shipping_method->calculate_shipping();
+
+	}
+
 }

--- a/tests/php/test_class-wc-connect-shipping-method.php
+++ b/tests/php/test_class-wc-connect-shipping-method.php
@@ -99,4 +99,32 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @covers WC_Connect_Shipping_Method::calculate_shipping
+	 */
+	public function test_invalid_destination_calculate_shipping() {
+
+		$loader = new WC_Connect_Loader();
+		$loader->load_dependencies();
+
+		$shipping_method = $this->getMockBuilder( 'WC_Connect_Shipping_Method' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'is_valid_package_destination', 'log' ) )
+			->getMock();
+
+		$shipping_method->expects( $this->any() )
+			->method( 'is_valid_package_destination' )
+			->will( $this->returnValue( false ) );
+
+		$shipping_method->expects( $this->once() )
+			->method( 'log' )
+			->with(
+				$this->stringContains( 'Package destination failed validation.' ),
+				$this->anything()
+			);
+
+		$shipping_method->calculate_shipping();
+
+	}
+
 }

--- a/tests/php/test_wc-connect-services-validator.php
+++ b/tests/php/test_wc-connect-services-validator.php
@@ -155,7 +155,7 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 
 	/**
 	 * @dataProvider validate_services_errors_provider
-	 * @covers WC_Connect_Services_Validator::validate_services
+	 * @covers WC_Connect_Service_Schemas_Validator::validate_service_schemas
 	 */
 	public function test_validate_services_errors( $services, $expected ) {
 
@@ -167,7 +167,7 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers WC_Connect_Services_Validator::validate_services
+	 * @covers WC_Connect_Service_Schemas_Validator::validate_service_schemas
 	 */
 	public function test_validate_services() {
 

--- a/tests/php/test_woocommerce-connect-client.php
+++ b/tests/php/test_woocommerce-connect-client.php
@@ -90,8 +90,8 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers WC_Connect_Loader::get_services_store
-	 * @covers WC_Connect_Loader::set_services_store
+	 * @covers WC_Connect_Loader::get_service_schemas_store
+	 * @covers WC_Connect_Loader::set_service_schemas_store
 	 */
 	public function test_services_store_getter_setter() {
 
@@ -108,8 +108,8 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers WC_Connect_Loader::get_services_validator
-	 * @covers WC_Connect_Loader::set_services_validator
+	 * @covers WC_Connect_Loader::get_service_schemas_validator
+	 * @covers WC_Connect_Loader::set_service_schemas_validator
 	 */
 	public function test_services_validator_getter_setter() {
 
@@ -141,9 +141,9 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @covers WC_Connect_Loader::init_shipping_method
+	 * @covers WC_Connect_Loader::init_service
 	 */
-	public function test_init_shipping_method() {
+	public function test_init_service() {
 
 		$store = $this->getMockBuilder( 'WC_Connect_Service_Schemas_Store' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
Fixes #193.

To test:
* Add a new USPS shipping instance to a zone and do not enter any settings for it
* Add an item to cart and attempt a checkout (that would fall under the above zone)
* Verify that a "Service settings empty." warning is logged