### PR TITLE
Fix/334 render div by default

### DIFF
--- a/client/components/wcc-settings-form/settings-group.js
+++ b/client/components/wcc-settings-form/settings-group.js
@@ -14,14 +14,14 @@ const SettingsGroup = ( { group, schema, storeOptions, settings, form, formActio
 				<CompactCard className="settings-group-card">
 					<FormSectionHeading className="settings-group-header">{ group.title }</FormSectionHeading>
 					<div className="settings-group-content">
-						{ group.items.map( item => (
+						{ group.items ? group.items.map( item => (
 							<SettingsItem
 								key={ item.key ? item.key : item }
 								layout={ item }
 								schema={ schema }
 								storeOptions={ storeOptions }
 							/>
-						) ) }
+						) ) : null }
 					</div>
 				</CompactCard>
 			);
@@ -43,13 +43,19 @@ const SettingsGroup = ( { group, schema, storeOptions, settings, form, formActio
 					/>
 				</CompactCard>
 			);
+
+		default:
+			return (
+				<div>
+				</div>
+			)
 	}
 };
 
 SettingsGroup.propTypes = {
 	group: PropTypes.shape( {
 		title: PropTypes.string,
-		items: PropTypes.array.isRequired,
+		items: PropTypes.array,
 	} ),
 	schema: PropTypes.object.isRequired,
 	storeOptions: PropTypes.object.isRequired,

--- a/client/components/wcc-settings-form/settings-group.js
+++ b/client/components/wcc-settings-form/settings-group.js
@@ -7,6 +7,19 @@ import * as FormActions from 'state/form/actions';
 import { bindActionCreators } from 'redux';
 import SaveForm from 'components/save-form';
 
+const renderGroupItems = ( items, schema, storeOptions ) => {
+	return (
+		items.map( item => (
+			<SettingsItem
+				key={ item.key ? item.key : item }
+				layout={ item }
+				schema={ schema }
+				storeOptions={ storeOptions }
+			/>
+		) )
+	);
+};
+
 const SettingsGroup = ( { group, schema, storeOptions, settings, form, formActions, saveFormData } ) => {
 	switch ( group.type ) {
 		case 'fieldset':
@@ -14,14 +27,7 @@ const SettingsGroup = ( { group, schema, storeOptions, settings, form, formActio
 				<CompactCard className="settings-group-card">
 					<FormSectionHeading className="settings-group-header">{ group.title }</FormSectionHeading>
 					<div className="settings-group-content">
-						{ group.items ? group.items.map( item => (
-							<SettingsItem
-								key={ item.key ? item.key : item }
-								layout={ item }
-								schema={ schema }
-								storeOptions={ storeOptions }
-							/>
-						) ) : null }
+						{ group.items ? renderGroupItems( group.items, schema, storeOptions ) : null }
 					</div>
 				</CompactCard>
 			);
@@ -46,7 +52,8 @@ const SettingsGroup = ( { group, schema, storeOptions, settings, form, formActio
 
 		default:
 			return (
-				<div>
+				<div className="settings-group-default">
+					{ group.items ? renderGroupItems( group.items, schema, storeOptions ) : null }
 				</div>
 			)
 	}


### PR DESCRIPTION
Fixes #334 

This PR seeks to make it less likely that a unrecognized type in form layout will cause all rendering of the form to break.

To test:
Hack a local server to remove the type from a fieldset, e.g. /lib/shipping/usps/service-settings.js form_layout[0].type
Refresh the client, receiving the new schema
Ensure the remainder of the form renders
