### PR TITLE
Timestamp setting updates

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -189,8 +189,9 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				'wc_version' => WC()->version,
 				'weight_unit' => strtolower( get_option( 'woocommerce_weight_unit' ) ),
 				'wp_version' => get_bloginfo( 'version' ),
-				'last_services_update' => get_option( 'wc_connect_services_last_update' ),
-				'last_heartbeat' => get_option( 'wc_connect_last_heartbeat' ),
+				'last_services_update' => get_option( 'wc_connect_services_last_update', 0 ),
+				'last_heartbeat' => get_option( 'wc_connect_last_heartbeat', 0 ),
+				'last_rate_request' => get_option( 'wc_connect_last_rate_request', 0 ),
 				'active_services' => $this->wc_connect_loader->get_active_services(),
 			) );
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -298,6 +298,16 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 					$this->add_rate( $rate_to_add );
 				}
 			}
+
+			$this->update_last_rate_request_timestamp();
+		}
+
+		public function update_last_rate_request_timestamp() {
+			$previous_timestamp = get_option( 'wc_connect_last_rate_request' );
+			if ( false === $previous_timestamp ||
+				( time() - HOUR_IN_SECONDS ) > $previous_timestamp ) {
+				update_option( 'wc_connect_last_rate_request', time() );
+			}
 		}
 
 		public function admin_options() {


### PR DESCRIPTION
* Add a new last_rate_request timestamp bumped whenever there's a shipping rate request (at most once an hour though to prevent too many writes)
* Send `0` as the fallback timestamp instead of `false`

Can only be merged after https://github.com/Automattic/woocommerce-connect-server/pull/266 is merged. See that PR for testing instructions

Fixes https://github.com/Automattic/woocommerce-connect-client/issues/216