### PR TITLE
Add tracks integration for shipping method actions

### DIFF
--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -17,6 +17,9 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 
 		public function __construct( WC_Connect_Logger $logger ) {
 			$this->logger = $logger;
+			add_action( 'wc_connect_shipping_zone_method_added', array( $this, 'shipping_zone_method_added' ), 10, 3 );
+			add_action( 'wc_connect_shipping_zone_method_deleted', array( $this, 'shipping_zone_method_deleted' ), 10, 3 );
+			add_action( 'wc_connect_shipping_zone_method_status_toggled', array( $this, 'shipping_zone_method_status_toggled' ), 10, 4 );
 			add_action( 'wc_connect_saved_service_settings', array( $this, 'saved_service_settings' ), 10, 3 );
 		}
 
@@ -28,9 +31,29 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 			return $this->record_user_event( 'opted_out' );
 		}
 
-		public function saved_service_settings( $id ) {
+		public function shipping_zone_method_added( $instance_id, $service_id ) {
+			$this->record_user_event( 'shipping_zone_method_added' );
+			$this->record_user_event( 'shipping_zone_' . $service_id . '_added' );
+		}
+
+		public function shipping_zone_method_deleted( $instance_id, $service_id ) {
+			$this->record_user_event( 'shipping_zone_method_deleted' );
+			$this->record_user_event( 'shipping_zone_' . $service_id . '_deleted' );
+		}
+
+		public function shipping_zone_method_status_toggled( $instance_id, $service_id, $zone_id, $enabled ) {
+			if ( $enabled ) {
+				$this->record_user_event( 'shipping_zone_method_enabled' );
+				$this->record_user_event( 'shipping_zone_' . $service_id . '_enabled' );
+			} else {
+				$this->record_user_event( 'shipping_zone_method_disabled' );
+				$this->record_user_event( 'shipping_zone_' . $service_id . '_disabled' );
+			}
+		}
+
+		public function saved_service_settings( $service_id ) {
 			$this->record_user_event( 'saved_service_settings' );
-			$this->record_user_event( 'saved_' . $id . '_settings' );
+			$this->record_user_event( 'saved_' . $service_id . '_settings' );
 		}
 
 		public function record_user_event( $event_type, $data = array() ) {

--- a/tests/php/test_class-wc-connect-shipping-method.php
+++ b/tests/php/test_class-wc-connect-shipping-method.php
@@ -2,6 +2,10 @@
 
 class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 
+	static function setUpBeforeClass()	{
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-shipping-method.php' );
+	}
+
 	public function is_valid_package_destination_provider() {
 
 		return array(
@@ -87,9 +91,6 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 	 */
 	public function test_is_valid_package_destination( $package, $expected ) {
 
-		$loader = new WC_Connect_Loader();
-		$loader->load_dependencies();
-
 		$shipping_method = $this->getMockBuilder( 'WC_Connect_Shipping_Method' )
 			->disableOriginalConstructor()
 			->setMethods( null )
@@ -103,9 +104,6 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 	 * @covers WC_Connect_Shipping_Method::calculate_shipping
 	 */
 	public function test_invalid_destination_calculate_shipping() {
-
-		$loader = new WC_Connect_Loader();
-		$loader->load_dependencies();
 
 		$shipping_method = $this->getMockBuilder( 'WC_Connect_Shipping_Method' )
 			->disableOriginalConstructor()
@@ -131,9 +129,6 @@ class WP_Test_WC_Connect_Shipping_Method extends WP_UnitTestCase {
 	 * @covers WC_Connect_Shipping_Method::calculate_shipping
 	 */
 	public function test_invalid_service_settings_calculate_shipping() {
-
-		$loader = new WC_Connect_Loader();
-		$loader->load_dependencies();
 
 		$shipping_method = $this->getMockBuilder( 'WC_Connect_Shipping_Method' )
 			->setConstructorArgs( array( 1 ) )

--- a/tests/php/test_woocommerce-connect-client.php
+++ b/tests/php/test_woocommerce-connect-client.php
@@ -179,4 +179,38 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 
 	}
 
+	/**
+	 * @covers WC_Connect_Loader::is_wc_connect_shipping_service
+	 */
+	public function test_is_wc_connect_shipping_service() {
+
+		$service_data = array(
+			'test_method_that_is_from_wc_connect'
+		);
+
+		$store = $this->getMockBuilder( 'WC_Connect_Service_Schemas_Store' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'get_all_service_ids_of_type' ) )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'get_all_service_ids_of_type' )
+			->will( $this->returnValue( $service_data ) );
+
+		$loader = $this->getMockBuilder( 'WC_Connect_Loader' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'get_service_schemas_store' ) )
+			->getMock();
+
+		$loader->expects( $this->any() )
+			->method( 'get_service_schemas_store' )
+			->will( $this->returnValue( $store ) );
+
+		$loader->load_dependencies();
+
+		$this->assertTrue( $loader->is_wc_connect_shipping_service( 'test_method_that_is_from_wc_connect' ) );
+		$this->assertFalse( $loader->is_wc_connect_shipping_service( 'test_method_that_is_not_from_wc_connect' ) );
+
+	}
+
 }

--- a/tests/php/test_woocommerce-connect-client.php
+++ b/tests/php/test_woocommerce-connect-client.php
@@ -5,9 +5,79 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	const SERVICE_SCRIPT_HANDLE = 'wc_connect_admin';
 
 	public function tearDown() {
-
 		wp_deregister_script( self::SERVICE_SCRIPT_HANDLE );
+		remove_all_actions( 'wc_connect_shipping_zone_method_added' );
+		remove_all_actions( 'wc_connect_shipping_zone_method_deleted' );
+		remove_all_actions( 'wc_connect_shipping_zone_method_status_toggled' );
+		remove_all_actions( 'wc_connect_saved_service_settings' );
+	}
 
+	protected function mockLoader( $store = false, $api_client = false, $logger = false, $tracks = false ) {
+		if ( ! $store ) {
+			$store = $this->getMockBuilder( 'WC_Connect_Service_Schemas_Store' )
+				->disableOriginalConstructor()
+				->setMethods( null )
+				->getMock();
+		}
+
+		$loader = $this->getMockBuilder( 'WC_Connect_Loader' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'get_service_schemas_store', 'get_api_client', 'get_logger' ) )
+			->getMock();
+
+		$loader->expects( $this->any() )
+			->method( 'get_service_schemas_store' )
+			->will( $this->returnValue( $store ) );
+
+		if ( ! $api_client ) {
+			$api_client = $this->getMockBuilder( 'WC_Connect_API_Client' )
+				->disableOriginalConstructor()
+				->getMock();
+		}
+
+		$loader->expects( $this->any() )
+			->method( 'get_api_client' )
+			->will( $this->returnValue( $api_client ) );
+
+		if ( ! $logger ) {
+			$logger = $this->getMockBuilder( 'WC_Connect_Logger' )
+				->disableOriginalConstructor()
+				->getMock();
+		}
+
+		$loader->expects( $this->any() )
+			->method( 'get_logger' )
+			->will( $this->returnValue( $logger ) );
+
+		if ( ! $tracks ) {
+			$tracks = $this->getMockBuilder( 'WC_Connect_Tracks' )
+				->disableOriginalConstructor()
+				->getMock();
+		}
+
+		$loader->expects( $this->any() )
+			->method( 'get_tracks' )
+			->will( $this->returnValue( $tracks ) );
+
+		return $loader;
+	}
+
+	public function mockLoaderAndActiveShippingMethods() {
+		$service_data = array(
+			'test_method_that_is_from_wc_connect'
+		);
+
+		$store = $this->getMockBuilder( 'WC_Connect_Service_Schemas_Store' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'get_all_service_ids_of_type' ) )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'get_all_service_ids_of_type' )
+			->will( $this->returnValue( $service_data ) );
+
+
+		return $this->mockLoader( $store );
 	}
 
 	public function test_class_exists() {
@@ -21,7 +91,10 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	 */
 	public function test_init_hook_attached_in_constructor() {
 
-		$loader   = new WC_Connect_Loader();
+		$loader = $this->getMockBuilder( 'WC_Connect_Loader' )
+			->setMethods( array( 'init' ) )
+			->getMock();
+
 		$attached = has_action( 'woocommerce_init', array( $loader, 'init' ) );
 
 		$this->assertNotFalse( $attached, 'WC_Connect_Loader::init() not attached to `woocommerce_init`.' );
@@ -45,7 +118,7 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	 */
 	public function test_enqueue_service_script( $hook, $tab, $instance_id, $expected ) {
 
-		$loader = new WC_Connect_Loader();
+		$loader = $this->mockLoader();
 
 		$loader->enqueue_service_script( $hook, $tab, $instance_id );
 
@@ -59,8 +132,7 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	 */
 	public function test_logger_getter_setter() {
 
-		$loader = new WC_Connect_Loader();
-		$loader->load_dependencies();
+		$loader = $this->mockLoader();
 
 		$logger = $this->getMockBuilder( 'WC_Connect_Logger' )
 			->disableOriginalConstructor()
@@ -77,12 +149,11 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	 */
 	public function test_api_client_getter_setter() {
 
-		$loader = new WC_Connect_Loader();
-		$loader->load_dependencies();
-
 		$client = $this->getMockBuilder( 'WC_Connect_API_Client' )
 			->disableOriginalConstructor()
 			->getMock();
+		$loader = $this->mockLoader( false, $client );
+
 		$loader->set_api_client( $client );
 
 		$this->assertEquals( $client, $loader->get_api_client() );
@@ -95,12 +166,12 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	 */
 	public function test_services_store_getter_setter() {
 
-		$loader = new WC_Connect_Loader();
-		$loader->load_dependencies();
-
 		$store = $this->getMockBuilder( 'WC_Connect_Service_Schemas_Store' )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$loader = $this->mockLoader( $store );
+
 		$loader->set_service_schemas_store( $store );
 
 		$this->assertEquals( $store, $loader->get_service_schemas_store() );
@@ -113,8 +184,7 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	 */
 	public function test_services_validator_getter_setter() {
 
-		$loader = new WC_Connect_Loader();
-		$loader->load_dependencies();
+		$loader = $this->mockLoader();
 
 		$validator = $this->getMockBuilder( 'WC_Connect_Service_Schemas_Validator' )
 			->disableOriginalConstructor()
@@ -130,14 +200,14 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	 */
 	public function test_load_dependencies() {
 
-		$loader = new WC_Connect_Loader();
+		$loader = $this->mockLoader();
 		$loader->load_dependencies();
 
 		$this->assertInstanceOf( 'WC_Connect_Logger', $loader->get_logger() );
 		$this->assertInstanceOf( 'WC_Connect_API_Client', $loader->get_api_client() );
 		$this->assertInstanceOf( 'WC_Connect_Service_Schemas_Validator', $loader->get_service_schemas_validator() );
 		$this->assertInstanceOf( 'WC_Connect_Service_Schemas_Store', $loader->get_service_schemas_store() );
-
+		$this->assertInstanceOf( 'WC_Connect_Tracks', $loader->get_tracks() );
 	}
 
 	/**
@@ -158,16 +228,7 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 			->method( 'get_service_schema_by_id_or_instance_id' )
 			->will( $this->returnValue( $service_data ) );
 
-		$loader = $this->getMockBuilder( 'WC_Connect_Loader' )
-			->disableOriginalConstructor()
-			->setMethods( array( 'get_service_schemas_store' ) )
-			->getMock();
-
-		$loader->expects( $this->any() )
-			->method( 'get_service_schemas_store' )
-			->will( $this->returnValue( $store ) );
-
-		$loader->load_dependencies();
+		$loader = $this->mockLoader( $store );
 
 		$method = new WC_Connect_Shipping_Method();
 
@@ -183,34 +244,26 @@ class WP_Test_WC_Connect_Loader extends WC_Unit_Test_Case {
 	 * @covers WC_Connect_Loader::is_wc_connect_shipping_service
 	 */
 	public function test_is_wc_connect_shipping_service() {
-
-		$service_data = array(
-			'test_method_that_is_from_wc_connect'
-		);
-
-		$store = $this->getMockBuilder( 'WC_Connect_Service_Schemas_Store' )
-			->disableOriginalConstructor()
-			->setMethods( array( 'get_all_service_ids_of_type' ) )
-			->getMock();
-
-		$store->expects( $this->any() )
-			->method( 'get_all_service_ids_of_type' )
-			->will( $this->returnValue( $service_data ) );
-
-		$loader = $this->getMockBuilder( 'WC_Connect_Loader' )
-			->disableOriginalConstructor()
-			->setMethods( array( 'get_service_schemas_store' ) )
-			->getMock();
-
-		$loader->expects( $this->any() )
-			->method( 'get_service_schemas_store' )
-			->will( $this->returnValue( $store ) );
-
-		$loader->load_dependencies();
+		$loader = $this->mockLoaderAndActiveShippingMethods();
 
 		$this->assertTrue( $loader->is_wc_connect_shipping_service( 'test_method_that_is_from_wc_connect' ) );
 		$this->assertFalse( $loader->is_wc_connect_shipping_service( 'test_method_that_is_not_from_wc_connect' ) );
 
+	}
+
+	/**
+	 * @covers WC_Connect_Loader::shipping_zone_method_added
+	 */
+	public function test_shipping_zone_method_added() {
+		$loader = $this->mockLoaderAndActiveShippingMethods();
+
+		$this->assertEquals( 0, did_action( 'wc_connect_shipping_zone_method_added' ) );
+		$loader->shipping_zone_method_added( 3, 'test_method_that_is_from_wc_connect', 2 );
+		$this->assertEquals( 1, did_action( 'wc_connect_shipping_zone_method_added' ) );
+		$loader->shipping_zone_method_added( 3, 'test_method_that_is_not_from_wc_connect', 2 );
+		$this->assertEquals( 1, did_action( 'wc_connect_shipping_zone_method_added' ) );
+		$loader->shipping_zone_method_added( 3, 'test_method_that_is_from_wc_connect', 2 );
+		$this->assertEquals( 2, did_action( 'wc_connect_shipping_zone_method_added' ) );
 	}
 
 }

--- a/tests/php/test_woocommerce-connect-tracks.php
+++ b/tests/php/test_woocommerce-connect-tracks.php
@@ -5,8 +5,7 @@ abstract class WP_Test_WC_Connect_Tracks extends WC_Unit_Test_Case {
 	protected $logger;
 
 	public static function setupBeforeClass() {
-		$loader = new WC_Connect_Loader();
-		$loader->load_dependencies();
+		require_once( dirname( __FILE__ ) . '/../../classes/class-wc-connect-tracks.php' );
 	}
 
 	public function setUp() {
@@ -149,6 +148,158 @@ class WP_Test_WC_Connect_Tracks_With_Jetpack extends WP_Test_WC_Connect_Tracks {
 		}
 
 		$this->tracks->saved_service_settings( 'usps' );
+	}
+
+	public function test_shipping_zone_method_added() {
+
+		// `withConsecutive` was introduced in phpunit 4.1 which only supports
+		// php 5.3.3 and higher. So we have a slightly different set of expectations
+		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
+		// rather then the less precise for all versions
+		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
+			$this->logger->expects( $this->exactly(2) )
+				->method( 'log' )
+				->withConsecutive(
+					array(
+						$this->stringContains( 'woocommerceconnect_shipping_zone_method_added' ),
+						$this->anything(),
+					),
+					array(
+						$this->stringContains( 'woocommerceconnect_shipping_zone_usps_added' ),
+						$this->anything(),
+					)
+				);
+		} else {
+			$this->logger->expects( $this->at(0) )
+				->method( 'log' )
+				->with(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_method_added' ),
+					$this->anything()
+				);
+
+			$this->logger->expects( $this->at(1) )
+				->method( 'log' )
+				->with(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_added' ),
+					$this->anything()
+				);
+		}
+
+		do_action( 'wc_connect_shipping_zone_method_added', 2, 'usps', 3 );
+	}
+
+	public function test_shipping_zone_method_deleted() {
+
+		// `withConsecutive` was introduced in phpunit 4.1 which only supports
+		// php 5.3.3 and higher. So we have a slightly different set of expectations
+		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
+		// rather then the less precise for all versions
+		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
+			$this->logger->expects( $this->exactly(2) )
+				->method( 'log' )
+				->withConsecutive(
+					array(
+						$this->stringContains( 'woocommerceconnect_shipping_zone_method_deleted' ),
+						$this->anything(),
+					),
+					array(
+						$this->stringContains( 'woocommerceconnect_shipping_zone_canada_post_deleted' ),
+						$this->anything(),
+					)
+				);
+		} else {
+			$this->logger->expects( $this->at(0) )
+				->method( 'log' )
+				->with(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_method_deleted' ),
+					$this->anything()
+				);
+
+			$this->logger->expects( $this->at(1) )
+				->method( 'log' )
+				->with(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_canada_post_deleted' ),
+					$this->anything()
+				);
+		}
+
+		do_action( 'wc_connect_shipping_zone_method_deleted', 2, 'canada_post', 3 );
+	}
+
+	public function test_shipping_zone_method_enabled() {
+
+		// `withConsecutive` was introduced in phpunit 4.1 which only supports
+		// php 5.3.3 and higher. So we have a slightly different set of expectations
+		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
+		// rather then the less precise for all versions
+		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
+			$this->logger->expects( $this->exactly(2) )
+				->method( 'log' )
+				->withConsecutive(
+					array(
+						$this->stringContains( 'woocommerceconnect_shipping_zone_method_enabled' ),
+						$this->anything(),
+					),
+					array(
+						$this->stringContains( 'woocommerceconnect_shipping_zone_usps_enabled' ),
+						$this->anything(),
+					)
+				);
+		} else {
+			$this->logger->expects( $this->at(0) )
+				->method( 'log' )
+				->with(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_method_enabled' ),
+					$this->anything()
+				);
+
+			$this->logger->expects( $this->at(1) )
+				->method( 'log' )
+				->with(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_enabled' ),
+					$this->anything()
+				);
+		}
+
+		do_action( 'wc_connect_shipping_zone_method_status_toggled', 2, 'usps', 3, true );
+	}
+
+	public function test_shipping_zone_method_disabled() {
+
+		// `withConsecutive` was introduced in phpunit 4.1 which only supports
+		// php 5.3.3 and higher. So we have a slightly different set of expectations
+		// for php 5.2. It's preferrable to have this more precise expectations for php 5.3+
+		// rather then the less precise for all versions
+		if ( class_exists( 'PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters' ) ) {
+			$this->logger->expects( $this->exactly(2) )
+				->method( 'log' )
+				->withConsecutive(
+					array(
+						$this->stringContains( 'woocommerceconnect_shipping_zone_method_disabled' ),
+						$this->anything(),
+					),
+					array(
+						$this->stringContains( 'woocommerceconnect_shipping_zone_usps_disabled' ),
+						$this->anything(),
+					)
+				);
+		} else {
+			$this->logger->expects( $this->at(0) )
+				->method( 'log' )
+				->with(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_method_disabled' ),
+					$this->anything()
+				);
+
+			$this->logger->expects( $this->at(1) )
+				->method( 'log' )
+				->with(
+					$this->stringContains( 'woocommerceconnect_shipping_zone_usps_disabled' ),
+					$this->anything()
+				);
+		}
+
+		do_action( 'wc_connect_shipping_zone_method_status_toggled', 2, 'usps', 3, false );
 	}
 
 }

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -464,6 +464,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			return $this->get_active_shipping_services();
 		}
 
+		public function is_wc_connect_shipping_service( $service_id ) {
+			$shipping_service_ids = $this->get_service_schemas_store()->get_all_service_ids_of_type( 'shipping' );
+			return in_array( $service_id, $shipping_service_ids );
+		}
+
 	}
 
 	if ( ! defined( 'WC_UNIT_TESTING' ) ) {

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -174,7 +174,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		 * Load all plugin dependencies.
 		 */
 		public function load_dependencies() {
-
 			require_once( plugin_basename( 'classes/class-wc-connect-logger.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-api-client.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-service-schemas-validator.php' ) );
@@ -229,6 +228,9 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				add_action( 'wc_connect_service_init', array( $this, 'init_service' ), 10, 2 );
 				add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
 				add_action( 'wc_connect_service_admin_options', array( $this, 'localize_and_enqueue_service_script' ), 10, 2 );
+				add_action( 'woocommerce_shipping_zone_method_added', array( $this, 'shipping_zone_method_added' ), 10, 3 );
+				add_action( 'woocommerce_shipping_zone_method_deleted', array( $this, 'shipping_zone_method_deleted' ), 10, 3 );
+				add_action( 'woocommerce_shipping_zone_method_status_toggled', array( $this, 'shipping_zone_method_status_toggled' ), 10, 4 );
 			}
 
 			add_action( 'wc_connect_fetch_service_schemas', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
@@ -467,6 +469,24 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		public function is_wc_connect_shipping_service( $service_id ) {
 			$shipping_service_ids = $this->get_service_schemas_store()->get_all_service_ids_of_type( 'shipping' );
 			return in_array( $service_id, $shipping_service_ids );
+		}
+
+		public function shipping_zone_method_added( $instance_id, $service_id, $zone_id ) {
+			if ( $this->is_wc_connect_shipping_service( $service_id ) ) {
+				do_action( 'wc_connect_shipping_zone_method_added', $instance_id, $service_id, $zone_id );
+			}
+		}
+
+		public function shipping_zone_method_deleted( $instance_id, $service_id, $zone_id ) {
+			if ( $this->is_wc_connect_shipping_service( $service_id ) ) {
+				do_action( 'wc_connect_shipping_zone_method_deleted', $instance_id, $service_id, $zone_id );
+			}
+		}
+
+		public function shipping_zone_method_status_toggled( $instance_id, $service_id, $zone_id, $enabled ) {
+			if ( $this->is_wc_connect_shipping_service( $service_id ) ) {
+				do_action( 'wc_connect_shipping_zone_method_status_toggled', $instance_id, $service_id, $zone_id, $enabled );
+			}
 		}
 
 	}


### PR DESCRIPTION
This PR seeks to:

* Add a function to check if a given shipping method (via it's `method_id`) is a WCC method
* Add hooks into WooCommerce's hooks for shipping method actions
(added/deleted/enabled/disabled -- see https://github.com/woothemes/woocommerce/pull/10891) and check if the shipping method the action occured on is a WCC method. If so, it then triggers another hook
that is WCC specific.
* Add tracks integration for shipping method actions (added/deleted/enabled/disabled) based on the hooks described above)
* Add several new tests and introduce some php testing improvements, specifically, this revises some test suite files to restrict their loading of WCC files, which serves multiple purposes:

1) speed things up (30s down to under 5s per test run)
2) avoid unexpected test side effects from running things that shouldn't run
3) allow the new tests added to work without creating inaccurate log messages about stat bumps

---

To test:

* You'll need a site that is actually connected via Jetpack, no fakes (but localhost works as long as it was once connected)
* Checkout latest WooCommerce master (https://github.com/woothemes/woocommerce/pull/10891 which was merged in today needs to be in it)
* Checkout this branch
* Run phpunit tests -- ensure they pass
* Go to the Shipping Zone settings page
* Add a Shipping Zone if you don't already have one
* Add USPS to that zone
* Verify that the following is added to your debug file: `Tracked the following event: woocommerceconnect_shipping_zone_method_added` and `Tracked the following event: woocommerceconnect_shipping_usps_zone_method_added`
* Disable USPS for that zone, and click `Save shipping methods`

![image](https://cloud.githubusercontent.com/assets/260253/15164931/fda437d4-16c6-11e6-842b-3a27655ed143.png)

* Verify that the following is added to your debug file: `Tracked the following event: woocommerceconnect_shipping_zone_method_disabled` and `Tracked the following event: woocommerceconnect_shipping_usps_zone_method_disabled`
* Re-enable USPS for that zone, and click `Save shipping methods`
* Verify that the following is added to your debug file: `Tracked the following event: woocommerceconnect_shipping_zone_method_enabled` and `Tracked the following event: woocommerceconnect_shipping_usps_zone_method_enabled`
* Delete USPS from that zone, and click `Save shipping methods`
* Verify that the following is added to your debug file: `Tracked the following event: woocommerceconnect_shipping_zone_method_deleted` and `Tracked the following event: woocommerceconnect_shipping_usps_zone_method_deleted`
* Wait approximately 5 minutes (enjoy a good cup of coffee!) -- there is an expected lag before the events are added to Tracks
* Visit the Tracks live event page (ping me if you need help finding it)
* Type in your Jetpack-connected WP.com username into the username box
* Ensure the above events were recorded appropriately (if they haven't shown up yet it could be a delay in the Tracks queue, try again in a few minutes)

---
@allendav @jeffstieler @nabsul Please review

Fixes #295