### PR TITLE
Make description optional for TextFields

### DIFF
--- a/client/components/text-field/index.js
+++ b/client/components/text-field/index.js
@@ -9,7 +9,7 @@ import { sanitize } from 'dompurify';
 
 const renderFieldDescription = ( description ) => {
 	return (
-		<FormSettingExplanation dangerouslySetInnerHTML={ { __html: sanitize( description, { ADD_ATTR: ['target'] } ) } } />
+		description ? <FormSettingExplanation dangerouslySetInnerHTML={ { __html: sanitize( description, { ADD_ATTR: ['target'] } ) } } /> : null
 	);
 };
 
@@ -44,7 +44,7 @@ TextField.propTypes = {
 	schema: PropTypes.shape( {
 		type: PropTypes.string.valueOf( 'string' ),
 		title: PropTypes.string.isRequired,
-		description: PropTypes.string.isRequired,
+		description: PropTypes.string,
 		default: PropTypes.string,
 	} ).isRequired,
 	value: PropTypes.string.isRequired,


### PR DESCRIPTION
Fixes #328 

To test:
* Hack a local server to remove a description, e.g. /lib/shipping/usps/service-settings.js service_settings.properties.title.description
* Refresh the client, receiving the new schema
* Ensure the TextField renders (albeit without a description now)