### PR TITLE
Package name: add href

### DIFF
--- a/client/components/shipping/packages/packages-list-item.js
+++ b/client/components/shipping/packages/packages-list-item.js
@@ -14,7 +14,7 @@ const PackagesListItem = ( {
 			<Gridicon icon={ data.is_letter ? 'mail' : 'flip-horizontal' } size={ 18 } />
 		</div>
 		<div className="package-name">
-			<a onClick={ () => {
+			<a href="#" onClick={ () => {
 				editPackage( Object.assign( {}, data, { index } ) );
 			} }>
 				{ data.name }


### PR DESCRIPTION
Fixes: https://github.com/Automattic/woocommerce-connect-client/issues/308 and partially: https://github.com/Automattic/woocommerce-connect-client/issues/310

Adding an href to the package name link so it gets all the special link properties that it deserves.

Before:
![](https://cloud.githubusercontent.com/assets/1595739/15087194/708c9e32-139b-11e6-9302-8b9e68de70ed.png)

After:
![href](https://cloud.githubusercontent.com/assets/5835847/15090048/ddfc1866-13d3-11e6-9e10-d2c771e74ec0.gif)