### PR TITLE
Foldable card chevron: add focus style

### DIFF
--- a/assets/stylesheets/components/foldable-card/style.scss
+++ b/assets/stylesheets/components/foldable-card/style.scss
@@ -130,7 +130,8 @@ button.foldable-card__action {
 		fill: $gray;
 	}
 
-	&:hover .gridicon {
+	&:hover .gridicon,
+	&:focus .gridicon {
 		fill: $blue-medium;
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/Automattic/woocommerce-connect-client/issues/309

Adds focus style on the chevron:

![focus](https://cloud.githubusercontent.com/assets/5835847/15090162/1aee3aa6-13d9-11e6-9376-c40ab88932c7.gif)

Accessibility ftw 