### PR TITLE
Foldable card description: fix line wrapping

### DIFF
--- a/assets/stylesheets/components/foldable-card/style.scss
+++ b/assets/stylesheets/components/foldable-card/style.scss
@@ -111,6 +111,7 @@ button.foldable-card__action {
 	align-items: center;
 	flex: 1 1;
 	justify-content: flex-end;
+	white-space: nowrap;
 }
 
 .foldable-card__expand {


### PR DESCRIPTION
Quick PR to fix the wrapping issues of the foldable card description on smaller screens. 

Before:

<img width="522" alt="screen shot 2016-05-13 at 3 19 34 pm" src="https://cloud.githubusercontent.com/assets/5835847/15262289/9983d7aa-191e-11e6-88e7-56e65fe74e23.png">

After:

<img width="460" alt="screen shot 2016-05-13 at 3 20 10 pm" src="https://cloud.githubusercontent.com/assets/5835847/15262288/99836b58-191e-11e6-97ff-79b972100b9f.png">

@allendav for review