### PR TITLE
Add/basic client side validation

### DIFF
--- a/client/components/text-field/index.js
+++ b/client/components/text-field/index.js
@@ -3,10 +3,25 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormInputValidation from 'components/forms/form-input-validation';
+import { isFieldError } from 'lib/utils/error';
 import { sanitize } from 'dompurify';
 
-const TextField = ( { id, schema, value, placeholder, updateValue } ) => {
+const renderFieldDescription = ( description ) => {
+	return (
+		<FormSettingExplanation dangerouslySetInnerHTML={ { __html: sanitize( description, { ADD_ATTR: ['target'] } ) } } />
+	);
+};
+
+const renderFieldError = ( validationHint ) => {
+	return (
+		<FormInputValidation isError text={ validationHint } />
+	);
+}
+
+const TextField = ( { id, schema, value, placeholder, updateValue, validationHint, required } ) => {
 	const handleChangeEvent = event => updateValue( event.target.value );
+	const isError = isFieldError( required, schema, value );
 
 	return (
 		<FormFieldset>
@@ -16,8 +31,10 @@ const TextField = ( { id, schema, value, placeholder, updateValue } ) => {
 				name={ id }
 				placeholder={ placeholder }
 				value={ value }
-				onChange={ handleChangeEvent } />
-			<FormSettingExplanation dangerouslySetInnerHTML={ { __html: sanitize( schema.description, { ADD_ATTR: ['target'] } ) } } />
+				onChange={ handleChangeEvent }
+				isError={ isError }
+			/>
+			{ isError && validationHint ? renderFieldError( validationHint ) : renderFieldDescription( schema.description ) }
 		</FormFieldset>
 	);
 };

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -61,6 +61,8 @@ const SettingsItem = ( { form, layout, schema, settings, settingsActions, storeO
 					value={ settings[id] }
 					placeholder={ layout.placeholder }
 					updateValue={ updateValue }
+					validationHint={ layout.validation_hint }
+					required={ -1 !== schema.required.indexOf( id ) }
 				/>
 			);
 	}

--- a/client/lib/utils/error.js
+++ b/client/lib/utils/error.js
@@ -1,0 +1,14 @@
+export const isFieldError = ( required, schema, value ) => {
+	if ( required && ! value ) {
+		return true;
+	}
+
+	if ( schema.pattern ) {
+		const pattern = new RegExp( schema.pattern );
+		if ( ! pattern.test( value ) ) {
+			return true;
+		}
+	}
+
+	return false;
+};

--- a/client/lib/utils/test/error.js
+++ b/client/lib/utils/test/error.js
@@ -1,0 +1,114 @@
+import { expect } from 'chai';
+import {
+	isFieldError,
+} from '../error';
+
+describe( 'Error utils', () => {
+	it( '#isFieldError(): required, no pattern, empty value', () => {
+		const required = true;
+		const schema = {
+			pattern: '',
+		};
+		const value = '';
+
+		const isError = isFieldError( required, schema, value );
+
+		expect( isError ).to.be.true;
+	} );
+
+	it( '#isFieldError(): required, no pattern, not empty value', () => {
+		const required = true;
+		const schema = {
+			pattern: '',
+		};
+		const value = '1234';
+
+		const isError = isFieldError( required, schema, value );
+
+		expect( isError ).to.be.false;
+	} );
+
+	it( '#isFieldError(): required, pattern, empty value', () => {
+		const required = true;
+		const schema = {
+			pattern: /^1234/,
+		};
+		const value = '';
+
+		const isError = isFieldError( required, schema, value );
+
+		expect( isError ).to.be.true;
+	} );
+
+	it( '#isFieldError(): not required, no pattern, empty value', () => {
+		const required = false;
+		const schema = {
+			pattern: '',
+		};
+		const value = '';
+
+		const isError = isFieldError( required, schema, value );
+
+		expect( isError ).to.be.false;
+	} );
+
+	it( '#isFieldError(): not required, pattern, empty value', () => {
+		const required = false;
+		const schema = {
+			pattern: /^1234/,
+		};
+		const value = '';
+
+		const isError = isFieldError( required, schema, value );
+
+		expect( isError ).to.be.true;
+	} );
+
+	it( '#isFieldError(): not required, pattern, expected value', () => {
+		const required = false;
+		const schema = {
+			pattern: /^1234/,
+		};
+		const value = '1234';
+
+		const isError = isFieldError( required, schema, value );
+
+		expect( isError ).to.be.false;
+	} );
+
+	it( '#isFieldError(): not required, pattern, not expected value', () => {
+		const required = false;
+		const schema = {
+			pattern: /^1234/,
+		};
+		const value = '1235';
+
+		const isError = isFieldError( required, schema, value );
+
+		expect( isError ).to.be.true;
+	} );
+
+	it( '#isFieldError(): required, pattern, expected value', () => {
+		const required = true;
+		const schema = {
+			pattern: /^1234/,
+		};
+		const value = '1234';
+
+		const isError = isFieldError( required, schema, value );
+
+		expect( isError ).to.be.false;
+	} );
+
+	it( '#isFieldError(): required, pattern, not expected value', () => {
+		const required = true;
+		const schema = {
+			pattern: /^1234/,
+		};
+		const value = '1235';
+
+		const isError = isFieldError( required, schema, value );
+
+		expect( isError ).to.be.true;
+	} );
+} );


### PR DESCRIPTION
This the beginning of supporting client-side validation. More to come, but I thought I'd start small to make reviewing and testing easier :)

This adds client side validation for text fields, specifically `Title` and `Origin` (since Account doesn't have any validation rules). It also adds a re-usable, and testable `isError` utility that we'll be able to re-use for other field types.

To test:

* You'll need to communicate with a server that is patched with PR 262 from the server
* Make sure to set `WOOCOMMERCE_CONNECT_SERVER_URL` accordingly
* Checkout this branch
* You may need to set `WOOCOMMERCE_CONNECT_FREQUENT_FETCH` or otherwise force a fetch
* Visit the settings page for a USPS instance
* Modify the title. Verify that the validation hint is displayed if you leave the title blank, but not otherwise
* Modify the origin. Verify that the validation hint is displayed if you leave the zip code blank or if you enter an invalid (not 5 digits or 5+4) zip code, but not otherwise.

![image](https://cloud.githubusercontent.com/assets/260253/15128243/89b4c834-15ef-11e6-89db-a60fab2d32c3.png)


Note: Further improvements to come so that we don't display the validation error right away (e.g. it's annoying to see it pop up while you type) but I wanted to get something basic working before I got too far down a rabbit hole.

cc @jeffstieler @allendav @nabsul
