### PR TITLE
Start building out the stateful status page

### DIFF
--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -6,7 +6,7 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 
 		public function __construct() {
 			add_filter( 'woocommerce_admin_status_tabs', array( $this, 'status_tabs' ) );
-			add_action( 'woocommerce_admin_status_connect', array( $this, 'page' ) );
+			add_action( 'woocommerce_admin_status_content_connect', array( $this, 'page' ) );
 		}
 
 		public function status_tabs( $tabs ) {

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -5,7 +5,7 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 	class WC_Connect_Help_Provider {
 
 		/**
-		 * @var WC_Connect_Service_Schemas_Store
+		 * @var WC_Connect_Service_Settings_Store
 		 */
 		protected $service_settings_store;
 

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -1,0 +1,76 @@
+<?php
+
+if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
+
+	class WC_Connect_Help_Provider {
+
+		public function __construct() {
+			add_action( 'admin_menu', array( $this, 'admin_menu' ), 50 ); // 50 was chosen to have it appear after Reports but before Settings
+		}
+
+		public function admin_menu() {
+			add_submenu_page( 'woocommerce', __( 'Connect', 'woocommerce' ),  __( 'Connect', 'woocommerce' ) , 'manage_woocommerce', 'wc-connect', array( $this, 'page' ) );
+		}
+
+		protected function get_form_schema() {
+			$form_schema = new stdClass();
+			$form_schema->properties = new stdClass();
+			return $form_schema;
+		}
+
+		protected function get_form_layout() {
+			return array(
+				(object) array(
+					'title' => __( 'Health', 'woocommerce' ),
+					'type' => 'fieldset',
+					'items' => array()
+				),
+				(object) array(
+					'title' => __( 'Services', 'woocommerce' ),
+					'type' => 'fieldset',
+					'items' => array()
+				),
+				(object) array(
+					'title' => __( 'Debug', 'woocommerce' ),
+					'type' => 'fieldset',
+					'items' => array()
+				),
+				(object) array(
+					'title' => __( 'Support', 'woocommerce' ),
+					'type' => 'fieldset',
+					'items' => array()
+				)
+			);
+		}
+
+		protected function get_form_data() {
+			return array(); // TODO
+		}
+
+		public function page() {
+			$form_schema = new stdClass();
+			$form_schema->properties = new stdClass();
+
+			$admin_array = array(
+				'storeOptions' => new stdClass(),
+				'formSchema'   => $this->get_form_schema(),
+				'formLayout'   => $this->get_form_layout(),
+				'formData'     => $this->get_form_data(),
+				'callbackURL'  => '',
+				'nonce'        => '',
+			);
+
+			wp_localize_script( 'wc_connect_admin', 'wcConnectData', $admin_array );
+			wp_enqueue_script( 'wc_connect_admin' );
+			wp_enqueue_style( 'wc_connect_admin' );
+
+			?>
+				<h2>
+					<?php _e( 'WooCommerce Connect Status', 'woocommerce' ); ?>
+				</h2>
+				<div id="wc-connect-admin-container"></div>
+			<?php
+		}
+	}
+
+}

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -4,65 +4,107 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 
 	class WC_Connect_Help_Provider {
 
-		public function __construct() {
+		/**
+		 * @var WC_Connect_Service_Schemas_Store
+		 */
+		protected $service_settings_store;
+
+		public function __construct( WC_Connect_Service_Settings_Store $service_settings_store ) {
+
+			$this->service_settings_store = $service_settings_store;
+
 			add_filter( 'woocommerce_admin_status_tabs', array( $this, 'status_tabs' ) );
 			add_action( 'woocommerce_admin_status_content_connect', array( $this, 'page' ) );
+
 		}
 
+		/**
+		 * Filters the WooCommerce System Status Tabs to add connect
+		 *
+		 * @param array $tabs
+		 * @return array
+		 */
 		public function status_tabs( $tabs ) {
+
 			if ( ! is_array( $tabs ) ) {
 				$tabs = array();
 			}
 			$tabs[ 'connect' ] = _x( 'Connect', 'The WooCommerce Connect brandname', 'woocommerce' );
 			return $tabs;
+
 		}
 
+		/**
+		 * Returns the form schema object for the entire help page
+		 *
+		 * @return object
+		 */
 		protected function get_form_schema() {
+
 			$form_schema = new stdClass();
 			$form_schema->properties = new stdClass();
 			return $form_schema;
+
 		}
 
+		/**
+		 * Returns the form layout array for the entire help page
+		 *
+		 * @return array
+		 */
 		protected function get_form_layout() {
+
 			return array(
 				(object) array(
 					'title' => __( 'Health', 'woocommerce' ),
 					'type' => 'fieldset',
-					'items' => array()
+					'items' => array() // TODO
 				),
 				(object) array(
 					'title' => __( 'Services', 'woocommerce' ),
 					'type' => 'fieldset',
-					'items' => array()
+					'items' => array() // TODO
 				),
 				(object) array(
 					'title' => __( 'Debug', 'woocommerce' ),
 					'type' => 'fieldset',
-					'items' => array()
+					'items' => array() // TODO
 				),
 				(object) array(
 					'title' => __( 'Support', 'woocommerce' ),
 					'type' => 'fieldset',
-					'items' => array()
+					'items' => array() // TODO
 				)
 			);
+
 		}
 
+		/**
+		 * Returns the data bootstrap for the help page
+		 *
+		 * @return array
+		 */
 		protected function get_form_data() {
+
 			return array(); // TODO
+
 		}
 
+		/**
+		 * Localizes the bootstrap, enqueues the script and styles for the help page
+		 */
 		public function page() {
+
 			$form_schema = new stdClass();
 			$form_schema->properties = new stdClass();
 
 			$admin_array = array(
-				'storeOptions' => new stdClass(),
+				'storeOptions' => $this->service_settings_store->get_shared_settings(),
 				'formSchema'   => $this->get_form_schema(),
 				'formLayout'   => $this->get_form_layout(),
 				'formData'     => $this->get_form_data(),
-				'callbackURL'  => '',
-				'nonce'        => '',
+				'callbackURL'  => '', // TODO
+				'nonce'        => '', // TODO
 			);
 
 			wp_localize_script( 'wc_connect_admin', 'wcConnectData', $admin_array );
@@ -76,6 +118,7 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 				<div id="wc-connect-admin-container"></div>
 			<?php
 		}
+
 	}
 
 }

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -5,11 +5,16 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 	class WC_Connect_Help_Provider {
 
 		public function __construct() {
-			add_action( 'admin_menu', array( $this, 'admin_menu' ), 50 ); // 50 was chosen to have it appear after Reports but before Settings
+			add_filter( 'woocommerce_admin_status_tabs', array( $this, 'status_tabs' ) );
+			add_action( 'woocommerce_admin_status_connect', array( $this, 'page' ) );
 		}
 
-		public function admin_menu() {
-			add_submenu_page( 'woocommerce', __( 'Connect', 'woocommerce' ),  __( 'Connect', 'woocommerce' ) , 'manage_woocommerce', 'wc-connect', array( $this, 'page' ) );
+		public function status_tabs( $tabs ) {
+			if ( ! is_array( $tabs ) ) {
+				$tabs = array();
+			}
+			$tabs[ 'connect' ] = _x( 'Connect', 'The WooCommerce Connect brandname', 'woocommerce' );
+			return $tabs;
 		}
 
 		protected function get_form_schema() {

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 			if ( ! is_array( $tabs ) ) {
 				$tabs = array();
 			}
-			$tabs[ 'connect' ] = _x( 'Connect', 'The WooCommerce Connect brandname', 'woocommerce' );
+			$tabs[ 'connect' ] = _x( 'WooCommerce Connect', 'The WooCommerce Connect brandname', 'woocommerce' );
 			return $tabs;
 
 		}
@@ -56,7 +56,7 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 
 			return array(
 				(object) array(
-					'title' => __( 'Health', 'woocommerce' ),
+					'title' => _x( 'Health', 'This section displays the overall health of WooCommerce Connect and the things it depends on', 'woocommerce' ),
 					'type' => 'fieldset',
 					'items' => array() // TODO
 				),

--- a/tests/php/test_woocommerce-connect-client.php
+++ b/tests/php/test_woocommerce-connect-client.php
@@ -2,7 +2,7 @@
 
 class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 
-	const SERVICE_SCRIPT_HANDLE = 'wc_connect_service_admin';
+	const SERVICE_SCRIPT_HANDLE = 'wc_connect_admin';
 
 	public function tearDown() {
 

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -190,7 +190,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$schemas_store  = new WC_Connect_Service_Schemas_Store( $api_client, $logger );
 			$settings_store = new WC_Connect_Service_Settings_Store( $schemas_store, $api_client, $logger );
 			$tracks         = new WC_Connect_Tracks( $logger );
-			$help_provider  = new WC_Connect_Help_Provider();
+			$help_provider  = new WC_Connect_Help_Provider( $settings_store );
 
 			$this->set_logger( $logger );
 			$this->set_api_client( $api_client );

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -423,7 +423,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				if ( 'shipping' !== $tab || empty( $instance_id ) ) {
 					return;
 				}
-			} else if ( 'woocommerce_page_wc-connect' !== $hook ) {
+			} else if ( 'woocommerce_page_wc-status' === $hook ) {
+				// If we are on a system status page, make sure it is the connect tab
+				if ( 'connect' !== $tab ) {
+					return;
+				}
+			} else {
 				// Don't recognize the hook? Go no further
 				return;
 			}


### PR DESCRIPTION
Ready for review

<del>Requires https://github.com/woothemes/woocommerce/pull/10874<del>

Completes the first item in https://github.com/Automattic/woocommerce-connect-client/issues/153#issuecomment-217036409

To test:
Navigate to wp-admin > WooCommerce > System Status
Verify you get a Connect tab now
Click on it
Verify you get the Health, Services, Debug and Support sections (currently empty - content comes in successive PRs)

cc @jkudish @nabsul @jeffstieler for review