### PR TITLE
PreventDefault so that the click doesn't cause a scroll up on the page

### DIFF
--- a/client/components/shipping/packages/packages-list-item.js
+++ b/client/components/shipping/packages/packages-list-item.js
@@ -14,7 +14,8 @@ const PackagesListItem = ( {
 			<Gridicon icon={ data.is_letter ? 'mail' : 'flip-horizontal' } size={ 18 } />
 		</div>
 		<div className="package-name">
-			<a href="#" onClick={ () => {
+			<a href="#" onClick={ ( event ) => {
+				event.preventDefault();
 				editPackage( Object.assign( {}, data, { index } ) );
 			} }>
 				{ data.name }


### PR DESCRIPTION
To test: Try editing an existing package. Before the fix it should scroll up, after it should not.

@kellychoffman @jkudish @allendav @jeffstieler 