### PR TITLE
Add/153 status health section read only

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -163,6 +163,7 @@
 
     // WCC Components
     @import '../../client/components/shipping/packages/style';
+    @import '../../client/components/indicators/style';
     @import '../../client/views/shipping/style';
 
 }

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -2,10 +2,6 @@
 
 if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 
-	define( 'WOOCOMMERCE_CONNECT_MINIMUM_WOOCOMMERCE_VERSION', '2.6' );
-	define( 'WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION', '4.0.2' );
-	define( 'WOOCOMMERCE_CONNECT_MAXIMUM_SCHEMA_AGE_SECONDS', 3 * DAY_IN_SECONDS );
-
 	class WC_Connect_Help_Provider {
 
 		/**
@@ -23,7 +19,8 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 		 */
 		protected $fieldsets;
 
-		public function __construct( WC_Connect_Service_Schemas_Store $service_schemas_store, WC_Connect_Service_Settings_Store $service_settings_store ) {
+		public function __construct( WC_Connect_Service_Schemas_Store $service_schemas_store,
+			WC_Connect_Service_Settings_Store $service_settings_store ) {
 
 			$this->service_schemas_store = $service_schemas_store;
 			$this->service_settings_store = $service_settings_store;
@@ -92,7 +89,7 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 					'checkmark-circle',
 					'indicator-success',
 					sprintf(
-						__( 'WooCommerce %s is working correctly', 'woocommerce' ),
+						__( 'WooCommerce %s is configured correctly', 'woocommerce' ),
 						WC()->version
 					),
 					''
@@ -198,12 +195,20 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 					__( 'Service data was found, but may be out of date', 'woocommerce' ),
 					''
 				);
-			} else if ( $last_fetch_timestamp < time() - WOOCOMMERCE_CONNECT_MAXIMUM_SCHEMA_AGE_SECONDS ) {
+			} else if ( $last_fetch_timestamp < time() - WOOCOMMERCE_CONNECT_SCHEMA_AGE_ERROR_THRESHOLD ) {
+				$health_item = $this->build_indicator(
+					'wcc_indicator',
+					'notice',
+					'indicator-error',
+					__( 'Service data was found, but is more than three days old', 'woocommerce' ),
+					$last_fetch_timestamp_formatted
+				);
+			} else if ( $last_fetch_timestamp < time() - WOOCOMMERCE_CONNECT_SCHEMA_AGE_WARNING_THRESHOLD ) {
 				$health_item = $this->build_indicator(
 					'wcc_indicator',
 					'notice',
 					'indicator-warning',
-					__( 'Service data was found, but is out of date', 'woocommerce' ),
+					__( 'Service data was found, but is more than one day old', 'woocommerce' ),
 					$last_fetch_timestamp_formatted
 				);
 			} else {

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -34,17 +34,72 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 
 		}
 
+		protected function get_indicator_schema() {
+
+			return (object) array(
+				"properties" => (object) array(
+					"id" => (object) array(
+						"type" => "string"
+					),
+					"state" => (object) array(
+						"type" => "string",
+						"default" => "bad"
+					),
+					"state_message" => (object) array(
+						"type" => "string",
+						"default" => "TBD",
+					),
+					"last_updated" => (object) array(
+						"type" => "string",
+						"default" => "Yesterday"
+					)
+				)
+			);
+
+		}
+
+		// TODO - refactor to accept scope as parameter or maybe use filtering?
+		protected function get_woocommerce_health_indicator_ids() {
+			return array(
+				(object) array(
+					"id" => "woocommerce",
+				)
+			);
+		}
+
+		protected function get_woocommerce_health_indicators() {
+			return array(
+				"woocommerce" => (object) array(
+					"id" => "woocommerce",
+					"state" => "purple",
+					"state_message" => "WooCommerce is Good to Go",
+					"last_updated" => "Sometime recently"
+				)
+			);
+		}
+
 		/**
 		 * Returns the form schema object for the entire help page
 		 *
 		 * @return object
 		 */
 		protected function get_form_schema() {
-
-			$form_schema = new stdClass();
-			$form_schema->properties = new stdClass();
-			return $form_schema;
-
+			return (object) array(
+				"type" => "object",
+				"required" => array(),
+				// these definitions enumerate the specific indicator IDs for each
+				"definitions" => (object) array(
+					"woocommerce_health_indicators" => $this->get_woocommerce_health_indicator_ids()
+				),
+				"properties" => (object) array(
+					"woocommerce_health" => (object) array(
+						"title" => "WooCommerce Health",
+						"type" => "object",
+						"definition" => "woocommerce_health_indicators", // this tells the form which definition to select from definitions
+						"items" => $this->get_indicator_schema()
+					)
+				)
+			);
 		}
 
 		/**
@@ -56,9 +111,14 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 
 			return array(
 				(object) array(
-					'title' => _x( 'Health', 'This section displays the overall health of WooCommerce Connect and the things it depends on', 'woocommerce' ),
-					'type' => 'fieldset',
-					'items' => array() // TODO
+					"title" => _x( "Health", "This section displays the overall health of WooCommerce Connect and the things it depends on", "woocommerce" ),
+					"type" => "fieldset",
+					"items" => array(
+						(object) array(
+							"key" => "woocommerce_health",
+							"type" => "indicators",
+						)
+					)
 				),
 				(object) array(
 					'title' => __( 'Services', 'woocommerce' ),
@@ -86,8 +146,10 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 		 */
 		protected function get_form_data() {
 
-			return array(); // TODO
-
+			return array(
+				"woocommerce_health" => $this->get_woocommerce_health_indicators(),
+				"last_name" => "Snook",
+			);
 		}
 
 		/**

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -69,7 +69,8 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 			if ( version_compare( WC()->version, WOOCOMMERCE_CONNECT_MINIMUM_WOOCOMMERCE_VERSION, "<" ) ) {
 				$health_item = $this->build_indicator(
 					'woocommerce_indicator',
-					'red',
+					'notice',
+					'indicator-error',
 					sprintf(
 						__( 'WooCommerce %s or higher is required (You are running %s)', 'woocommerce' ),
 						WOOCOMMERCE_CONNECT_MINIMUM_WOOCOMMERCE_VERSION,
@@ -80,14 +81,16 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 			} else if ( empty( $base_country ) ) {
 				$health_item = $this->build_indicator(
 					'woocommerce_indicator',
-					'red',
+					'notice',
+					'indicator-error',
 					__( 'Please set Base Location in WooCommerce Settings > General' ),
 					''
 				);
 			} else {
 				$health_item = $this->build_indicator(
 					'woocommerce_indicator',
-					'green',
+					'checkmark-circle',
+					'indicator-success',
 					sprintf(
 						__( 'WooCommerce %s is working correctly', 'woocommerce' ),
 						WC()->version
@@ -117,17 +120,19 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 			if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
 				$health_item = $this->build_indicator(
 					'jetpack_indicator',
-					'red',
+					'notice',
+					'indicator-error',
 					sprintf(
 						__( 'Please install and activate the Jetpack plugin, version %s or higher', 'woocommerce' ),
-						$minimum_jp_version
+						WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION
 					),
 					''
 				);
 			} else if ( version_compare( JETPACK__VERSION, WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION, "<" ) ) {
 				$health_item = $this->build_indicator(
 					'jetpack_indicator',
-					'red',
+					'notice',
+					'indicator-error',
 					sprintf(
 						__( 'Jetpack %s or higher is required (You are running %s)', 'woocommerce' ),
 						WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION,
@@ -138,17 +143,16 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 			} else if ( ! $is_connected ) {
 				$health_item = $this->build_indicator(
 					'jetpack_indicator',
-					'red',
-					sprintf(
-						__( 'Please connect Jetpack to WordPress.com', 'woocommerce' ),
-						$minimum_jp_version
-					),
+					'notice',
+					'indicator-error',
+					__( 'Please connect Jetpack to WordPress.com', 'woocommerce' ),
 					''
 				);
 			} else {
 				$health_item = $this->build_indicator(
 					'jetpack_indicator',
-					'green',
+					'checkmark-circle',
+					'indicator-success',
 					sprintf(
 						__( 'Jetpack %s is connected and working correctly', 'woocommerce' ),
 						JETPACK__VERSION
@@ -172,7 +176,7 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 			$last_fetch_timestamp = $this->service_schemas_store->get_last_fetch_timestamp();
 			if ( ! is_null( $last_fetch_timestamp ) ) {
 				$last_fetch_timestamp_formatted = sprintf(
-					_x( 'Schemas last updated %s ago', '%s = human-readable time difference', 'woocommerce' ),
+					_x( 'Last updated %s ago', '%s = human-readable time difference', 'woocommerce' ),
 					human_time_diff( $last_fetch_timestamp )
 				);
 			} else {
@@ -181,36 +185,40 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 			if ( is_null( $schemas ) ) {
 				$health_item = $this->build_indicator(
 					'wcc_indicator',
-					'red',
-					__( 'No service schemas available', 'woocommerce' ),
+					'notice',
+					'indicator-error',
+					__( 'No service data available', 'woocommerce' ),
 					''
 				);
 			} else if ( is_null( $last_fetch_timestamp ) ) {
 				$health_item = $this->build_indicator(
 					'wcc_indicator',
-					'yellow',
-					__( 'Service schemas were found, but they may be out of date', 'woocommerce' ),
+					'notice',
+					'indicator-warning',
+					__( 'Service data was found, but may be out of date', 'woocommerce' ),
 					''
 				);
 			} else if ( $last_fetch_timestamp < time() - WOOCOMMERCE_CONNECT_MAXIMUM_SCHEMA_AGE_SECONDS ) {
 				$health_item = $this->build_indicator(
 					'wcc_indicator',
-					'yellow',
-					__( 'Service schemas were found, but they are out of date', 'woocommerce' ),
+					'notice',
+					'indicator-warning',
+					__( 'Service data was found, but is out of date', 'woocommerce' ),
 					$last_fetch_timestamp_formatted
 				);
 			} else {
 				$health_item = $this->build_indicator(
 					'wcc_indicator',
-					'green',
-					__( 'WooCommerce Connect is connected and working correctly', 'woocommerce' ),
+					'checkmark-circle',
+					'indicator-success',
+					__( 'Service data is up-to-date', 'woocommerce' ),
 					$last_fetch_timestamp_formatted
 				);
 			}
 
 			$health_items[] =	(object) array(
 				'key' => 'wcc_health_items',
-				'title' => __( 'WooCommerce Connect' ),
+				'title' => __( 'WooCommerce Connect Service Data' ),
 				'type' => 'indicators',
 				'items' => array(
 					'wcc_indicator' => $health_item
@@ -241,12 +249,13 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 
 		}
 
-		protected function build_indicator( $id, $state, $state_message, $last_updated ) {
+		protected function build_indicator( $id, $icon, $class, $message, $last_updated ) {
 
 			return (object) array(
 				'id' => $id,
-				'state' => $state,
-				'state_message' => $state_message,
+				'icon' => $icon,
+				'class' => $class,
+				'message' => $message,
 				'last_updated' => $last_updated
 			);
 
@@ -275,17 +284,21 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 					"id" => (object) array(
 						"type" => "string"
 					),
-					"state" => (object) array(
+					"icon" => (object) array(
 						"type" => "string",
-						"default" => "bad"
+						"default" => "notice"
 					),
-					"state_message" => (object) array(
+					"class" => (object) array(
 						"type" => "string",
-						"default" => "TBD",
+						"default" => ""
+					),
+					"message" => (object) array(
+						"type" => "string",
+						"default" => "",
 					),
 					"last_updated" => (object) array(
 						"type" => "string",
-						"default" => "Yesterday"
+						"default" => ""
 					)
 				)
 			);

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -47,6 +47,10 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 			update_option( 'wc_connect_services', $service_schemas );
 		}
 
+		public function get_last_fetch_timestamp() {
+			return get_option( 'wc_connect_services_last_update', null );
+		}
+
 		protected function update_last_fetch_timestamp() {
 			update_option( 'wc_connect_services_last_update', time() );
 		}

--- a/client/components/indicators/index.js
+++ b/client/components/indicators/index.js
@@ -4,7 +4,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import Gridicon from 'components/gridicon';
 
-// TODO - proper markup
 const Indicator = ( { icon, className, message, lastUpdated } ) => {
 	return (
 		<div className={ classNames( 'indicator', className ) }>

--- a/client/components/indicators/index.js
+++ b/client/components/indicators/index.js
@@ -1,14 +1,26 @@
 import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
+import Gridicon from 'components/gridicon';
 
 // TODO - proper markup
-const Indicator = ( { state, stateMessage, lastUpdated } ) => {
+const Indicator = ( { icon, className, message, lastUpdated } ) => {
 	return (
-		<div>
-			<span>{ state }</span>
-			<span>{ stateMessage }</span>
-			<span>{ lastUpdated }</span>
+		<div className={ classNames( 'indicator', className ) }>
+			<div className="indicator-icon-and-message">
+				<div className="indicator-icon">
+					<Gridicon icon={ icon }/>
+				</div>
+				<div className="indicator-message">
+					{ message }
+				</div>
+			</div>
+			{ lastUpdated
+				? <div className="indicator-lastupdated">
+						<span>{ lastUpdated }</span>
+					</div>
+				: null }
 		</div>
 	);
 };
@@ -20,8 +32,9 @@ const Indicators = ( { schema, indicators } ) => {
 			{ indicators.map( indicator => (
 				<Indicator
 					key={ indicator.id }
-					state={ indicator.state }
-					stateMessage={ indicator.state_message }
+					icon={ indicator.icon }
+					className={ indicator.class }
+					message={ indicator.message }
 					lastUpdated={ indicator.last_updated }
 				/>
 			) ) }

--- a/client/components/indicators/index.js
+++ b/client/components/indicators/index.js
@@ -1,0 +1,37 @@
+import React, { PropTypes } from 'react';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLegend from 'components/forms/form-legend';
+
+// TODO - proper markup
+const Indicator = ( { state, stateMessage, lastUpdated } ) => {
+	return (
+		<div>
+			<span>{ state }</span>
+			<span>{ stateMessage }</span>
+			<span>{ lastUpdated }</span>
+		</div>
+	);
+};
+
+const Indicators = ( { schema, indicators } ) => {
+	return (
+		<FormFieldset>
+			<FormLegend>{ schema.title }</FormLegend>
+			{ indicators.map( indicator => (
+				<Indicator
+					key={ indicator.id }
+					state={ indicator.state }
+					stateMessage={ indicator.state_message }
+					lastUpdated={ indicator.last_updated }
+				/>
+			) ) }
+		</FormFieldset>
+	);
+};
+
+Indicators.propTypes = {
+	schema: PropTypes.object.isRequired,
+	indicators: PropTypes.array.isRequired,
+};
+
+export default Indicators;

--- a/client/components/indicators/index.js
+++ b/client/components/indicators/index.js
@@ -7,16 +7,16 @@ import Gridicon from 'components/gridicon';
 const Indicator = ( { icon, className, message, lastUpdated } ) => {
 	return (
 		<div className={ classNames( 'indicator', className ) }>
-			<div className="indicator-icon-and-message">
-				<div className="indicator-icon">
+			<div className="indicator__icon-and-message">
+				<div className="indicator__icon">
 					<Gridicon icon={ icon }/>
 				</div>
-				<div className="indicator-message">
+				<div className="indicator__message">
 					{ message }
 				</div>
 			</div>
 			{ lastUpdated
-				? <div className="indicator-lastupdated">
+				? <div className="form-setting-explanation indicator__last-updated">
 						<span>{ lastUpdated }</span>
 					</div>
 				: null }

--- a/client/components/indicators/style.scss
+++ b/client/components/indicators/style.scss
@@ -1,0 +1,46 @@
+.indicator {
+	margin-top: 5px;
+	margin-bottom: 5px;
+	.indicator-icon-and-message {
+		display: flex;
+		align-items: center;
+		.indicator-icon {
+			padding-right: 5px;
+		}
+		.indicator-message {
+			margin-top: -5px;
+		}
+	}
+	.indicator-lastupdated {
+		color: $gray;
+		font-style: italic;
+		font-weight: 200;
+	}
+}
+
+
+.indicator-success {
+	.indicator-icon-and-message {
+		color: $alert-green;
+		.gridicon {
+			fill: $alert-green;
+		}
+	}
+}
+
+.indicator-warning {
+	.indicator-icon-and-message {
+		color: $alert-yellow;
+		.gridicon {
+			fill: $alert-yellow;
+		}
+	}
+}
+.indicator-error {
+	.indicator-icon-and-message {
+		color: $alert-red;
+		.gridicon {
+			fill: $alert-red;
+		}
+	}
+}

--- a/client/components/indicators/style.scss
+++ b/client/components/indicators/style.scss
@@ -1,46 +1,45 @@
 .indicator {
-	margin-top: 5px;
-	margin-bottom: 5px;
-	.indicator-icon-and-message {
-		display: flex;
-		align-items: center;
-		.indicator-icon {
-			padding-right: 5px;
-		}
-		.indicator-message {
-			margin-top: -5px;
-		}
+	margin-top: 4px;
+	margin-bottom: 4px;
+}
+
+.indicator .indicator__icon-and-message {
+	display: flex;
+	align-items: center;
+
+	.indicator__icon {
+		margin-right: 6px;
 	}
-	.indicator-lastupdated {
-		color: $gray;
-		font-style: italic;
-		font-weight: 200;
+
+	.indicator__message {
+		margin-top: -4px;
 	}
 }
 
+.form-setting-explanation.indicator__last-updated {
+	margin-top: 0;
+}
 
-.indicator-success {
-	.indicator-icon-and-message {
-		color: $alert-green;
-		.gridicon {
-			fill: $alert-green;
-		}
+.indicator-success .indicator__icon-and-message {
+	color: $alert-green;
+
+	.gridicon {
+		fill: $alert-green;
 	}
 }
 
-.indicator-warning {
-	.indicator-icon-and-message {
-		color: $alert-yellow;
-		.gridicon {
-			fill: $alert-yellow;
-		}
+.indicator-warning .indicator__icon-and-message {
+	color: $alert-yellow;
+
+	.gridicon {
+		fill: $alert-yellow;
 	}
 }
-.indicator-error {
-	.indicator-icon-and-message {
-		color: $alert-red;
-		.gridicon {
-			fill: $alert-red;
-		}
+
+.indicator-error .indicator__icon-and-message {
+	color: $alert-red;
+
+	.gridicon {
+		fill: $alert-red;
 	}
 }

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import Indicators from 'components/indicators';
 import TextField from 'components/text-field';
 import RadioButtons from 'components/radio-buttons';
 import ShippingServiceGroups from 'components/shipping/services';
@@ -50,6 +51,15 @@ const SettingsItem = ( { form, layout, schema, settings, settingsActions, storeO
 					removePackage={ removeArrayItem }
 					savePackage={ savePackage }
 					weightUnit={ storeOptions.weight_unit }
+				/>
+			);
+
+		case 'indicators':
+			return (
+				<Indicators
+					layout={ layout }
+					schema={ schema.properties[id] }
+					indicators={ Object.values( settings[id] ) }
 				/>
 			);
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "babel-plugin-add-module-exports": "^0.1.3",
     "babel-polyfill": "^6.7.4",
     "chai": "3.5.0",
+    "classnames": "1.1.1",
     "colors": "^1.1.2",
     "confirm-simple": "^1.0.3",
     "cross-env": "^1.0.7",

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -190,7 +190,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$schemas_store  = new WC_Connect_Service_Schemas_Store( $api_client, $logger );
 			$settings_store = new WC_Connect_Service_Settings_Store( $schemas_store, $api_client, $logger );
 			$tracks         = new WC_Connect_Tracks( $logger );
-			$help_provider  = new WC_Connect_Help_Provider( $settings_store );
+			$help_provider  = new WC_Connect_Help_Provider( $schemas_store, $settings_store );
 
 			$this->set_logger( $logger );
 			$this->set_api_client( $api_client );

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -29,6 +29,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
+	define( 'WOOCOMMERCE_CONNECT_MINIMUM_WOOCOMMERCE_VERSION', '2.6' );
+	define( 'WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION', '3.9' );
+	define( 'WOOCOMMERCE_CONNECT_SCHEMA_AGE_WARNING_THRESHOLD', DAY_IN_SECONDS );
+	define( 'WOOCOMMERCE_CONNECT_SCHEMA_AGE_ERROR_THRESHOLD', 3 * DAY_IN_SECONDS );
+
 	class WC_Connect_Loader {
 
 		/**


### PR DESCRIPTION
Ready for review. Ref #153 - adds read only health section

To test:
* Ensure the status page Health section renders, including WooCommerce, Jetpack and WooCommerce Connect sections at wp-admin > WooCommerce > System Status > WooCommerce Connect
* Ensure the Javascript Dev Console is error/warning free
* Deactivate Jetpack. Go to the status page again. Verify it barks at you about Jetpack.
* Reactivate Jetpack. Go to the status page again. Verify it no longer barks at you about Jetpack.

* Tweak the WOOCOMMERCE_CONNECT_MINIMUM_WOOCOMMERCE_VERSION constant at the top of the file to a higher number.
* Refresh the status page. Verify it barks at you about WooCommerce's version.
* Put the constant back to 2.6
* Refresh the status page. Verify it no longer barks at you about WooCommerce's version.

* Tweak the WOOCOMMERCE_CONNECT_MINIMUM_JETPACK_VERSION constant at the top of the file to a higher number.
* Refresh the status page. Verify it barks at you about Jetpack's version.
* Put the constant back to 4.0.2
* Refresh the status page. Verify it no longer barks at you about Jetpack's version.

* Change the WOOCOMMERCE_CONNECT_MAXIMUM_SCHEMA_AGE_SECONDS constant at the top of the file to 1.
* Refresh the status page. Verify it barks at you about the schemas' age.
* Put the constant back to 3 * DAY_IN_SECONDS
* Refresh the status page. Verify it no longer barks at you about the schema's age.

Note: When WCC becomes part of WC, the WC version check won't really make sense any more, so we will probably remove that then. For now, as a feature plugin, it does make sense to keep it.