### PR TITLE
Make package presets optional

### DIFF
--- a/client/components/shipping/packages/add-package-presets.js
+++ b/client/components/shipping/packages/add-package-presets.js
@@ -20,9 +20,9 @@ const defaultPackages = {
 };
 
 const getOptionGroups = ( presets ) => {
-	return [
-		defaultPackages,
-		{
+	const groups = [defaultPackages];
+	if ( presets ) {
+		groups.push( {
 			label: presets.title,
 			options: presets.boxes.map( ( box, idx ) => {
 				return {
@@ -30,8 +30,10 @@ const getOptionGroups = ( presets ) => {
 					label: box.name,
 				};
 			} ),
-		},
-	]
+		} );
+	};
+
+	return groups;
 };
 
 const handleSelectEvent = ( e, selectDefault, selectPreset, setSelectedPreset ) => {
@@ -64,7 +66,7 @@ const AddPackagePresets = ( { selectedPreset, setSelectedPreset, presets, onSele
 AddPackagePresets.propTypes = {
 	selectedPreset: PropTypes.string,
 	setSelectedPreset: PropTypes.func.isRequired,
-	presets: PropTypes.object.isRequired,
+	presets: PropTypes.object,
 	onSelectDefault: PropTypes.func.isRequired,
 	onSelectPreset: PropTypes.func.isRequired,
 };

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -186,7 +186,7 @@ const AddPackageDialog = ( props ) => {
 
 AddPackageDialog.propTypes = {
 	dismissModal: PropTypes.func.isRequired,
-	presets: PropTypes.object.isRequired,
+	presets: PropTypes.object,
 	weightUnit: PropTypes.string.isRequired,
 	mode: PropTypes.string.isRequired,
 	updatePackagesField: PropTypes.func.isRequired,


### PR DESCRIPTION
Not all shipping methods will have preset packages. This change makes it optional.

To test: 
- Edit the server by deleting the preset_boxes from the definitions. 
- Make sure the UI component properly only shows the box and envelope option

@jkudish @allendav @jeffstieler 