### PR TITLE
Check that schema.required exists before using it

### DIFF
--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -62,7 +62,7 @@ const SettingsItem = ( { form, layout, schema, settings, settingsActions, storeO
 					placeholder={ layout.placeholder }
 					updateValue={ updateValue }
 					validationHint={ layout.validation_hint }
-					required={ -1 !== schema.required.indexOf( id ) }
+					required={ schema.required && -1 !== schema.required.indexOf( id ) }
 				/>
 			);
 	}


### PR DESCRIPTION
This fixes #327 

To test: 
* make sure that required fields (title/origin) continue to show a validation error if left empty. 
* ensure no regressions are introduced

cc @allendav 