### PR TITLE
Update/preset packaging readonly

### DIFF
--- a/client/components/shipping/packages/add-package-presets.js
+++ b/client/components/shipping/packages/add-package-presets.js
@@ -32,10 +32,11 @@ const getOptionGroups = ( presets ) => {
 	]
 };
 
-const handleSelectEvent = ( e, selectDefault, selectPreset ) => {
+const handleSelectEvent = ( e, selectDefault, selectPreset, setSelectedPreset ) => {
 	const parts = e.target.value.split( '_' );
 	const type = parts[0];
 	const id = parts[1];
+	setSelectedPreset( e.target.value );
 	switch ( type ) {
 		case 'default':
 			return selectDefault( id );
@@ -44,13 +45,14 @@ const handleSelectEvent = ( e, selectDefault, selectPreset ) => {
 	}
 };
 
-const AddPackagePresets = ( { presets, onSelectDefault, onSelectPreset } ) => {
+const AddPackagePresets = ( { selectedPreset, setSelectedPreset, presets, onSelectDefault, onSelectPreset } ) => {
 	return (
 		<FormFieldset>
 			<FormLabel htmlFor="package_type">Type of package</FormLabel>
 			<SelectOptGroups
 				id="package_type"
-				onChange={ ( e ) => handleSelectEvent( e, onSelectDefault, onSelectPreset ) }
+				defaultValue={ selectedPreset }
+				onChange={ ( e ) => handleSelectEvent( e, onSelectDefault, onSelectPreset, setSelectedPreset ) }
 				optGroups={ getOptionGroups( presets ) }
 				readOnly={ false }/>
 		</FormFieldset>
@@ -58,6 +60,8 @@ const AddPackagePresets = ( { presets, onSelectDefault, onSelectPreset } ) => {
 };
 
 AddPackagePresets.propTypes = {
+	selectedPreset: PropTypes.string,
+	setSelectedPreset: PropTypes.func.isRequired,
 	presets: PropTypes.object.isRequired,
 	onSelectDefault: PropTypes.func.isRequired,
 	onSelectPreset: PropTypes.func.isRequired,

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -75,6 +75,11 @@ const useDefaultField = ( value, updatePackagesField, setModalReadOnly ) => {
 	updatePackagesField( {
 		index: null,
 		is_letter: 'envelope' === value ? true : false,
+		name: '',
+		outer_dimensions: '',
+		inner_dimensions: '',
+		box_weight: '',
+		max_weight: '',
 	} );
 	setModalReadOnly( false );
 };

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -5,17 +5,19 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormButton from 'components/forms/form-button';
-import FormCheckbox from 'components/forms/form-checkbox';
+// import FormCheckbox from 'components/forms/form-checkbox';
 import Dialog from 'components/dialog';
 import AddPackagePresets from './add-package-presets';
 import { translate as __ } from 'lib/mixins/i18n';
 
 const getDialogButtons = ( mode, savePackage, packageData ) => {
 	return [
+		/*
 		<FormLabel className="share-package-option">
 			<FormCheckbox checked={ true } readOnly={ true } />
 			<span>Save package to use in other shipping methods</span>
 		</FormLabel>,
+		*/
 		<FormButton onClick={ () => savePackage( packageData ) }>
 			{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }
 		</FormButton>,

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -92,6 +92,8 @@ const AddPackageDialog = ( props ) => {
 		updatePackagesField,
 		modalReadOnly,
 		setModalReadOnly,
+		selectedPreset,
+		setSelectedPreset,
 	} = props;
 
 	const {
@@ -111,6 +113,8 @@ const AddPackageDialog = ( props ) => {
 			<FormSectionHeading>{ ( 'edit' === mode ) ? __( 'Edit package' ) : __( 'Add a package' ) }</FormSectionHeading>
 			{ ( 'add' === mode ) ? (
 				<AddPackagePresets
+					selectedPreset={ selectedPreset }
+					setSelectedPreset={ setSelectedPreset }
 					presets={ presets }
 					onSelectDefault={ ( value ) => useDefaultField( value, updatePackagesField, setModalReadOnly ) }
 					onSelectPreset={ ( idx ) => usePresetValues( presets.boxes[idx], updatePackagesField, setModalReadOnly ) }
@@ -180,6 +184,8 @@ AddPackageDialog.propTypes = {
 	packageData: PropTypes.object,
 	setModalReadOnly: PropTypes.func.isRequired,
 	modalReadOnly: PropTypes.bool,
+	setSelectedPreset: PropTypes.func.isRequired,
+	selectedPreset: PropTypes.string,
 };
 
 AddPackageDialog.defaultProps = {

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -16,7 +16,9 @@ const getDialogButtons = ( mode, savePackage, packageData ) => {
 			<FormCheckbox checked={ true } readOnly={ true } />
 			<span>Save package to use in other shipping methods</span>
 		</FormLabel>,
-		<FormButton onClick={ () => savePackage( packageData ) }>{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }</FormButton>,
+		<FormButton onClick={ () => savePackage( packageData ) }>
+			{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }
+		</FormButton>,
 	];
 };
 
@@ -44,7 +46,7 @@ const updateFormTextField = ( event, updatePackagesField ) => {
 	updatePackagesField( { [name]: value } );
 };
 
-const renderOuterDimensions = ( showOuterDimensions, packageData, value, updatePackagesField ) => {
+const renderOuterDimensions = ( showOuterDimensions, packageData, value, updatePackagesField, modalReadOnly ) => {
 	return ( showOuterDimensions || packageData.outer_dimensions ) ? (
 		<FormFieldset>
 			<FormLabel>Outer Dimensions (L x W x H)</FormLabel>
@@ -53,23 +55,26 @@ const renderOuterDimensions = ( showOuterDimensions, packageData, value, updateP
 				placeholder="100.25 x 25.25 x 5.75"
 				value={ value }
 				onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+				disabled={ modalReadOnly }
 			/>
 		</FormFieldset>
 	) : null;
 };
 
-const usePresetValues = ( preset, updatePackagesField ) => {
+const usePresetValues = ( preset, updatePackagesField, setModalReadOnly ) => {
 	updatePackagesField( {
 		index: null,
 		...preset,
 	} );
+	setModalReadOnly( true );
 };
 
-const useDefaultField = ( value, updatePackagesField ) => {
+const useDefaultField = ( value, updatePackagesField, setModalReadOnly ) => {
 	updatePackagesField( {
 		index: null,
 		is_letter: 'envelope' === value ? true : false,
 	} );
+	setModalReadOnly( false );
 };
 
 const AddPackageDialog = ( props ) => {
@@ -83,6 +88,8 @@ const AddPackageDialog = ( props ) => {
 		toggleOuterDimensions,
 		savePackage,
 		updatePackagesField,
+		modalReadOnly,
+		setModalReadOnly,
 	} = props;
 
 	const {
@@ -103,8 +110,8 @@ const AddPackageDialog = ( props ) => {
 			{ ( 'add' === mode ) ? (
 				<AddPackagePresets
 					presets={ presets }
-					onSelectDefault={ ( value ) => useDefaultField( value, updatePackagesField ) }
-					onSelectPreset={ ( idx ) => usePresetValues( presets.boxes[idx], updatePackagesField ) }
+					onSelectDefault={ ( value ) => useDefaultField( value, updatePackagesField, setModalReadOnly ) }
+					onSelectPreset={ ( idx ) => usePresetValues( presets.boxes[idx], updatePackagesField, setModalReadOnly ) }
 				/>
 			) : null }
 			<FormFieldset>
@@ -124,10 +131,11 @@ const AddPackageDialog = ( props ) => {
 					placeholder="100 x 25 x 5.5"
 					value={ inner_dimensions }
 					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+					disabled={ modalReadOnly }
 				/>
 				{ renderOuterDimensionsToggle( showOuterDimensions, packageData, toggleOuterDimensions ) }
 			</FormFieldset>
-			{ renderOuterDimensions( showOuterDimensions, packageData, outer_dimensions, updatePackagesField ) }
+			{ renderOuterDimensions( showOuterDimensions, packageData, outer_dimensions, updatePackagesField, modalReadOnly ) }
 			<FormFieldset className="wcc-shipping-add-package-weight-group">
 				<div className="wcc-shipping-add-package-weight">
 					<FormLabel htmlFor="box_weight">Package weight</FormLabel>
@@ -137,6 +145,7 @@ const AddPackageDialog = ( props ) => {
 						placeholder="Weight of box"
 						value={ box_weight }
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+						disabled={ modalReadOnly }
 					/>
 				</div>
 				<div className="wcc-shipping-add-package-weight">
@@ -147,6 +156,7 @@ const AddPackageDialog = ( props ) => {
 						placeholder="Max weight"
 						value={ max_weight }
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+						disabled={ modalReadOnly }
 					/>
 					<span className="wcc-shipping-add-package-weight-unit">{ weightUnit }</span>
 				</div>
@@ -166,7 +176,8 @@ AddPackageDialog.propTypes = {
 	toggleOuterDimensions: PropTypes.func.isRequired,
 	savePackage: PropTypes.func.isRequired,
 	packageData: PropTypes.object,
-
+	setModalReadOnly: PropTypes.func.isRequired,
+	modalReadOnly: PropTypes.bool,
 };
 
 AddPackageDialog.defaultProps = {

--- a/client/state/form/packages/actions.js
+++ b/client/state/form/packages/actions.js
@@ -2,6 +2,7 @@ export const ADD_PACKAGE = 'ADD_PACKAGE';
 export const EDIT_PACKAGE = 'EDIT_PACKAGE';
 export const DISMISS_MODAL = 'DISMISS_MODAL';
 export const SET_MODAL_READONLY = 'SET_MODAL_READONLY';
+export const SET_SELECTED_PRESET = 'SET_SELECTED_PRESET';
 export const SAVE_PACKAGE = 'SAVE_PACKAGE';
 export const UPDATE_PACKAGES_FIELD = 'UPDATE_PACKAGES_FIELD';
 export const TOGGLE_OUTER_DIMENSIONS = 'TOGGLE_OUTER_DIMENSIONS';
@@ -21,6 +22,11 @@ export const dismissModal = () => ( {
 
 export const setModalReadOnly = ( value ) => ( {
 	type: SET_MODAL_READONLY,
+	value,
+} );
+
+export const setSelectedPreset = ( value ) => ( {
+	type: SET_SELECTED_PRESET,
 	value,
 } );
 

--- a/client/state/form/packages/actions.js
+++ b/client/state/form/packages/actions.js
@@ -1,6 +1,7 @@
 export const ADD_PACKAGE = 'ADD_PACKAGE';
 export const EDIT_PACKAGE = 'EDIT_PACKAGE';
 export const DISMISS_MODAL = 'DISMISS_MODAL';
+export const SET_MODAL_READONLY = 'SET_MODAL_READONLY';
 export const SAVE_PACKAGE = 'SAVE_PACKAGE';
 export const UPDATE_PACKAGES_FIELD = 'UPDATE_PACKAGES_FIELD';
 export const TOGGLE_OUTER_DIMENSIONS = 'TOGGLE_OUTER_DIMENSIONS';
@@ -16,6 +17,11 @@ export const editPackage = ( packageToEdit ) => ( {
 
 export const dismissModal = () => ( {
 	type: DISMISS_MODAL,
+} );
+
+export const setModalReadOnly = ( value ) => ( {
+	type: SET_MODAL_READONLY,
+	value,
 } );
 
 export const savePackage = ( settings_key, packageData ) => ( {

--- a/client/state/form/packages/reducer.js
+++ b/client/state/form/packages/reducer.js
@@ -3,6 +3,7 @@ import {
 	EDIT_PACKAGE,
 	DISMISS_MODAL,
 	SET_MODAL_READONLY,
+	SET_SELECTED_PRESET,
 	UPDATE_PACKAGES_FIELD,
 	SAVE_PACKAGE,
 	TOGGLE_OUTER_DIMENSIONS,
@@ -41,6 +42,12 @@ reducers[DISMISS_MODAL] = ( state ) => {
 reducers[SET_MODAL_READONLY] = ( state, action ) => {
 	return Object.assign( {}, state, {
 		modalReadOnly: action.value,
+	} );
+};
+
+reducers[SET_SELECTED_PRESET] = ( state, action ) => {
+	return Object.assign( {}, state, {
+		selectedPreset: action.value,
 	} );
 };
 

--- a/client/state/form/packages/reducer.js
+++ b/client/state/form/packages/reducer.js
@@ -25,6 +25,7 @@ reducers[ADD_PACKAGE] = ( state ) => {
 reducers[EDIT_PACKAGE] = ( state, action ) => {
 	return Object.assign( {}, state, {
 		showModal: true,
+		modalReadOnly: false,
 		mode: 'edit',
 		packageData: action.package,
 		showOuterDimensions: false,

--- a/client/state/form/packages/reducer.js
+++ b/client/state/form/packages/reducer.js
@@ -2,6 +2,7 @@ import {
 	ADD_PACKAGE,
 	EDIT_PACKAGE,
 	DISMISS_MODAL,
+	SET_MODAL_READONLY,
 	UPDATE_PACKAGES_FIELD,
 	SAVE_PACKAGE,
 	TOGGLE_OUTER_DIMENSIONS,
@@ -36,6 +37,12 @@ reducers[DISMISS_MODAL] = ( state ) => {
 	} );
 };
 
+reducers[SET_MODAL_READONLY] = ( state, action ) => {
+	return Object.assign( {}, state, {
+		modalReadOnly: action.value,
+	} );
+};
+
 reducers[UPDATE_PACKAGES_FIELD] = ( state, action ) => {
 	const mergedPackageData = Object.assign( {}, state.packageData, action.values );
 	const newPackageData = omitBy( mergedPackageData, isNull );
@@ -57,7 +64,7 @@ reducers[TOGGLE_OUTER_DIMENSIONS] = ( state ) => {
 	return Object.assign( {}, state, {
 		showOuterDimensions: true,
 	} );
-}
+};
 
 const packages = ( state = {}, action ) => {
 	if ( reducers.hasOwnProperty( action.type ) ) {

--- a/client/state/form/packages/test/actions.js
+++ b/client/state/form/packages/test/actions.js
@@ -3,12 +3,16 @@ import {
 	addPackage,
 	editPackage,
 	dismissModal,
+	setModalReadOnly,
+	setSelectedPreset,
 	savePackage,
 	updatePackagesField,
 	toggleOuterDimensions,
 	ADD_PACKAGE,
 	EDIT_PACKAGE,
 	DISMISS_MODAL,
+	SET_MODAL_READONLY,
+	SET_SELECTED_PRESET,
 	SAVE_PACKAGE,
 	UPDATE_PACKAGES_FIELD,
 	TOGGLE_OUTER_DIMENSIONS,
@@ -36,6 +40,30 @@ describe( 'Packages state actions', () => {
 	it( '#dismissModal()', () => {
 		expect( dismissModal() ).to.eql( {
 			type: DISMISS_MODAL,
+		} );
+	} );
+
+	it( '#setModalReadOnly()', () => {
+		expect( setModalReadOnly( true ) ).to.eql( {
+			type: SET_MODAL_READONLY,
+			value: true,
+		} );
+
+		expect( setModalReadOnly( false ) ).to.eql( {
+			type: SET_MODAL_READONLY,
+			value: false,
+		} );
+	} );
+
+	it( '#setSelectedPreset()', () => {
+		expect( setSelectedPreset( 'a' ) ).to.eql( {
+			type: SET_SELECTED_PRESET,
+			value: 'a',
+		} );
+
+		expect( setSelectedPreset( 'ab' ) ).to.eql( {
+			type: SET_SELECTED_PRESET,
+			value: 'ab',
 		} );
 	} );
 

--- a/client/state/form/packages/test/reducer.js
+++ b/client/state/form/packages/test/reducer.js
@@ -4,6 +4,8 @@ import {
 	addPackage,
 	editPackage,
 	dismissModal,
+	setModalReadOnly,
+	setSelectedPreset,
 	updatePackagesField,
 	toggleOuterDimensions,
 } from '../actions';
@@ -89,6 +91,44 @@ describe( 'Packages form reducer', () => {
 
 		expect( state ).to.eql( {
 			showModal: false,
+		} );
+	} );
+
+	it( 'SET_MODAL_READONLY', () => {
+		let state = {};
+
+		state = reducer( state, setModalReadOnly( true ) );
+		expect( state ).to.eql( {
+			modalReadOnly: true,
+		} );
+
+		state = reducer( state, setModalReadOnly( true ) );
+		expect( state ).to.eql( {
+			modalReadOnly: true,
+		} );
+
+		state = reducer( state, setModalReadOnly( false ) );
+		expect( state ).to.eql( {
+			modalReadOnly: false,
+		} );
+	} );
+
+	it( 'SET_SELECTED_PRESET', () => {
+		let state = {};
+
+		state = reducer( state, setSelectedPreset( 'a' ) );
+		expect( state ).to.eql( {
+			selectedPreset: 'a',
+		} );
+
+		state = reducer( state, setSelectedPreset( 'aaa' ) );
+		expect( state ).to.eql( {
+			selectedPreset: 'aaa',
+		} );
+
+		state = reducer( state, setSelectedPreset( '1112' ) );
+		expect( state ).to.eql( {
+			selectedPreset: '1112',
 		} );
 	} );
 

--- a/client/state/form/packages/test/reducer.js
+++ b/client/state/form/packages/test/reducer.js
@@ -73,6 +73,7 @@ describe( 'Packages form reducer', () => {
 
 		expect( state ).to.eql( {
 			showModal: true,
+			modalReadOnly: false,
 			mode: 'edit',
 			packageData,
 			showOuterDimensions: false,


### PR DESCRIPTION
Note: This is branched off of #298 .This PR let's you view the differences between them, but actually #300 will be merged into master

This change causes the add-package modal to disable dimension and weight fields when a preset package is used.

Notes:

After a preset package is added to the list of packages, it can be edited like any normal package
To test:

Check this branch out and try switching around the presets in the drop-down when adding a package
See that everything saves correctly, etc.
@allendav @jeffstieler @jkudish
