### PR TITLE
Clear event hook on plugin de-activation

### DIFF
--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -86,7 +86,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		static function plugin_deactivation() {
 			$tracks = self::load_tracks_for_activation_hooks();
 			$tracks->opted_out();
-
+			wp_clear_scheduled_hook( 'wc_connect_fetch_service_schemas' );
 		}
 
 		public function __construct() {


### PR DESCRIPTION
This PR ensures that our daily event is cleared when the WC Connect plugin is de-activated. Fixes #337

To test:

* Easiest to do this with a site where you can access `wp-cli`
* Checkout this branch
* Make sure WC Connect is activated and `WOOCOMMERCE_CONNECT_FREQUENT_FETCH` is NOT set
* Run `wp cron event list`, and verify that `wc_connect_fetch_service_schemas` is in the list of future events
* De-activate WC Connect
* Run `wp cron event list`, and verify that `wc_connect_fetch_service_schemas` is no longer in the list of future events
* Re-activate WC Connect
* Run `wp cron event list`, and verify that `wc_connect_fetch_service_schemas` is once again in the list of future events

cc @allendav @nabsul @jeffstieler 