### PR TITLE
Update/preset packaging readonly

### DIFF
--- a/client/components/shipping/packages/add-package-presets.js
+++ b/client/components/shipping/packages/add-package-presets.js
@@ -9,10 +9,12 @@ const defaultPackages = {
 		{
 			value: 'default_box',
 			label: 'Box',
+			is_user_defined: true,
 		},
 		{
 			value: 'default_envelope',
 			label: 'Envelope',
+			is_user_defined: true,
 		},
 	],
 };

--- a/client/components/shipping/packages/add-package-presets.js
+++ b/client/components/shipping/packages/add-package-presets.js
@@ -32,10 +32,11 @@ const getOptionGroups = ( presets ) => {
 	]
 };
 
-const handleSelectEvent = ( e, selectDefault, selectPreset ) => {
+const handleSelectEvent = ( e, selectDefault, selectPreset, setSelectedPreset ) => {
 	const parts = e.target.value.split( '_' );
 	const type = parts[0];
 	const id = parts[1];
+	setSelectedPreset( e.target.value );
 	switch ( type ) {
 		case 'default':
 			return selectDefault( id );
@@ -44,13 +45,14 @@ const handleSelectEvent = ( e, selectDefault, selectPreset ) => {
 	}
 };
 
-const AddPackagePresets = ( { presets, onSelectDefault, onSelectPreset } ) => {
+const AddPackagePresets = ( { selectedPreset, setSelectedPreset, presets, onSelectDefault, onSelectPreset } ) => {
 	return (
 		<FormFieldset>
 			<FormLabel htmlFor="package_type">Type of package</FormLabel>
 			<SelectOptGroups
 				id="package_type"
-				onChange={ ( e ) => handleSelectEvent( e, onSelectDefault, onSelectPreset ) }
+				defaultValue={ selectedPreset }
+				onChange={ ( e ) => handleSelectEvent( e, onSelectDefault, onSelectPreset, setSelectedPreset ) }
 				optGroups={ getOptionGroups( presets ) }
 				readOnly={ false }/>
 		</FormFieldset>
@@ -58,6 +60,8 @@ const AddPackagePresets = ( { presets, onSelectDefault, onSelectPreset } ) => {
 };
 
 AddPackagePresets.propTypes = {
+	selectedPreset: PropTypes.string,
+	setSelectedPreset: PropTypes.func.isRequired,
 	presets: PropTypes.object.isRequired,
 	onSelectDefault: PropTypes.func.isRequired,
 	onSelectPreset: PropTypes.func.isRequired,

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -75,6 +75,11 @@ const useDefaultField = ( value, updatePackagesField, setModalReadOnly ) => {
 	updatePackagesField( {
 		index: null,
 		is_letter: 'envelope' === value ? true : false,
+		name: '',
+		outer_dimensions: '',
+		inner_dimensions: '',
+		box_weight: '',
+		max_weight: '',
 	} );
 	setModalReadOnly( false );
 };

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -54,7 +54,7 @@ const renderOuterDimensions = ( showOuterDimensions, packageData, value, updateP
 				name="outer_dimensions"
 				placeholder={ exampleDimensions( 100.25, 25.25, 5.75 ) }
 				value={ value }
-				className="flat-rate-package__outer-dimensions__read-only"
+				className={ is_user_defined ? '' : 'flat-rate-package__outer-dimensions__read-only' }
 				onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 				disabled={ ! is_user_defined }
 			/>
@@ -140,7 +140,7 @@ const AddPackageDialog = ( props ) => {
 					name="inner_dimensions"
 					placeholder={ exampleDimensions( 100, 25, 5.5 ) }
 					value={ inner_dimensions }
-					className="flat-rate-package__inner-dimensions__read-only"
+					className={ is_user_defined ? '' : 'flat-rate-package__inner-dimensions__read-only' }
 					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 					disabled={ ! is_user_defined }
 				/>
@@ -155,7 +155,7 @@ const AddPackageDialog = ( props ) => {
 						name="box_weight"
 						placeholder={ __( 'Weight of box' ) }
 						value={ box_weight }
-						className="flat-rate-package__package-weight__read-only"
+						className={ is_user_defined ? '' : 'flat-rate-package__package-weight__read-only' }
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 						disabled={ ! is_user_defined }
 					/>
@@ -167,7 +167,7 @@ const AddPackageDialog = ( props ) => {
 						name="max_weight"
 						placeholder={ __( 'Max weight' ) }
 						value={ max_weight }
-						className="flat-rate-package__max-weight__read-only"
+						className={ is_user_defined ? '' : 'flat-rate-package__max-weight__read-only' }
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 						disabled={ ! is_user_defined }
 					/>

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -5,18 +5,22 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormButton from 'components/forms/form-button';
-import FormCheckbox from 'components/forms/form-checkbox';
+// import FormCheckbox from 'components/forms/form-checkbox';
 import Dialog from 'components/dialog';
 import AddPackagePresets from './add-package-presets';
 import { translate as __ } from 'lib/mixins/i18n';
 
 const getDialogButtons = ( mode, savePackage, packageData ) => {
 	return [
+		/*
 		<FormLabel className="share-package-option">
 			<FormCheckbox checked={ true } readOnly={ true } />
 			<span>Save package to use in other shipping methods</span>
 		</FormLabel>,
-		<FormButton onClick={ () => savePackage( packageData ) }>{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }</FormButton>,
+		*/
+		<FormButton onClick={ () => savePackage( packageData ) }>
+			{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }
+		</FormButton>,
 	];
 };
 
@@ -44,7 +48,7 @@ const updateFormTextField = ( event, updatePackagesField ) => {
 	updatePackagesField( { [name]: value } );
 };
 
-const renderOuterDimensions = ( showOuterDimensions, packageData, value, updatePackagesField ) => {
+const renderOuterDimensions = ( showOuterDimensions, packageData, value, updatePackagesField, modalReadOnly ) => {
 	return ( showOuterDimensions || packageData.outer_dimensions ) ? (
 		<FormFieldset>
 			<FormLabel>Outer Dimensions (L x W x H)</FormLabel>
@@ -53,23 +57,26 @@ const renderOuterDimensions = ( showOuterDimensions, packageData, value, updateP
 				placeholder="100.25 x 25.25 x 5.75"
 				value={ value }
 				onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+				disabled={ modalReadOnly }
 			/>
 		</FormFieldset>
 	) : null;
 };
 
-const usePresetValues = ( preset, updatePackagesField ) => {
+const usePresetValues = ( preset, updatePackagesField, setModalReadOnly ) => {
 	updatePackagesField( {
 		index: null,
 		...preset,
 	} );
+	setModalReadOnly( true );
 };
 
-const useDefaultField = ( value, updatePackagesField ) => {
+const useDefaultField = ( value, updatePackagesField, setModalReadOnly ) => {
 	updatePackagesField( {
 		index: null,
 		is_letter: 'envelope' === value ? true : false,
 	} );
+	setModalReadOnly( false );
 };
 
 const AddPackageDialog = ( props ) => {
@@ -83,6 +90,8 @@ const AddPackageDialog = ( props ) => {
 		toggleOuterDimensions,
 		savePackage,
 		updatePackagesField,
+		modalReadOnly,
+		setModalReadOnly,
 	} = props;
 
 	const {
@@ -103,8 +112,8 @@ const AddPackageDialog = ( props ) => {
 			{ ( 'add' === mode ) ? (
 				<AddPackagePresets
 					presets={ presets }
-					onSelectDefault={ ( value ) => useDefaultField( value, updatePackagesField ) }
-					onSelectPreset={ ( idx ) => usePresetValues( presets.boxes[idx], updatePackagesField ) }
+					onSelectDefault={ ( value ) => useDefaultField( value, updatePackagesField, setModalReadOnly ) }
+					onSelectPreset={ ( idx ) => usePresetValues( presets.boxes[idx], updatePackagesField, setModalReadOnly ) }
 				/>
 			) : null }
 			<FormFieldset>
@@ -124,10 +133,11 @@ const AddPackageDialog = ( props ) => {
 					placeholder="100 x 25 x 5.5"
 					value={ inner_dimensions }
 					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+					disabled={ modalReadOnly }
 				/>
 				{ renderOuterDimensionsToggle( showOuterDimensions, packageData, toggleOuterDimensions ) }
 			</FormFieldset>
-			{ renderOuterDimensions( showOuterDimensions, packageData, outer_dimensions, updatePackagesField ) }
+			{ renderOuterDimensions( showOuterDimensions, packageData, outer_dimensions, updatePackagesField, modalReadOnly ) }
 			<FormFieldset className="wcc-shipping-add-package-weight-group">
 				<div className="wcc-shipping-add-package-weight">
 					<FormLabel htmlFor="box_weight">Package weight</FormLabel>
@@ -137,6 +147,7 @@ const AddPackageDialog = ( props ) => {
 						placeholder="Weight of box"
 						value={ box_weight }
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+						disabled={ modalReadOnly }
 					/>
 				</div>
 				<div className="wcc-shipping-add-package-weight">
@@ -147,6 +158,7 @@ const AddPackageDialog = ( props ) => {
 						placeholder="Max weight"
 						value={ max_weight }
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+						disabled={ modalReadOnly }
 					/>
 					<span className="wcc-shipping-add-package-weight-unit">{ weightUnit }</span>
 				</div>
@@ -166,7 +178,8 @@ AddPackageDialog.propTypes = {
 	toggleOuterDimensions: PropTypes.func.isRequired,
 	savePackage: PropTypes.func.isRequired,
 	packageData: PropTypes.object,
-
+	setModalReadOnly: PropTypes.func.isRequired,
+	modalReadOnly: PropTypes.bool,
 };
 
 AddPackageDialog.defaultProps = {

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -9,10 +9,13 @@ import Dialog from 'components/dialog';
 import AddPackagePresets from './add-package-presets';
 import { translate as __ } from 'lib/mixins/i18n';
 
-const getDialogButtons = ( mode, savePackage, packageData ) => {
+const getDialogButtons = ( mode, dismissModal, savePackage, packageData ) => {
 	return [
 		<FormButton onClick={ () => savePackage( packageData ) }>
 			{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }
+		</FormButton>,
+		<FormButton onClick={ () => dismissModal() } isPrimary={ false }>
+			{ __( 'Cancel' ) }
 		</FormButton>,
 	];
 };
@@ -27,7 +30,7 @@ const renderOuterDimensionsToggle = ( showOuterDimensions, packageData, toggleOu
 					evt.preventDefault();
 					toggleOuterDimensions();
 				} }>
-				{ __( 'Define exterior dimensions' ) }
+				{ __( 'View exterior dimensions' ) }
 			</a>
 		);
 	}
@@ -113,7 +116,7 @@ const AddPackageDialog = ( props ) => {
 			isVisible={ showModal }
 			additionalClassNames="wcc-modal wcc-shipping-add-edit-package-dialog"
 			onClose={ dismissModal }
-			buttons={ getDialogButtons( mode, savePackage, packageData ) }>
+			buttons={ getDialogButtons( mode, dismissModal, savePackage, packageData ) }>
 			<FormSectionHeading>{ ( 'edit' === mode ) ? __( 'Edit package' ) : __( 'Add a package' ) }</FormSectionHeading>
 			{ ( 'add' === mode ) ? (
 				<AddPackagePresets

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -5,19 +5,12 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormButton from 'components/forms/form-button';
-// import FormCheckbox from 'components/forms/form-checkbox';
 import Dialog from 'components/dialog';
 import AddPackagePresets from './add-package-presets';
 import { translate as __ } from 'lib/mixins/i18n';
 
 const getDialogButtons = ( mode, savePackage, packageData ) => {
 	return [
-		/*
-		<FormLabel className="share-package-option">
-			<FormCheckbox checked={ true } readOnly={ true } />
-			<span>Save package to use in other shipping methods</span>
-		</FormLabel>,
-		*/
 		<FormButton onClick={ () => savePackage( packageData ) }>
 			{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }
 		</FormButton>,
@@ -34,10 +27,15 @@ const renderOuterDimensionsToggle = ( showOuterDimensions, packageData, toggleOu
 					evt.preventDefault();
 					toggleOuterDimensions();
 				} }>
-				Define exterior dimensions
+				{ __( 'Define exterior dimensions' ) }
 			</a>
 		);
 	}
+};
+
+const exampleDimensions = ( length, width, height, locale ) => {
+	return length.toLocaleString( locale ) + ' x ' + width.toLocaleString( locale ) +
+		' x ' + height.toLocaleString( locale );
 };
 
 const updateFormTextField = ( event, updatePackagesField ) => {
@@ -51,10 +49,10 @@ const updateFormTextField = ( event, updatePackagesField ) => {
 const renderOuterDimensions = ( showOuterDimensions, packageData, value, updatePackagesField, modalReadOnly ) => {
 	return ( showOuterDimensions || packageData.outer_dimensions ) ? (
 		<FormFieldset>
-			<FormLabel>Outer Dimensions (L x W x H)</FormLabel>
+			<FormLabel>{ __( 'Outer Dimensions (L x W x H)' ) }</FormLabel>
 			<FormTextInput
 				name="outer_dimensions"
-				placeholder="100.25 x 25.25 x 5.75"
+				placeholder={ exampleDimensions( 100.25, 25.25, 5.75 ) }
 				value={ value }
 				onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 				disabled={ modalReadOnly }
@@ -74,7 +72,7 @@ const usePresetValues = ( preset, updatePackagesField, setModalReadOnly ) => {
 const useDefaultField = ( value, updatePackagesField, setModalReadOnly ) => {
 	updatePackagesField( {
 		index: null,
-		is_letter: 'envelope' === value ? true : false,
+		is_letter: 'envelope' === value,
 		name: '',
 		outer_dimensions: '',
 		inner_dimensions: '',
@@ -86,6 +84,7 @@ const useDefaultField = ( value, updatePackagesField, setModalReadOnly ) => {
 
 const AddPackageDialog = ( props ) => {
 	const {
+		showModal,
 		dismissModal,
 		mode,
 		presets,
@@ -111,7 +110,7 @@ const AddPackageDialog = ( props ) => {
 
 	return (
 		<Dialog
-			isVisible={ true }
+			isVisible={ showModal }
 			additionalClassNames="wcc-modal wcc-shipping-add-edit-package-dialog"
 			onClose={ dismissModal }
 			buttons={ getDialogButtons( mode, savePackage, packageData ) }>
@@ -126,20 +125,20 @@ const AddPackageDialog = ( props ) => {
 				/>
 			) : null }
 			<FormFieldset>
-				<FormLabel htmlFor="name">Package name</FormLabel>
+				<FormLabel htmlFor="name">{ __( 'Package name' ) }</FormLabel>
 				<FormTextInput
 					id="name"
 					name="name"
-					placeholder="The customer will see this during checkout"
+					placeholder={ __( 'The customer will see this during checkout' ) }
 					value={ name }
 					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 				/>
 			</FormFieldset>
 			<FormFieldset>
-				<FormLabel>Inner Dimensions (L x W x H)</FormLabel>
+				<FormLabel>{ __( 'Inner Dimensions (L x W x H)' ) }</FormLabel>
 				<FormTextInput
 					name="inner_dimensions"
-					placeholder="100 x 25 x 5.5"
+					placeholder={ exampleDimensions( 100, 25, 5.5 ) }
 					value={ inner_dimensions }
 					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 					disabled={ modalReadOnly }
@@ -149,29 +148,31 @@ const AddPackageDialog = ( props ) => {
 			{ renderOuterDimensions( showOuterDimensions, packageData, outer_dimensions, updatePackagesField, modalReadOnly ) }
 			<FormFieldset className="wcc-shipping-add-package-weight-group">
 				<div className="wcc-shipping-add-package-weight">
-					<FormLabel htmlFor="box_weight">Package weight</FormLabel>
+					<FormLabel htmlFor="box_weight">{ __( 'Package weight' ) }</FormLabel>
 					<FormTextInput
 						id="box_weight"
 						name="box_weight"
-						placeholder="Weight of box"
+						placeholder={ __( 'Weight of box' ) }
 						value={ box_weight }
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 						disabled={ modalReadOnly }
 					/>
 				</div>
 				<div className="wcc-shipping-add-package-weight">
-					<FormLabel htmlFor="max_weight">Max weight</FormLabel>
+					<FormLabel htmlFor="max_weight">{ __( 'Max weight' ) }</FormLabel>
 					<FormTextInput
 						id="max_weight"
 						name="max_weight"
-						placeholder="Max weight"
+						placeholder={ __( 'Max weight' ) }
 						value={ max_weight }
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 						disabled={ modalReadOnly }
 					/>
 					<span className="wcc-shipping-add-package-weight-unit">{ weightUnit }</span>
 				</div>
-				<FormSettingExplanation> Define both the weight of the empty box and the max weight it can hold</FormSettingExplanation>
+				<FormSettingExplanation>
+					{ __( 'Defines both the weight of the empty box and the max weight it can hold' ) }
+				</FormSettingExplanation>
 			</FormFieldset>
 		</Dialog>
 	);
@@ -195,6 +196,7 @@ AddPackageDialog.propTypes = {
 
 AddPackageDialog.defaultProps = {
 	packageData: {},
+	mode: 'add',
 };
 
 export default AddPackageDialog;

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -54,6 +54,7 @@ const renderOuterDimensions = ( showOuterDimensions, packageData, value, updateP
 				name="outer_dimensions"
 				placeholder={ exampleDimensions( 100.25, 25.25, 5.75 ) }
 				value={ value }
+				className="flat-rate-package__outer-dimensions"
 				onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 				disabled={ modalReadOnly }
 			/>
@@ -139,6 +140,7 @@ const AddPackageDialog = ( props ) => {
 					name="inner_dimensions"
 					placeholder={ exampleDimensions( 100, 25, 5.5 ) }
 					value={ inner_dimensions }
+					className="flat-rate-package__inner-dimensions"
 					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 					disabled={ read_only }
 				/>
@@ -153,6 +155,7 @@ const AddPackageDialog = ( props ) => {
 						name="box_weight"
 						placeholder={ __( 'Weight of box' ) }
 						value={ box_weight }
+						className="flat-rate-package__package-weight"
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 						disabled={ read_only }
 					/>
@@ -164,6 +167,7 @@ const AddPackageDialog = ( props ) => {
 						name="max_weight"
 						placeholder={ __( 'Max weight' ) }
 						value={ max_weight }
+						className="flat-rate-package__max-weight"
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 						disabled={ read_only }
 					/>

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -10,170 +10,151 @@ import Dialog from 'components/dialog';
 import AddPackagePresets from './add-package-presets';
 import { translate as __ } from 'lib/mixins/i18n';
 
-class AddPackageDialog extends React.Component {
+const getDialogButtons = ( mode, savePackage, packageData ) => {
+	return [
+		<FormLabel className="share-package-option">
+			<FormCheckbox checked={ true } readOnly={ true } />
+			<span>Save package to use in other shipping methods</span>
+		</FormLabel>,
+		<FormButton onClick={ () => savePackage( packageData ) }>{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }</FormButton>,
+	];
+};
 
-	constructor() {
-		super();
-		this.updateFormTextField = this.updateFormTextField.bind( this );
-	}
-
-	getDialogButtons() {
-		const {
-			mode,
-			savePackage,
-			packageData,
-		} = this.props;
-		return [
-			<FormLabel className="share-package-option">
-				<FormCheckbox checked={ true } readOnly={ true } />
-				<span>Save package to use in other shipping methods</span>
-			</FormLabel>,
-			<FormButton onClick={ () => savePackage( packageData ) }>{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }</FormButton>,
-		];
-	}
-
-	renderOuterDimensionsToggle() {
-		const {
-			showOuterDimensions,
-			packageData,
-			toggleOuterDimensions,
-		} = this.props;
-
-		if ( ! showOuterDimensions && ! packageData.outer_dimensions ) {
-			return (
-				<a
-					href="#"
-					className="form-setting-explanation"
-					onClick={ ( evt ) => {
-						evt.preventDefault();
-						toggleOuterDimensions();
-					} }>
-					Define exterior dimensions
-				</a>
-			);
-		}
-	}
-
-	renderOuterDimensions( value ) {
-		const {
-			showOuterDimensions,
-			packageData,
-		} = this.props;
-
-		return ( showOuterDimensions || packageData.outer_dimensions ) ? (
-			<FormFieldset>
-				<FormLabel>Outer Dimensions (L x W x H)</FormLabel>
-				<FormTextInput
-					name="outer_dimensions"
-					placeholder="100.25 x 25.25 x 5.75"
-					value={ value }
-					onChange={ this.updateFormTextField }
-				/>
-			</FormFieldset>
-		) : null;
-	}
-
-	usePresetValues( idx ) {
-		const preset = this.props.presets.boxes[idx];
-		this.props.updatePackagesField( {
-			index: null,
-			...preset,
-		} );
-	}
-
-	updateFormTextField( event ) {
-		const {
-			name,
-			value,
-		} = event.target;
-		this.props.updatePackagesField( { [name]: value } );
-	}
-
-	useDefaultField( value ) {
-		this.props.updatePackagesField( {
-			index: null,
-			is_letter: 'envelope' === value ? true : false,
-		} );
-	}
-
-	render() {
-		const {
-			dismissModal,
-			mode,
-			presets,
-			weightUnit,
-			packageData,
-		} = this.props;
-		const {
-			name,
-			inner_dimensions,
-			outer_dimensions,
-			box_weight,
-			max_weight,
-		} = packageData;
+const renderOuterDimensionsToggle = ( showOuterDimensions, packageData, toggleOuterDimensions ) => {
+	if ( ! showOuterDimensions && ! packageData.outer_dimensions ) {
 		return (
-			<Dialog
-				isVisible={ true }
-				additionalClassNames="wcc-modal wcc-shipping-add-edit-package-dialog"
-				onClose={ dismissModal }
-				buttons={ this.getDialogButtons() }>
-				<FormSectionHeading>{ ( 'edit' === mode ) ? __( 'Edit package' ) : __( 'Add a package' ) }</FormSectionHeading>
-				{ ( 'add' === mode ) ? (
-					<AddPackagePresets
-						presets={ presets }
-						onSelectDefault={ ( value ) => this.useDefaultField( value ) }
-						onSelectPreset={ ( idx ) => this.usePresetValues( idx ) }
-					/>
-				) : null }
-				<FormFieldset>
-					<FormLabel htmlFor="name">Package name</FormLabel>
-					<FormTextInput
-						id="name"
-						name="name"
-						placeholder="The customer will see this during checkout"
-						value={ name }
-						onChange={ this.updateFormTextField }
-					/>
-				</FormFieldset>
-				<FormFieldset>
-					<FormLabel>Inner Dimensions (L x W x H)</FormLabel>
-					<FormTextInput
-						name="inner_dimensions"
-						placeholder="100 x 25 x 5.5"
-						value={ inner_dimensions }
-						onChange={ this.updateFormTextField }
-					/>
-					{ this.renderOuterDimensionsToggle() }
-				</FormFieldset>
-				{ this.renderOuterDimensions( outer_dimensions ) }
-				<FormFieldset className="wcc-shipping-add-package-weight-group">
-					<div className="wcc-shipping-add-package-weight">
-						<FormLabel htmlFor="box_weight">Package weight</FormLabel>
-						<FormTextInput
-							id="box_weight"
-							name="box_weight"
-							placeholder="Weight of box"
-							value={ box_weight }
-							onChange={ this.updateFormTextField }
-						/>
-					</div>
-					<div className="wcc-shipping-add-package-weight">
-						<FormLabel htmlFor="max_weight">Max weight</FormLabel>
-						<FormTextInput
-							id="max_weight"
-							name="max_weight"
-							placeholder="Max weight"
-							value={ max_weight }
-							onChange={ this.updateFormTextField }
-						/>
-						<span className="wcc-shipping-add-package-weight-unit">{ weightUnit }</span>
-					</div>
-					<FormSettingExplanation> Define both the weight of the empty box and the max weight it can hold</FormSettingExplanation>
-				</FormFieldset>
-			</Dialog>
+			<a
+				href="#"
+				className="form-setting-explanation"
+				onClick={ ( evt ) => {
+					evt.preventDefault();
+					toggleOuterDimensions();
+				} }>
+				Define exterior dimensions
+			</a>
 		);
 	}
-}
+};
+
+const updateFormTextField = ( event, updatePackagesField ) => {
+	const {
+		name,
+		value,
+	} = event.target;
+	updatePackagesField( { [name]: value } );
+};
+
+const renderOuterDimensions = ( showOuterDimensions, packageData, value, updatePackagesField ) => {
+	return ( showOuterDimensions || packageData.outer_dimensions ) ? (
+		<FormFieldset>
+			<FormLabel>Outer Dimensions (L x W x H)</FormLabel>
+			<FormTextInput
+				name="outer_dimensions"
+				placeholder="100.25 x 25.25 x 5.75"
+				value={ value }
+				onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+			/>
+		</FormFieldset>
+	) : null;
+};
+
+const usePresetValues = ( preset, updatePackagesField ) => {
+	updatePackagesField( {
+		index: null,
+		...preset,
+	} );
+};
+
+const useDefaultField = ( value, updatePackagesField ) => {
+	updatePackagesField( {
+		index: null,
+		is_letter: 'envelope' === value ? true : false,
+	} );
+};
+
+const AddPackageDialog = ( props ) => {
+	const {
+		dismissModal,
+		mode,
+		presets,
+		weightUnit,
+		packageData,
+		showOuterDimensions,
+		toggleOuterDimensions,
+		savePackage,
+		updatePackagesField,
+	} = props;
+
+	const {
+		name,
+		inner_dimensions,
+		outer_dimensions,
+		box_weight,
+		max_weight,
+	} = packageData;
+
+	return (
+		<Dialog
+			isVisible={ true }
+			additionalClassNames="wcc-modal wcc-shipping-add-edit-package-dialog"
+			onClose={ dismissModal }
+			buttons={ getDialogButtons( mode, savePackage, packageData ) }>
+			<FormSectionHeading>{ ( 'edit' === mode ) ? __( 'Edit package' ) : __( 'Add a package' ) }</FormSectionHeading>
+			{ ( 'add' === mode ) ? (
+				<AddPackagePresets
+					presets={ presets }
+					onSelectDefault={ ( value ) => useDefaultField( value, updatePackagesField ) }
+					onSelectPreset={ ( idx ) => usePresetValues( presets.boxes[idx], updatePackagesField ) }
+				/>
+			) : null }
+			<FormFieldset>
+				<FormLabel htmlFor="name">Package name</FormLabel>
+				<FormTextInput
+					id="name"
+					name="name"
+					placeholder="The customer will see this during checkout"
+					value={ name }
+					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+				/>
+			</FormFieldset>
+			<FormFieldset>
+				<FormLabel>Inner Dimensions (L x W x H)</FormLabel>
+				<FormTextInput
+					name="inner_dimensions"
+					placeholder="100 x 25 x 5.5"
+					value={ inner_dimensions }
+					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+				/>
+				{ renderOuterDimensionsToggle( showOuterDimensions, packageData, toggleOuterDimensions ) }
+			</FormFieldset>
+			{ renderOuterDimensions( showOuterDimensions, packageData, outer_dimensions, updatePackagesField ) }
+			<FormFieldset className="wcc-shipping-add-package-weight-group">
+				<div className="wcc-shipping-add-package-weight">
+					<FormLabel htmlFor="box_weight">Package weight</FormLabel>
+					<FormTextInput
+						id="box_weight"
+						name="box_weight"
+						placeholder="Weight of box"
+						value={ box_weight }
+						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+					/>
+				</div>
+				<div className="wcc-shipping-add-package-weight">
+					<FormLabel htmlFor="max_weight">Max weight</FormLabel>
+					<FormTextInput
+						id="max_weight"
+						name="max_weight"
+						placeholder="Max weight"
+						value={ max_weight }
+						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+					/>
+					<span className="wcc-shipping-add-package-weight-unit">{ weightUnit }</span>
+				</div>
+				<FormSettingExplanation> Define both the weight of the empty box and the max weight it can hold</FormSettingExplanation>
+			</FormFieldset>
+		</Dialog>
+	);
+};
 
 AddPackageDialog.propTypes = {
 	dismissModal: PropTypes.func.isRequired,
@@ -182,6 +163,10 @@ AddPackageDialog.propTypes = {
 	mode: PropTypes.string.isRequired,
 	updatePackagesField: PropTypes.func.isRequired,
 	showOuterDimensions: PropTypes.bool,
+	toggleOuterDimensions: PropTypes.func.isRequired,
+	savePackage: PropTypes.func.isRequired,
+	packageData: PropTypes.object,
+
 };
 
 AddPackageDialog.defaultProps = {

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -61,25 +61,25 @@ const renderOuterDimensions = ( showOuterDimensions, packageData, value, updateP
 	) : null;
 };
 
-const usePresetValues = ( preset, updatePackagesField, setModalReadOnly ) => {
+const usePresetValues = ( preset, updatePackagesField ) => {
 	updatePackagesField( {
 		index: null,
+		read_only: true,
 		...preset,
 	} );
-	setModalReadOnly( true );
 };
 
-const useDefaultField = ( value, updatePackagesField, setModalReadOnly ) => {
+const useDefaultField = ( value, updatePackagesField ) => {
 	updatePackagesField( {
 		index: null,
 		is_letter: 'envelope' === value,
 		name: '',
+		read_only: false,
 		outer_dimensions: '',
 		inner_dimensions: '',
 		box_weight: '',
 		max_weight: '',
 	} );
-	setModalReadOnly( false );
 };
 
 const AddPackageDialog = ( props ) => {
@@ -94,8 +94,6 @@ const AddPackageDialog = ( props ) => {
 		toggleOuterDimensions,
 		savePackage,
 		updatePackagesField,
-		modalReadOnly,
-		setModalReadOnly,
 		selectedPreset,
 		setSelectedPreset,
 	} = props;
@@ -106,6 +104,7 @@ const AddPackageDialog = ( props ) => {
 		outer_dimensions,
 		box_weight,
 		max_weight,
+		read_only,
 	} = packageData;
 
 	return (
@@ -120,8 +119,8 @@ const AddPackageDialog = ( props ) => {
 					selectedPreset={ selectedPreset }
 					setSelectedPreset={ setSelectedPreset }
 					presets={ presets }
-					onSelectDefault={ ( value ) => useDefaultField( value, updatePackagesField, setModalReadOnly ) }
-					onSelectPreset={ ( idx ) => usePresetValues( presets.boxes[idx], updatePackagesField, setModalReadOnly ) }
+					onSelectDefault={ ( value ) => useDefaultField( value, updatePackagesField ) }
+					onSelectPreset={ ( idx ) => usePresetValues( presets.boxes[idx], updatePackagesField ) }
 				/>
 			) : null }
 			<FormFieldset>
@@ -141,11 +140,11 @@ const AddPackageDialog = ( props ) => {
 					placeholder={ exampleDimensions( 100, 25, 5.5 ) }
 					value={ inner_dimensions }
 					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
-					disabled={ modalReadOnly }
+					disabled={ read_only }
 				/>
 				{ renderOuterDimensionsToggle( showOuterDimensions, packageData, toggleOuterDimensions ) }
 			</FormFieldset>
-			{ renderOuterDimensions( showOuterDimensions, packageData, outer_dimensions, updatePackagesField, modalReadOnly ) }
+			{ renderOuterDimensions( showOuterDimensions, packageData, outer_dimensions, updatePackagesField, read_only ) }
 			<FormFieldset className="wcc-shipping-add-package-weight-group">
 				<div className="wcc-shipping-add-package-weight">
 					<FormLabel htmlFor="box_weight">{ __( 'Package weight' ) }</FormLabel>
@@ -155,7 +154,7 @@ const AddPackageDialog = ( props ) => {
 						placeholder={ __( 'Weight of box' ) }
 						value={ box_weight }
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
-						disabled={ modalReadOnly }
+						disabled={ read_only }
 					/>
 				</div>
 				<div className="wcc-shipping-add-package-weight">
@@ -166,7 +165,7 @@ const AddPackageDialog = ( props ) => {
 						placeholder={ __( 'Max weight' ) }
 						value={ max_weight }
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
-						disabled={ modalReadOnly }
+						disabled={ read_only }
 					/>
 					<span className="wcc-shipping-add-package-weight-unit">{ weightUnit }</span>
 				</div>
@@ -188,8 +187,6 @@ AddPackageDialog.propTypes = {
 	toggleOuterDimensions: PropTypes.func.isRequired,
 	savePackage: PropTypes.func.isRequired,
 	packageData: PropTypes.object,
-	setModalReadOnly: PropTypes.func.isRequired,
-	modalReadOnly: PropTypes.bool,
 	setSelectedPreset: PropTypes.func.isRequired,
 	selectedPreset: PropTypes.string,
 };

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -105,9 +105,8 @@ const AddPackageDialog = ( props ) => {
 		outer_dimensions,
 		box_weight,
 		max_weight,
+		is_user_defined,
 	} = packageData;
-
-	const is_user_defined = ! selectedPreset || packageData.is_user_defined;
 
 	return (
 		<Dialog

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -92,6 +92,8 @@ const AddPackageDialog = ( props ) => {
 		updatePackagesField,
 		modalReadOnly,
 		setModalReadOnly,
+		selectedPreset,
+		setSelectedPreset,
 	} = props;
 
 	const {
@@ -111,6 +113,8 @@ const AddPackageDialog = ( props ) => {
 			<FormSectionHeading>{ ( 'edit' === mode ) ? __( 'Edit package' ) : __( 'Add a package' ) }</FormSectionHeading>
 			{ ( 'add' === mode ) ? (
 				<AddPackagePresets
+					selectedPreset={ selectedPreset }
+					setSelectedPreset={ setSelectedPreset }
 					presets={ presets }
 					onSelectDefault={ ( value ) => useDefaultField( value, updatePackagesField, setModalReadOnly ) }
 					onSelectPreset={ ( idx ) => usePresetValues( presets.boxes[idx], updatePackagesField, setModalReadOnly ) }
@@ -180,6 +184,8 @@ AddPackageDialog.propTypes = {
 	packageData: PropTypes.object,
 	setModalReadOnly: PropTypes.func.isRequired,
 	modalReadOnly: PropTypes.bool,
+	setSelectedPreset: PropTypes.func.isRequired,
+	selectedPreset: PropTypes.string,
 };
 
 AddPackageDialog.defaultProps = {

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -46,7 +46,7 @@ const updateFormTextField = ( event, updatePackagesField ) => {
 	updatePackagesField( { [name]: value } );
 };
 
-const renderOuterDimensions = ( showOuterDimensions, packageData, value, updatePackagesField, modalReadOnly ) => {
+const renderOuterDimensions = ( showOuterDimensions, packageData, value, updatePackagesField, is_user_defined ) => {
 	return ( showOuterDimensions || packageData.outer_dimensions ) ? (
 		<FormFieldset>
 			<FormLabel>{ __( 'Outer Dimensions (L x W x H)' ) }</FormLabel>
@@ -54,9 +54,9 @@ const renderOuterDimensions = ( showOuterDimensions, packageData, value, updateP
 				name="outer_dimensions"
 				placeholder={ exampleDimensions( 100.25, 25.25, 5.75 ) }
 				value={ value }
-				className="flat-rate-package__outer-dimensions"
+				className="flat-rate-package__outer-dimensions__read-only"
 				onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
-				disabled={ modalReadOnly }
+				disabled={ ! is_user_defined }
 			/>
 		</FormFieldset>
 	) : null;
@@ -65,7 +65,7 @@ const renderOuterDimensions = ( showOuterDimensions, packageData, value, updateP
 const usePresetValues = ( preset, updatePackagesField ) => {
 	updatePackagesField( {
 		index: null,
-		read_only: true,
+		is_user_defined: false,
 		...preset,
 	} );
 };
@@ -75,7 +75,7 @@ const useDefaultField = ( value, updatePackagesField ) => {
 		index: null,
 		is_letter: 'envelope' === value,
 		name: '',
-		read_only: false,
+		is_user_defined: true,
 		outer_dimensions: '',
 		inner_dimensions: '',
 		box_weight: '',
@@ -105,8 +105,9 @@ const AddPackageDialog = ( props ) => {
 		outer_dimensions,
 		box_weight,
 		max_weight,
-		read_only,
 	} = packageData;
+
+	const is_user_defined = ! selectedPreset || packageData.is_user_defined;
 
 	return (
 		<Dialog
@@ -140,13 +141,13 @@ const AddPackageDialog = ( props ) => {
 					name="inner_dimensions"
 					placeholder={ exampleDimensions( 100, 25, 5.5 ) }
 					value={ inner_dimensions }
-					className="flat-rate-package__inner-dimensions"
+					className="flat-rate-package__inner-dimensions__read-only"
 					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
-					disabled={ read_only }
+					disabled={ ! is_user_defined }
 				/>
 				{ renderOuterDimensionsToggle( showOuterDimensions, packageData, toggleOuterDimensions ) }
 			</FormFieldset>
-			{ renderOuterDimensions( showOuterDimensions, packageData, outer_dimensions, updatePackagesField, read_only ) }
+			{ renderOuterDimensions( showOuterDimensions, packageData, outer_dimensions, updatePackagesField, is_user_defined ) }
 			<FormFieldset className="wcc-shipping-add-package-weight-group">
 				<div className="wcc-shipping-add-package-weight">
 					<FormLabel htmlFor="box_weight">{ __( 'Package weight' ) }</FormLabel>
@@ -155,9 +156,9 @@ const AddPackageDialog = ( props ) => {
 						name="box_weight"
 						placeholder={ __( 'Weight of box' ) }
 						value={ box_weight }
-						className="flat-rate-package__package-weight"
+						className="flat-rate-package__package-weight__read-only"
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
-						disabled={ read_only }
+						disabled={ ! is_user_defined }
 					/>
 				</div>
 				<div className="wcc-shipping-add-package-weight">
@@ -167,9 +168,9 @@ const AddPackageDialog = ( props ) => {
 						name="max_weight"
 						placeholder={ __( 'Max weight' ) }
 						value={ max_weight }
-						className="flat-rate-package__max-weight"
+						className="flat-rate-package__max-weight__read-only"
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
-						disabled={ read_only }
+						disabled={ ! is_user_defined }
 					/>
 					<span className="wcc-shipping-add-package-weight-unit">{ weightUnit }</span>
 				</div>
@@ -196,7 +197,9 @@ AddPackageDialog.propTypes = {
 };
 
 AddPackageDialog.defaultProps = {
-	packageData: {},
+	packageData: {
+		is_user_defined: true,
+	},
 	mode: 'add',
 };
 

--- a/client/components/shipping/packages/index.js
+++ b/client/components/shipping/packages/index.js
@@ -3,40 +3,32 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormButton from 'components/forms/form-button';
 import PackagesList from './packages-list';
 import AddPackageDialog from './add-package';
+import { translate as __ } from 'lib/mixins/i18n';
 
-const Packages = React.createClass( {
-	displayName: 'Packages',
-	propTypes: {
-		addPackage: PropTypes.func.isRequired,
-		showModal: PropTypes.bool,
-		dismissModal: PropTypes.func.isRequired,
-	},
-	render: function() {
-		return (
-			<div>
-				<PackagesList { ...this.props } />
-				{ this.renderAddPackage() }
-				<FormFieldset className="add-package-button-field">
-					<FormButton
-						type="button"
-						isPrimary={ false }
-						compact
-						onClick={ this.props.addPackage }
-					>
-						Add a package
-					</FormButton>
-				</FormFieldset>
-			</div>
-		);
-	},
-	renderAddPackage: function() {
-		if ( this.props.showModal ) {
-			return (
-				<AddPackageDialog { ...this.props } />
-			);
-		}
-	},
-} );
+const Packages = ( props ) => {
+	return (
+		<div>
+			<PackagesList { ...props } />
+			<AddPackageDialog { ...props } />
+			<FormFieldset className="add-package-button-field">
+				<FormButton
+					type="button"
+					isPrimary={ false }
+					compact
+					onClick={ props.addPackage }
+				>
+					{ __( 'Add a package' ) }
+				</FormButton>
+			</FormFieldset>
+		</div>
+	);
+};
+
+Packages.propTypes = {
+	addPackage: PropTypes.func.isRequired,
+	showModal: PropTypes.bool,
+	dismissModal: PropTypes.func.isRequired,
+};
 
 export default Packages;
 

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -103,3 +103,23 @@
     float: left;
     margin-left: 0;
 }
+
+.form-text-input.flat-rate-package__inner-dimensions__read-only:disabled,
+.form-text-input.flat-rate-package__outer-dimensions__read-only:disabled,
+.form-text-input.flat-rate-package__package-weight__read-only:disabled,
+.form-text-input.flat-rate-package__max-weight__read-only:disabled {
+    border: 0;
+    background: white !important;
+    padding: 0 32px 0 0;
+    cursor: default;
+    color: $gray-dark;
+    -webkit-text-fill-color: $gray-dark;
+
+    @include placeholder {
+        color: $gray-dark;
+    }
+
+    &:focus {
+        box-shadow: none;
+    }
+}

--- a/client/state/form/packages/actions.js
+++ b/client/state/form/packages/actions.js
@@ -2,6 +2,7 @@ export const ADD_PACKAGE = 'ADD_PACKAGE';
 export const EDIT_PACKAGE = 'EDIT_PACKAGE';
 export const DISMISS_MODAL = 'DISMISS_MODAL';
 export const SET_MODAL_READONLY = 'SET_MODAL_READONLY';
+export const SET_SELECTED_PRESET = 'SET_SELECTED_PRESET';
 export const SAVE_PACKAGE = 'SAVE_PACKAGE';
 export const UPDATE_PACKAGES_FIELD = 'UPDATE_PACKAGES_FIELD';
 export const TOGGLE_OUTER_DIMENSIONS = 'TOGGLE_OUTER_DIMENSIONS';
@@ -21,6 +22,11 @@ export const dismissModal = () => ( {
 
 export const setModalReadOnly = ( value ) => ( {
 	type: SET_MODAL_READONLY,
+	value,
+} );
+
+export const setSelectedPreset = ( value ) => ( {
+	type: SET_SELECTED_PRESET,
 	value,
 } );
 

--- a/client/state/form/packages/actions.js
+++ b/client/state/form/packages/actions.js
@@ -1,6 +1,7 @@
 export const ADD_PACKAGE = 'ADD_PACKAGE';
 export const EDIT_PACKAGE = 'EDIT_PACKAGE';
 export const DISMISS_MODAL = 'DISMISS_MODAL';
+export const SET_MODAL_READONLY = 'SET_MODAL_READONLY';
 export const SAVE_PACKAGE = 'SAVE_PACKAGE';
 export const UPDATE_PACKAGES_FIELD = 'UPDATE_PACKAGES_FIELD';
 export const TOGGLE_OUTER_DIMENSIONS = 'TOGGLE_OUTER_DIMENSIONS';
@@ -16,6 +17,11 @@ export const editPackage = ( packageToEdit ) => ( {
 
 export const dismissModal = () => ( {
 	type: DISMISS_MODAL,
+} );
+
+export const setModalReadOnly = ( value ) => ( {
+	type: SET_MODAL_READONLY,
+	value,
 } );
 
 export const savePackage = ( settings_key, packageData ) => ( {

--- a/client/state/form/packages/actions.js
+++ b/client/state/form/packages/actions.js
@@ -1,7 +1,6 @@
 export const ADD_PACKAGE = 'ADD_PACKAGE';
 export const EDIT_PACKAGE = 'EDIT_PACKAGE';
 export const DISMISS_MODAL = 'DISMISS_MODAL';
-export const SET_MODAL_READONLY = 'SET_MODAL_READONLY';
 export const SET_SELECTED_PRESET = 'SET_SELECTED_PRESET';
 export const SAVE_PACKAGE = 'SAVE_PACKAGE';
 export const UPDATE_PACKAGES_FIELD = 'UPDATE_PACKAGES_FIELD';
@@ -18,11 +17,6 @@ export const editPackage = ( packageToEdit ) => ( {
 
 export const dismissModal = () => ( {
 	type: DISMISS_MODAL,
-} );
-
-export const setModalReadOnly = ( value ) => ( {
-	type: SET_MODAL_READONLY,
-	value,
 } );
 
 export const setSelectedPreset = ( value ) => ( {

--- a/client/state/form/packages/reducer.js
+++ b/client/state/form/packages/reducer.js
@@ -3,6 +3,7 @@ import {
 	EDIT_PACKAGE,
 	DISMISS_MODAL,
 	SET_MODAL_READONLY,
+	SET_SELECTED_PRESET,
 	UPDATE_PACKAGES_FIELD,
 	SAVE_PACKAGE,
 	TOGGLE_OUTER_DIMENSIONS,
@@ -41,6 +42,12 @@ reducers[DISMISS_MODAL] = ( state ) => {
 reducers[SET_MODAL_READONLY] = ( state, action ) => {
 	return Object.assign( {}, state, {
 		modalReadOnly: action.value,
+	} );
+};
+
+reducers[SET_SELECTED_PRESET] = ( state, action ) => {
+	return Object.assign( {}, state, {
+		selectedPreset: action.value,
 	} );
 };
 

--- a/client/state/form/packages/reducer.js
+++ b/client/state/form/packages/reducer.js
@@ -25,6 +25,7 @@ reducers[ADD_PACKAGE] = ( state ) => {
 reducers[EDIT_PACKAGE] = ( state, action ) => {
 	return Object.assign( {}, state, {
 		showModal: true,
+		modalReadOnly: false,
 		mode: 'edit',
 		packageData: action.package,
 		showOuterDimensions: false,

--- a/client/state/form/packages/reducer.js
+++ b/client/state/form/packages/reducer.js
@@ -2,6 +2,7 @@ import {
 	ADD_PACKAGE,
 	EDIT_PACKAGE,
 	DISMISS_MODAL,
+	SET_MODAL_READONLY,
 	UPDATE_PACKAGES_FIELD,
 	SAVE_PACKAGE,
 	TOGGLE_OUTER_DIMENSIONS,
@@ -36,6 +37,12 @@ reducers[DISMISS_MODAL] = ( state ) => {
 	} );
 };
 
+reducers[SET_MODAL_READONLY] = ( state, action ) => {
+	return Object.assign( {}, state, {
+		modalReadOnly: action.value,
+	} );
+};
+
 reducers[UPDATE_PACKAGES_FIELD] = ( state, action ) => {
 	const mergedPackageData = Object.assign( {}, state.packageData, action.values );
 	const newPackageData = omitBy( mergedPackageData, isNull );
@@ -57,7 +64,7 @@ reducers[TOGGLE_OUTER_DIMENSIONS] = ( state ) => {
 	return Object.assign( {}, state, {
 		showOuterDimensions: true,
 	} );
-}
+};
 
 const packages = ( state = {}, action ) => {
 	if ( reducers.hasOwnProperty( action.type ) ) {

--- a/client/state/form/packages/reducer.js
+++ b/client/state/form/packages/reducer.js
@@ -7,19 +7,22 @@ import {
 	SAVE_PACKAGE,
 	TOGGLE_OUTER_DIMENSIONS,
 } from './actions';
-import omit from 'lodash/omit';
 import omitBy from 'lodash/omitBy';
 import isNull from 'lodash/isNull';
 
 const reducers = {};
 
 reducers[ADD_PACKAGE] = ( state ) => {
-	const newPackageData = ( 'edit' === state.mode ) ? {} : omit( state.packageData, 'index' );
-	return Object.assign( {}, state, {
+	const newState = Object.assign( {}, state, {
 		showModal: true,
 		mode: 'add',
-		packageData: newPackageData,
 	} );
+
+	if ( 'edit' === state.mode || ! newState.packageData ) {
+		newState.packageData = { is_user_defined: true }
+	}
+
+	return newState;
 };
 
 reducers[EDIT_PACKAGE] = ( state, action ) => {

--- a/client/state/form/packages/reducer.js
+++ b/client/state/form/packages/reducer.js
@@ -2,7 +2,6 @@ import {
 	ADD_PACKAGE,
 	EDIT_PACKAGE,
 	DISMISS_MODAL,
-	SET_MODAL_READONLY,
 	SET_SELECTED_PRESET,
 	UPDATE_PACKAGES_FIELD,
 	SAVE_PACKAGE,
@@ -36,12 +35,6 @@ reducers[EDIT_PACKAGE] = ( state, action ) => {
 reducers[DISMISS_MODAL] = ( state ) => {
 	return Object.assign( {}, state, {
 		showModal: false,
-	} );
-};
-
-reducers[SET_MODAL_READONLY] = ( state, action ) => {
-	return Object.assign( {}, state, {
-		modalReadOnly: action.value,
 	} );
 };
 

--- a/client/state/form/packages/test/actions.js
+++ b/client/state/form/packages/test/actions.js
@@ -3,7 +3,6 @@ import {
 	addPackage,
 	editPackage,
 	dismissModal,
-	setModalReadOnly,
 	setSelectedPreset,
 	savePackage,
 	updatePackagesField,
@@ -11,7 +10,6 @@ import {
 	ADD_PACKAGE,
 	EDIT_PACKAGE,
 	DISMISS_MODAL,
-	SET_MODAL_READONLY,
 	SET_SELECTED_PRESET,
 	SAVE_PACKAGE,
 	UPDATE_PACKAGES_FIELD,
@@ -40,18 +38,6 @@ describe( 'Packages state actions', () => {
 	it( '#dismissModal()', () => {
 		expect( dismissModal() ).to.eql( {
 			type: DISMISS_MODAL,
-		} );
-	} );
-
-	it( '#setModalReadOnly()', () => {
-		expect( setModalReadOnly( true ) ).to.eql( {
-			type: SET_MODAL_READONLY,
-			value: true,
-		} );
-
-		expect( setModalReadOnly( false ) ).to.eql( {
-			type: SET_MODAL_READONLY,
-			value: false,
 		} );
 	} );
 

--- a/client/state/form/packages/test/actions.js
+++ b/client/state/form/packages/test/actions.js
@@ -3,12 +3,16 @@ import {
 	addPackage,
 	editPackage,
 	dismissModal,
+	setModalReadOnly,
+	setSelectedPreset,
 	savePackage,
 	updatePackagesField,
 	toggleOuterDimensions,
 	ADD_PACKAGE,
 	EDIT_PACKAGE,
 	DISMISS_MODAL,
+	SET_MODAL_READONLY,
+	SET_SELECTED_PRESET,
 	SAVE_PACKAGE,
 	UPDATE_PACKAGES_FIELD,
 	TOGGLE_OUTER_DIMENSIONS,
@@ -36,6 +40,30 @@ describe( 'Packages state actions', () => {
 	it( '#dismissModal()', () => {
 		expect( dismissModal() ).to.eql( {
 			type: DISMISS_MODAL,
+		} );
+	} );
+
+	it( '#setModalReadOnly()', () => {
+		expect( setModalReadOnly( true ) ).to.eql( {
+			type: SET_MODAL_READONLY,
+			value: true,
+		} );
+
+		expect( setModalReadOnly( false ) ).to.eql( {
+			type: SET_MODAL_READONLY,
+			value: false,
+		} );
+	} );
+
+	it( '#setSelectedPreset()', () => {
+		expect( setSelectedPreset( 'a' ) ).to.eql( {
+			type: SET_SELECTED_PRESET,
+			value: 'a',
+		} );
+
+		expect( setSelectedPreset( 'ab' ) ).to.eql( {
+			type: SET_SELECTED_PRESET,
+			value: 'ab',
 		} );
 	} );
 

--- a/client/state/form/packages/test/reducer.js
+++ b/client/state/form/packages/test/reducer.js
@@ -4,7 +4,6 @@ import {
 	addPackage,
 	editPackage,
 	dismissModal,
-	setModalReadOnly,
 	setSelectedPreset,
 	updatePackagesField,
 	toggleOuterDimensions,
@@ -91,25 +90,6 @@ describe( 'Packages form reducer', () => {
 
 		expect( state ).to.eql( {
 			showModal: false,
-		} );
-	} );
-
-	it( 'SET_MODAL_READONLY', () => {
-		let state = {};
-
-		state = reducer( state, setModalReadOnly( true ) );
-		expect( state ).to.eql( {
-			modalReadOnly: true,
-		} );
-
-		state = reducer( state, setModalReadOnly( true ) );
-		expect( state ).to.eql( {
-			modalReadOnly: true,
-		} );
-
-		state = reducer( state, setModalReadOnly( false ) );
-		expect( state ).to.eql( {
-			modalReadOnly: false,
 		} );
 	} );
 

--- a/client/state/form/packages/test/reducer.js
+++ b/client/state/form/packages/test/reducer.js
@@ -4,6 +4,8 @@ import {
 	addPackage,
 	editPackage,
 	dismissModal,
+	setModalReadOnly,
+	setSelectedPreset,
 	updatePackagesField,
 	toggleOuterDimensions,
 } from '../actions';
@@ -73,6 +75,7 @@ describe( 'Packages form reducer', () => {
 
 		expect( state ).to.eql( {
 			showModal: true,
+			modalReadOnly: false,
 			mode: 'edit',
 			packageData,
 			showOuterDimensions: false,
@@ -88,6 +91,44 @@ describe( 'Packages form reducer', () => {
 
 		expect( state ).to.eql( {
 			showModal: false,
+		} );
+	} );
+
+	it( 'SET_MODAL_READONLY', () => {
+		let state = {};
+
+		state = reducer( state, setModalReadOnly( true ) );
+		expect( state ).to.eql( {
+			modalReadOnly: true,
+		} );
+
+		state = reducer( state, setModalReadOnly( true ) );
+		expect( state ).to.eql( {
+			modalReadOnly: true,
+		} );
+
+		state = reducer( state, setModalReadOnly( false ) );
+		expect( state ).to.eql( {
+			modalReadOnly: false,
+		} );
+	} );
+
+	it( 'SET_SELECTED_PRESET', () => {
+		let state = {};
+
+		state = reducer( state, setSelectedPreset( 'a' ) );
+		expect( state ).to.eql( {
+			selectedPreset: 'a',
+		} );
+
+		state = reducer( state, setSelectedPreset( 'aaa' ) );
+		expect( state ).to.eql( {
+			selectedPreset: 'aaa',
+		} );
+
+		state = reducer( state, setSelectedPreset( '1112' ) );
+		expect( state ).to.eql( {
+			selectedPreset: '1112',
 		} );
 	} );
 

--- a/client/state/form/packages/test/reducer.js
+++ b/client/state/form/packages/test/reducer.js
@@ -57,7 +57,7 @@ describe( 'Packages form reducer', () => {
 		expect( state ).to.eql( {
 			showModal: true,
 			mode: 'add',
-			packageData: {},
+			packageData: { is_user_defined: true },
 		} );
 	} );
 


### PR DESCRIPTION
This change causes the add-package modal to disable dimension and weight fields when a preset package is used. A `read_only` field is needed in the box fields to support this. The server needs to support this (PR pending).

Notes: You'll need the corresponding server branch to be able to save. Everything else works.

To test:
- Check this branch out and try switching around the presets in the drop-down when adding a package
- Check that after saving the box, editing results in the correct fields being read only.
- See that everything saves correctly, etc.

Closes #260 
Closes #303 
Closes #307

@allendav @jeffstieler @jkudish 