### PR TITLE
Packages: Clean up ui

### DIFF
--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -10,13 +10,14 @@
         width: 10%;
         @include breakpoint( '<660px' ) {
             width: 12%;
-    }
+        }
 
-    .gridicon {
-        border-radius: 50%;
-        background-color: $gray;
-        fill: white;
-        padding: 4px;
+        .gridicon {
+            border-radius: 50%;
+            background-color: lighten( $gray, 10% );
+            fill: white;
+            padding: 4px;
+            margin-bottom: -4px;
         }
     }
 
@@ -99,7 +100,7 @@
     }
 
     &:focus {
-        box-shadow: 0 0 0 1px $blue-medium,0 0 2px 1px rgba(30,140,190,.8); 
+        box-shadow: 0 0 0 1px $blue-medium,0 0 2px 1px rgba(30,140,190,.8);
     }
 }
 

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -114,7 +114,7 @@
     }
 
     &:focus {
-        box-shadow: 0 0 0 1px $blue-medium,0 0 2px 1px rgba(30,140,190,.8);
+        box-shadow: 0 0 0 1px $blue-medium, 0 0 2px 1px rgba( $blue-medium, 0.8 );
     }
 }
 

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -97,6 +97,10 @@
     &:hover {
         color: $alert-red;
     }
+
+    &:focus {
+        box-shadow: 0 0 0 1px $blue-medium,0 0 2px 1px rgba(30,140,190,.8); 
+    }
 }
 
 .add-package-button-field .button {

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -39,6 +39,7 @@
 
     .package-dimensions {
         width: 34%;
+        cursor: default;
         @include breakpoint( '<660px' ) {
             width: 37%;
         }

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -1,5 +1,9 @@
 .wcc-shipping-packages-list {
 
+    div {
+        box-sizing: border-box;
+    }
+
     &.form-fieldset {
         margin-bottom: 12px;
         padding-bottom: 8px;
@@ -9,7 +13,7 @@
     .package-type {
         width: 10%;
         @include breakpoint( '<660px' ) {
-            width: 12%;
+            width: 11%;
         }
 
         .gridicon {
@@ -22,19 +26,24 @@
     }
 
     .package-name {
-        width: 55%;
+        width: 51%;
+        padding-right: 8px;
         @include breakpoint( '<660px' ) {
-            width: 43%;
+            width: 44%;
+        }
+
+        &.form-legend {
+            padding-right: 0;
         }
     }
 
     .package-dimensions {
-        width: 30%;
+        width: 34%;
         @include breakpoint( '<660px' ) {
-            width: 40%;
+            width: 37%;
         }
         &.form-legend {
-            width: 35%;
+            width: 39%;
             @include breakpoint( '<660px' ) {
                 width: 45%;
             }
@@ -43,6 +52,10 @@
 
     .package-actions {
         width: 5%;
+        text-align: right;
+        @include breakpoint( '<660px' ) {
+            width: 8%;
+        }
     }
 }
 


### PR DESCRIPTION
Clean up the packages UI. Fixes the rest of https://github.com/Automattic/woocommerce-connect-client/issues/310 ( I don't want to wait for Calypso and I think we should add an outline here)

Before:

<img width="543" alt="screen shot 2016-05-10 at 11 10 35 am" src="https://cloud.githubusercontent.com/assets/5835847/15157146/7f57423c-16a7-11e6-816b-700de112e8b7.png">

After:

<img width="401" alt="screen shot 2016-05-10 at 11 52 43 am" src="https://cloud.githubusercontent.com/assets/5835847/15157147/7f5ab944-16a7-11e6-84f2-ddd6b9751d8c.png">
<img width="533" alt="screen shot 2016-05-10 at 12 00 12 pm" src="https://cloud.githubusercontent.com/assets/5835847/15157148/7f61eb92-16a7-11e6-86a5-c0e87a5c6099.png">

- Lots of alignment tweaks, including small screen
- Allows for up to 3 decimal point dimensions without breaking on to another line (large screen view)
- Changes to package type icon: alignment, color, stylesheet cleanup
- Correct cursor type
- Focus outline for removing a package