### PR TITLE
Add/service settings save tracks integration

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -138,6 +138,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
 			// On success, save the settings to the database and exit
 			update_option( $this->get_service_settings_key( $id, $instance ), $settings );
+			do_action( 'wc_connect_saved_service_settings', $id, $instance, $settings );
 
 			return true;
 		}

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -17,6 +17,7 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 
 		public function __construct( WC_Connect_Logger $logger ) {
 			$this->logger = $logger;
+			add_action( 'wc_connect_saved_service_settings', array( $this, 'saved_service_settings' ), 10, 3 );
 		}
 
 		public function opted_in() {
@@ -25,6 +26,11 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 
 		public function opted_out() {
 			return $this->record_user_event( 'opted_out' );
+		}
+
+		public function saved_service_settings( $id ) {
+			$this->record_user_event( 'saved_service_settings' );
+			$this->record_user_event( 'saved_' . $id . '_settings' );
 		}
 
 		public function record_user_event( $event_type, $data = array() ) {

--- a/tests/php/test_woocommerce-connect-tracks.php
+++ b/tests/php/test_woocommerce-connect-tracks.php
@@ -113,4 +113,22 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		$this->assertArrayHasKey( 'wp_version', $record[2] );
 	}
 
+	public function test_saved_service_settings() {
+
+		$this->logger->expects( $this->exactly(2) )
+			->method( 'log' )
+			->withConsecutive(
+				array(
+					$this->stringContains( 'woocommerceconnect_saved_service_settings' ),
+					$this->anything(),
+				),
+				array(
+					$this->stringContains( 'woocommerceconnect_saved_usps_settings' ),
+					$this->anything(),
+				)
+			);
+
+		$this->tracks->saved_service_settings( 'usps' );
+	}
+
 }

--- a/tests/php/test_woocommerce-connect-tracks.php
+++ b/tests/php/test_woocommerce-connect-tracks.php
@@ -115,18 +115,38 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 
 	public function test_saved_service_settings() {
 
-		$this->logger->expects( $this->exactly(2) )
-			->method( 'log' )
-			->withConsecutive(
-				array(
+		// `withConsecutive` was introduced in phpunit 4.1 which only supports
+		// php 5.3.3 and higher. So we have a slightly different set of expectations
+		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
+		// rather then the less precise for all versions
+		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
+			$this->logger->expects( $this->exactly(2) )
+				->method( 'log' )
+				->withConsecutive(
+					array(
+						$this->stringContains( 'woocommerceconnect_saved_service_settings' ),
+						$this->anything(),
+					),
+					array(
+						$this->stringContains( 'woocommerceconnect_saved_usps_settings' ),
+						$this->anything(),
+					)
+				);
+		} else {
+			$this->logger->expects( $this->at(0) )
+				->method( 'log' )
+				->with(
 					$this->stringContains( 'woocommerceconnect_saved_service_settings' ),
-					$this->anything(),
-				),
-				array(
+					$this->anything()
+				);
+
+			$this->logger->expects( $this->at(1) )
+				->method( 'log' )
+				->with(
 					$this->stringContains( 'woocommerceconnect_saved_usps_settings' ),
-					$this->anything(),
-				)
-			);
+					$this->anything()
+				);
+		}
 
 		$this->tracks->saved_service_settings( 'usps' );
 	}


### PR DESCRIPTION
This PR seeks to:

* Add an action hook for when service settings are saved
* Add tracks integration with said hook
* Bump a general tracks event for the save action and a specific event for the service
* Adds a test for the above

To test:

* You'll need a site that is actually connected via Jetpack, no fakes (but localhost works as long as it was once connected)
* Checkout this branch
* Run phpunit tests -- make sure they pass
* Go into the settings of an existing or new USPS shipping method instance, and save its settings.
* Verify that the following is added to your debug file: `Tracked the following event: woocommerceconnect_saved_service_settings` and `Tracked the following event: woocommerceconnect_saved_usps_settings`
* Wait approximately 5 minutes (enjoy a good cup of coffee!) -- there is an expected lag before the events are added to Tracks
* Visit the Tracks live event page (ping me if you need help finding it)
* Type in `woocommerceconnect_saved_service_settings` and/or `woocommerceconnect_saved_usps_settings into the Event Name box
* Ensure events with your username were recorded appropriately (if they haven't shown up yet it could be a delay in the Tracks queue, try again in a few minutes)

See #295