### PR TITLE
Add global notices

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -53,7 +53,7 @@
 //@import 'components/forms/range/style';
 @import 'components/forms/sortable-list/index';
 //@import 'components/gauge/style';
-//@import 'components/global-notices/style';
+@import 'components/global-notices/style';
 //@import 'components/gravatar/style';
 @import 'components/gridicon/style';
 //@import 'components/happiness-support/style';

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -139,6 +139,17 @@
         font-size: 13px;
     }
 
+    // Global notices
+    // adjust until system fonts get in wp-admin
+    .global-notices .notice__text,
+    .wcc-modal .global-notices .notice__text {
+        padding: 10px 8px 8px;
+
+        @include breakpoint( '<660px' ) {
+            padding: 16px;
+        }
+    }
+
     // Custom styles
     max-width: 700px;
 

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -143,9 +143,23 @@
     }
 
     // Global notices
+
+    .global-notices .notice,
+    .global-notices .notice {
+        margin-left: 164px;
+        max-width: 1040px;
+        
+        @include breakpoint( '<960px' ) {
+            margin-left: 36px;
+        }
+        @include breakpoint( '<780px' ) {
+            margin-left: 0;
+        }
+    }
+
     // adjust until system fonts get in wp-admin
     .global-notices .notice__text,
-    .wcc-modal .global-notices .notice__text {
+    .global-notices .notice__text {
         padding: 10px 8px 8px;
 
         @include breakpoint( '<660px' ) {

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -31,6 +31,9 @@
     // Components
     @import 'components';
 
+    // Breakpoints
+    $breakpoints: 480px, 660px, 780px, 960px, 1040px; // adds wp-admin specific breakpoints
+
     // Buttons
     .button {
         background: $gray-light;

--- a/client/components/save-form/index.js
+++ b/client/components/save-form/index.js
@@ -1,33 +1,11 @@
 import React, { PropTypes } from 'react';
-import Notice from 'components/notice';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import { translate as __ } from 'lib/mixins/i18n';
 
-const renderFormNotices = ( success, error, dismissSuccess ) => {
-	if ( error ) {
-		return (
-			<Notice status="is-error" text={ error } showDismiss={ false } />
-		);
-	}
-	if ( success ) {
-		return (
-			<Notice
-				className="wcc-form-success"
-				status="is-success"
-				text={ __( 'Your changes have been saved.' ) }
-				showDismiss={ false }
-				onDismissClick={ dismissSuccess }
-				duration={ 2250 }
-			/>
-		);
-	}
-};
-
-const SaveForm = ( { saveForm, isSaving, success, error, dismissSuccess } ) => {
+const SaveForm = ( { saveForm, isSaving } ) => {
 	return (
 		<FormButtonsBar>
-			{ renderFormNotices( success, error, dismissSuccess ) }
 			<FormButton type="button" onClick={ saveForm }>
 				{ isSaving ? __( 'Saving...' ) : __( 'Save changes' ) }
 			</FormButton>
@@ -38,9 +16,6 @@ const SaveForm = ( { saveForm, isSaving, success, error, dismissSuccess } ) => {
 SaveForm.propTypes = {
 	saveForm: PropTypes.func.isRequired,
 	isSaving: PropTypes.bool,
-	success: PropTypes.bool,
-	error: PropTypes.string,
-	dismissSuccess: PropTypes.func.isRequired,
 };
 
 export default SaveForm;

--- a/client/components/wcc-settings-form/index.js
+++ b/client/components/wcc-settings-form/index.js
@@ -1,9 +1,12 @@
 import React, { PropTypes } from 'react';
 import WCCSettingsGroup from './settings-group';
+import notices from 'notices';
+import GlobalNotices from 'components/global-notices';
 
 const WCCSettingsForm = ( { storeOptions, schema, layout, saveFormData } ) => {
 	return (
 		<div>
+			<GlobalNotices id="notices" notices={ notices.list } />
 			{ layout.map( ( group, idx ) => (
 				<WCCSettingsGroup
 					key={ idx }

--- a/client/components/wcc-settings-form/settings-group.js
+++ b/client/components/wcc-settings-form/settings-group.js
@@ -6,6 +6,9 @@ import { connect } from 'react-redux';
 import * as FormActions from 'state/form/actions';
 import { bindActionCreators } from 'redux';
 import SaveForm from 'components/save-form';
+import { translate as __ } from 'lib/mixins/i18n';
+import { successNotice, errorNotice } from 'state/notices/actions';
+import isString from 'lodash/isString';
 
 const renderGroupItems = ( items, schema, storeOptions ) => {
 	return (
@@ -20,7 +23,7 @@ const renderGroupItems = ( items, schema, storeOptions ) => {
 	);
 };
 
-const SettingsGroup = ( { group, schema, storeOptions, settings, form, formActions, saveFormData } ) => {
+const SettingsGroup = ( { group, schema, storeOptions, settings, form, formActions, noticeActions, saveFormData } ) => {
 	switch ( group.type ) {
 		case 'fieldset':
 			return (
@@ -34,8 +37,18 @@ const SettingsGroup = ( { group, schema, storeOptions, settings, form, formActio
 
 		case 'actions':
 			const setIsSaving = ( value ) => formActions.setField( 'isSaving', value );
-			const setSuccess = ( value ) => formActions.setField( 'success', value );
-			const setError = ( value ) => formActions.setField( 'error', value );
+			const setSuccess = ( value ) => {
+				formActions.setField( 'success', value );
+				if ( true === value ) {
+					noticeActions.successNotice( __( 'Your changes have been saved.' ) );
+				}
+			};
+			const setError = ( value ) => {
+				formActions.setField( 'error', value );
+				if ( isString( value ) ) {
+					noticeActions.errorNotice( __( value ) );
+				}
+			}
 			const dismissSuccess = () => formActions.setField( 'success', false );
 			const saveForm = () => saveFormData( setIsSaving, setSuccess, setError, settings );
 			return (
@@ -43,8 +56,6 @@ const SettingsGroup = ( { group, schema, storeOptions, settings, form, formActio
 					<SaveForm
 						saveForm={ saveForm }
 						isSaving={ form.isSaving }
-						success={ form.success }
-						error={ form.error }
 						dismissSuccess={ dismissSuccess }
 					/>
 				</CompactCard>
@@ -70,6 +81,7 @@ SettingsGroup.propTypes = {
 	settings: PropTypes.object.isRequired,
 	form: PropTypes.object.isRequired,
 	formActions: PropTypes.object.isRequired,
+	noticeActions: PropTypes.object.isRequired,
 };
 
 function mapStateToProps( state ) {
@@ -82,6 +94,7 @@ function mapStateToProps( state ) {
 function mapDispatchToProps( dispatch ) {
 	return {
 		formActions: bindActionCreators( FormActions, dispatch ),
+		noticeActions: bindActionCreators( { successNotice, errorNotice }, dispatch ),
 	};
 }
 

--- a/client/components/wcc-settings-form/settings-group.js
+++ b/client/components/wcc-settings-form/settings-group.js
@@ -40,23 +40,23 @@ const SettingsGroup = ( { group, schema, storeOptions, settings, form, formActio
 			const setSuccess = ( value ) => {
 				formActions.setField( 'success', value );
 				if ( true === value ) {
-					noticeActions.successNotice( __( 'Your changes have been saved.' ) );
+					noticeActions.successNotice( __( 'Your changes have been saved.' ), {
+						duration: 2250,
+					} );
 				}
 			};
 			const setError = ( value ) => {
 				formActions.setField( 'error', value );
 				if ( isString( value ) ) {
-					noticeActions.errorNotice( __( value ) );
+					noticeActions.errorNotice( value );
 				}
 			}
-			const dismissSuccess = () => formActions.setField( 'success', false );
 			const saveForm = () => saveFormData( setIsSaving, setSuccess, setError, settings );
 			return (
 				<CompactCard className="save-button-bar">
 					<SaveForm
 						saveForm={ saveForm }
 						isSaving={ form.isSaving }
-						dismissSuccess={ dismissSuccess }
 					/>
 				</CompactCard>
 			);

--- a/client/components/wcc-settings-form/settings-group.js
+++ b/client/components/wcc-settings-form/settings-group.js
@@ -48,7 +48,9 @@ const SettingsGroup = ( { group, schema, storeOptions, settings, form, formActio
 			const setError = ( value ) => {
 				formActions.setField( 'error', value );
 				if ( isString( value ) ) {
-					noticeActions.errorNotice( value );
+					noticeActions.errorNotice( value, {
+						duration: 7000,
+					} );
 				}
 			}
 			const saveForm = () => saveFormData( setIsSaving, setSuccess, setError, settings );

--- a/client/lib/calypso-boot/index.js
+++ b/client/lib/calypso-boot/index.js
@@ -1,0 +1,17 @@
+import ReactInjection from 'react/lib/ReactInjection';
+import i18n from '../mixins/i18n';
+
+export default function boot() {
+	// Initialize i18n
+	let i18nLocaleStringsObject = {};
+
+	if ( window.i18nLocaleStrings ) {
+		i18nLocaleStringsObject = window.i18nLocaleStrings;
+	}
+
+	i18n.initialize( i18nLocaleStringsObject );
+
+	ReactInjection.Class.injectMixin( i18n.mixin );
+}
+
+boot();

--- a/client/lib/mixins/i18n/index.js
+++ b/client/lib/mixins/i18n/index.js
@@ -11,7 +11,12 @@ const translate = ( text ) => {
 	return ( text in translations ) ? translations[text] : text;
 };
 
+const mixin = {
+	translate,
+};
+
 export default {
 	initialize,
 	translate,
+	mixin,
 };

--- a/client/main.js
+++ b/client/main.js
@@ -6,7 +6,7 @@ import configureStore from 'state';
 import '../assets/stylesheets/style.scss';
 import initializeState from './lib/initialize-state';
 import saveForm from './lib/save-form';
-import i18n from './lib/mixins/i18n';
+import './lib/calypso-boot';
 
 const {
 	formData,
@@ -16,15 +16,6 @@ const {
 	callbackURL,
 	nonce,
 } = wcConnectData;
-
-// Initialize i18n
-let i18nLocaleStringsObject = {};
-
-if ( window.i18nLocaleStrings ) {
-	i18nLocaleStringsObject = window.i18nLocaleStrings;
-}
-
-i18n.initialize( i18nLocaleStringsObject );
 
 const saveFormData = ( isSaving, setSuccess, setError, data ) => saveForm( isSaving, setSuccess, setError, callbackURL, nonce, data );
 

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -2,9 +2,13 @@ import { createStore, combineReducers } from 'redux';
 import settings from './settings/reducer';
 import form from './form/reducer';
 
+// from calypso
+import notices from 'state/notices/reducer';
+
 const rootReducer = combineReducers( {
 	settings,
 	form,
+	notices,
 } );
 
 const configureStore = ( initialState ) => {
@@ -19,6 +23,7 @@ const configureStore = ( initialState ) => {
 			const nextRootReducer = combineReducers( {
 				settings: require( './settings/reducer' ),
 				form: require( './form/reducer' ),
+				notices: require( 'state/notices/reducer' ),
 			} );
 			store.replaceReducer( nextRootReducer );
 		} );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -45,11 +45,6 @@
       "from": "alphanum-sort@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
     },
-    "alter": {
-      "version": "0.2.0",
-      "from": "alter@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz"
-    },
     "amdefine": {
       "version": "1.0.0",
       "from": "amdefine@>=0.0.4"
@@ -80,6 +75,22 @@
     "anymatch": {
       "version": "1.3.0",
       "from": "anymatch@>=1.3.0 <2.0.0"
+    },
+    "archiver-utils": {
+      "version": "1.2.0",
+      "from": "archiver-utils@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.2.0.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "7.0.3",
+          "from": "glob@>=7.0.0 <8.0.0"
+        },
+        "lodash": {
+          "version": "4.12.0",
+          "from": "lodash@>=4.8.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz"
+        }
+      }
     },
     "are-we-there-yet": {
       "version": "1.1.2",
@@ -150,16 +161,6 @@
       "version": "1.0.1",
       "from": "assertion-error@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz"
-    },
-    "ast-traverse": {
-      "version": "0.1.1",
-      "from": "ast-traverse@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
-    },
-    "ast-types": {
-      "version": "0.8.2",
-      "from": "ast-types@0.8.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.2.tgz"
     },
     "async": {
       "version": "1.5.2",
@@ -338,77 +339,6 @@
       "version": "6.7.2",
       "from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.7.2.tgz"
-    },
-    "babel-plugin-constant-folding": {
-      "version": "1.0.1",
-      "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
-    },
-    "babel-plugin-dead-code-elimination": {
-      "version": "1.0.2",
-      "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
-    },
-    "babel-plugin-eval": {
-      "version": "1.0.1",
-      "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
-    },
-    "babel-plugin-inline-environment-variables": {
-      "version": "1.0.1",
-      "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
-    },
-    "babel-plugin-jscript": {
-      "version": "1.0.4",
-      "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
-    },
-    "babel-plugin-member-expression-literals": {
-      "version": "1.0.1",
-      "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
-    },
-    "babel-plugin-property-literals": {
-      "version": "1.0.1",
-      "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
-    },
-    "babel-plugin-proto-to-assign": {
-      "version": "1.0.4",
-      "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.9.3 <4.0.0"
-        }
-      }
-    },
-    "babel-plugin-react-constant-elements": {
-      "version": "1.0.3",
-      "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
-    },
-    "babel-plugin-react-display-name": {
-      "version": "1.0.3",
-      "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
-    },
-    "babel-plugin-remove-console": {
-      "version": "1.0.1",
-      "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
-    },
-    "babel-plugin-remove-debugger": {
-      "version": "1.0.1",
-      "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
-    },
-    "babel-plugin-runtime": {
-      "version": "1.0.7",
-      "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.5.0",
@@ -627,16 +557,6 @@
       "from": "babel-plugin-transform-strict-mode@>=6.6.5 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.6.5.tgz"
     },
-    "babel-plugin-undeclared-variables-check": {
-      "version": "1.0.2",
-      "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz"
-    },
-    "babel-plugin-undefined-to-void": {
-      "version": "1.1.6",
-      "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
-    },
     "babel-preset-es2015": {
       "version": "6.6.0",
       "from": "babel-preset-es2015@>=6.6.0 <7.0.0",
@@ -661,6 +581,11 @@
       "version": "6.5.0",
       "from": "babel-preset-stage-3@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.5.0.tgz"
+    },
+    "babel-regenerator-runtime": {
+      "version": "6.5.0",
+      "from": "babel-regenerator-runtime@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-regenerator-runtime/-/babel-regenerator-runtime-6.5.0.tgz"
     },
     "babel-register": {
       "version": "6.7.2",
@@ -761,11 +686,6 @@
       "version": "0.0.8",
       "from": "block-stream@*"
     },
-    "bluebird": {
-      "version": "2.10.2",
-      "from": "bluebird@>=2.9.33 <3.0.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
-    },
     "boom": {
       "version": "2.10.1",
       "from": "boom@>=2.0.0 <3.0.0"
@@ -779,11 +699,6 @@
       "from": "braces@>=1.8.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz"
     },
-    "breakable": {
-      "version": "1.0.0",
-      "from": "breakable@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
-    },
     "browserify-zlib": {
       "version": "0.1.4",
       "from": "browserify-zlib@>=0.1.4 <0.2.0"
@@ -795,6 +710,11 @@
     "buffer": {
       "version": "3.6.0",
       "from": "buffer@>=3.0.3 <4.0.0"
+    },
+    "buffer-crc32": {
+      "version": "0.2.5",
+      "from": "buffer-crc32@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -867,15 +787,10 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.4",
-      "from": "classnames@>=2.1.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.4.tgz"
-    },
     "clean-css": {
-      "version": "3.4.12",
+      "version": "3.4.13",
       "from": "clean-css@>=3.3.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.13.tgz",
       "dependencies": {
         "commander": {
           "version": "2.8.1",
@@ -970,6 +885,11 @@
       "from": "colors@>=1.1.2 <1.2.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
     },
+    "colors-mini": {
+      "version": "1.0.2",
+      "from": "colors-mini@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/colors-mini/-/colors-mini-1.0.2.tgz"
+    },
     "combined-stream": {
       "version": "1.0.5",
       "from": "combined-stream@>=1.0.5 <1.1.0"
@@ -979,10 +899,20 @@
       "from": "commander@>=2.9.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
     },
-    "commoner": {
-      "version": "0.10.4",
-      "from": "commoner@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz"
+    "component-classes": {
+      "version": "1.2.6",
+      "from": "component-classes@1.2.6",
+      "resolved": "https://registry.npmjs.org/component-classes/-/component-classes-1.2.6.tgz"
+    },
+    "component-indexof": {
+      "version": "0.0.3",
+      "from": "component-indexof@0.0.3",
+      "resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz"
+    },
+    "compress-commons": {
+      "version": "1.0.0",
+      "from": "compress-commons@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.0.0.tgz"
     },
     "compressible": {
       "version": "2.0.7",
@@ -1000,17 +930,7 @@
     },
     "concat-stream": {
       "version": "1.5.1",
-      "from": "concat-stream@>=1.4.6 <2.0.0",
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "from": "inherits@>=2.0.1 <2.1.0"
-        }
-      }
-    },
-    "config-chain": {
-      "version": "1.1.10",
-      "from": "config-chain@>=1.1.8 <1.2.0"
+      "from": "concat-stream@>=1.4.6 <2.0.0"
     },
     "connect-history-api-fallback": {
       "version": "1.1.0",
@@ -1067,6 +987,11 @@
     "core-util-is": {
       "version": "1.0.2",
       "from": "core-util-is@>=1.0.0 <1.1.0"
+    },
+    "crc32-stream": {
+      "version": "1.0.0",
+      "from": "crc32-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.0.tgz"
     },
     "cross-spawn-async": {
       "version": "2.0.0",
@@ -1161,38 +1086,6 @@
       "version": "1.0.0",
       "from": "defined@>=1.0.0 <2.0.0"
     },
-    "defs": {
-      "version": "1.1.1",
-      "from": "defs@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "from": "camelcase@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "from": "cliui@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
-        },
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-        },
-        "yargs": {
-          "version": "3.27.0",
-          "from": "yargs@>=3.27.0 <3.28.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz"
-        }
-      }
-    },
     "del": {
       "version": "2.2.0",
       "from": "del@>=2.0.2 <3.0.0"
@@ -1218,18 +1111,6 @@
       "version": "3.0.1",
       "from": "detect-indent@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz"
-    },
-    "detective": {
-      "version": "4.3.1",
-      "from": "detective@>=4.3.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
-      "dependencies": {
-        "acorn": {
-          "version": "1.2.2",
-          "from": "acorn@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
-        }
-      }
     },
     "diff": {
       "version": "1.4.0",
@@ -1272,6 +1153,11 @@
     "emojis-list": {
       "version": "1.0.1",
       "from": "emojis-list@>=1.0.0 <2.0.0"
+    },
+    "end-of-stream": {
+      "version": "1.1.0",
+      "from": "end-of-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
     },
     "enhanced-resolve": {
       "version": "0.9.1",
@@ -1591,11 +1477,6 @@
         }
       }
     },
-    "glob": {
-      "version": "5.0.15",
-      "from": "glob@>=5.0.5 <6.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-    },
     "glob-base": {
       "version": "0.3.0",
       "from": "glob-base@>=0.3.0 <0.4.0"
@@ -1736,11 +1617,6 @@
       "version": "0.0.0",
       "from": "https-browserify@0.0.0"
     },
-    "iconv-lite": {
-      "version": "0.4.13",
-      "from": "iconv-lite@>=0.4.5 <0.5.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-    },
     "icss-replace-symbols": {
       "version": "1.0.2",
       "from": "icss-replace-symbols@>=1.0.2 <2.0.0",
@@ -1787,10 +1663,6 @@
     "inherits": {
       "version": "2.0.1",
       "from": "inherits@>=2.0.1 <2.1.0"
-    },
-    "ini": {
-      "version": "1.3.4",
-      "from": "ini@>=1.2.0 <2.0.0"
     },
     "inquirer": {
       "version": "0.12.0",
@@ -1970,20 +1842,9 @@
       "from": "isstream@>=0.1.2 <0.2.0"
     },
     "jade": {
-      "version": "0.26.3",
-      "from": "jade@0.26.3",
-      "dependencies": {
-        "commander": {
-          "version": "0.6.1",
-          "from": "commander@0.6.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-        },
-        "mkdirp": {
-          "version": "0.3.0",
-          "from": "mkdirp@0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
-        }
-      }
+      "version": "1.11.0",
+      "from": "pugjs/jade#29784fd",
+      "resolved": "git://github.com/pugjs/jade.git#29784fd1ec6043397f4b43d45b4ee9e25177b940"
     },
     "jade-attrs": {
       "version": "2.0.0",
@@ -2160,28 +2021,18 @@
       "from": "lazy-cache@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
     },
+    "lazystream": {
+      "version": "1.0.0",
+      "from": "lazystream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
+    },
     "lcid": {
       "version": "1.0.0",
       "from": "lcid@>=1.0.0 <2.0.0"
     },
-    "left-pad": {
-      "version": "0.0.3",
-      "from": "left-pad@0.0.3",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-    },
-    "leven": {
-      "version": "1.0.2",
-      "from": "leven@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
-    },
     "levn": {
       "version": "0.3.0",
       "from": "levn@>=0.3.0 <0.4.0"
-    },
-    "line-numbers": {
-      "version": "0.2.0",
-      "from": "line-numbers@0.2.0",
-      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz"
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -2301,11 +2152,6 @@
       "version": "3.2.0",
       "from": "lodash.deburr@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz"
-    },
-    "lodash.get": {
-      "version": "4.2.1",
-      "from": "lodash.get@>=4.2.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.2.1.tgz"
     },
     "lodash.isarguments": {
       "version": "3.0.8",
@@ -2467,10 +2313,6 @@
       "version": "0.0.5",
       "from": "mute-stream@0.0.5"
     },
-    "nan": {
-      "version": "2.2.1",
-      "from": "nan@>=2.2.0 <3.0.0"
-    },
     "negotiator": {
       "version": "0.6.0",
       "from": "negotiator@0.6.0",
@@ -2502,6 +2344,11 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz"
         }
       }
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "from": "node-int64@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
     },
     "node-libs-browser": {
       "version": "0.5.3",
@@ -2547,17 +2394,6 @@
       "version": "1.4.1",
       "from": "normalize-url@>=1.4.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.1.tgz"
-    },
-    "npmconf": {
-      "version": "2.1.2",
-      "from": "npmconf@>=2.1.2 <3.0.0",
-      "dependencies": {
-        "semver": {
-          "version": "4.3.6",
-          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-        }
-      }
     },
     "npmlog": {
       "version": "2.0.3",
@@ -2713,6 +2549,11 @@
     "pbkdf2-compat": {
       "version": "2.0.1",
       "from": "pbkdf2-compat@2.0.1"
+    },
+    "phone": {
+      "version": "1.0.4-11",
+      "from": "git+https://github.com/Automattic/node-phone.git#1.0.4-11",
+      "resolved": "git+https://github.com/Automattic/node-phone.git#3161829eba3dbab67c69a3795f74765026d4337a"
     },
     "pify": {
       "version": "2.3.0",
@@ -2924,10 +2765,6 @@
       "version": "7.1.1",
       "from": "promise@>=7.0.3 <8.0.0"
     },
-    "proto-list": {
-      "version": "1.2.4",
-      "from": "proto-list@>=1.2.1 <1.3.0"
-    },
     "proxy-addr": {
       "version": "1.0.10",
       "from": "proxy-addr@>=1.0.10 <1.1.0"
@@ -3020,21 +2857,10 @@
       "version": "1.0.1",
       "from": "readline2@>=1.0.1 <2.0.0"
     },
-    "recast": {
-      "version": "0.10.18",
-      "from": "recast@0.10.18",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.18.tgz",
-      "dependencies": {
-        "esprima-fb": {
-          "version": "14001.1.0-dev-harmony-fb",
-          "from": "esprima-fb@>=14001.1.0-dev-harmony-fb <14001.2.0",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-14001.1.0-dev-harmony-fb.tgz"
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "from": "source-map@>=0.4.1 <0.5.0"
-        }
-      }
+    "rechoir": {
+      "version": "0.6.2",
+      "from": "rechoir@>=0.6.2 <0.7.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
     },
     "redent": {
       "version": "1.0.0",
@@ -3085,33 +2911,9 @@
       "version": "1.2.1",
       "from": "regenerate@>=1.2.1 <2.0.0"
     },
-    "regenerator": {
-      "version": "0.8.34",
-      "from": "regenerator@0.8.34",
-      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.34.tgz",
-      "dependencies": {
-        "esprima-fb": {
-          "version": "13001.1.0-dev-harmony-fb",
-          "from": "esprima-fb@>=13001.1.0-dev-harmony-fb <13001.2.0",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1.0-dev-harmony-fb.tgz"
-        }
-      }
-    },
     "regex-cache": {
       "version": "0.4.3",
       "from": "regex-cache@>=0.4.2 <0.5.0"
-    },
-    "regexpu": {
-      "version": "1.3.0",
-      "from": "regexpu@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.2",
-          "from": "esprima@>=2.6.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-        }
-      }
     },
     "regexpu-core": {
       "version": "1.0.0",
@@ -3248,10 +3050,6 @@
       "from": "shebang-regex@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
-    "shelljs": {
-      "version": "0.5.3",
-      "from": "shelljs@>=0.5.3 <0.6.0"
-    },
     "shellwords": {
       "version": "0.1.0",
       "from": "shellwords@>=0.1.0 <0.2.0",
@@ -3264,16 +3062,6 @@
     "signal-exit": {
       "version": "2.1.2",
       "from": "signal-exit@>=2.1.2 <3.0.0"
-    },
-    "simple-fmt": {
-      "version": "0.1.0",
-      "from": "simple-fmt@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
-    },
-    "simple-is": {
-      "version": "0.2.0",
-      "from": "simple-is@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
     },
     "slash": {
       "version": "1.0.0",
@@ -3364,11 +3152,6 @@
         }
       }
     },
-    "stable": {
-      "version": "0.1.5",
-      "from": "stable@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
-    },
     "stackframe": {
       "version": "0.3.1",
       "from": "stackframe@>=0.3.1 <0.4.0",
@@ -3409,16 +3192,6 @@
     "string-width": {
       "version": "1.0.1",
       "from": "string-width@>=1.0.1 <2.0.0"
-    },
-    "stringmap": {
-      "version": "0.2.2",
-      "from": "stringmap@>=0.2.2 <0.3.0",
-      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
-    },
-    "stringset": {
-      "version": "0.2.1",
-      "from": "stringset@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
     },
     "stringstream": {
       "version": "0.0.5",
@@ -3480,6 +3253,11 @@
       "version": "2.2.1",
       "from": "tar@>=2.0.0 <3.0.0"
     },
+    "tar-stream": {
+      "version": "1.5.2",
+      "from": "tar-stream@>=1.5.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz"
+    },
     "tcomb": {
       "version": "2.7.0",
       "from": "tcomb@2.7.0",
@@ -3488,7 +3266,14 @@
     "tcomb-form-templates-bootstrap": {
       "version": "0.1.2",
       "from": "tcomb-form-templates-bootstrap@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/tcomb-form-templates-bootstrap/-/tcomb-form-templates-bootstrap-0.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/tcomb-form-templates-bootstrap/-/tcomb-form-templates-bootstrap-0.1.2.tgz",
+      "dependencies": {
+        "classnames": {
+          "version": "2.2.5",
+          "from": "classnames@>=2.1.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
+        }
+      }
     },
     "tcomb-validation": {
       "version": "2.3.0",
@@ -3534,19 +3319,9 @@
       "from": "trim-right@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
     },
-    "try-resolve": {
-      "version": "1.0.1",
-      "from": "try-resolve@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
-    },
     "tryit": {
       "version": "1.0.2",
       "from": "tryit@>=1.0.1 <2.0.0"
-    },
-    "tryor": {
-      "version": "0.1.2",
-      "from": "tryor@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -3623,10 +3398,6 @@
     "uglify-to-browserify": {
       "version": "1.0.2",
       "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
-    },
-    "uid-number": {
-      "version": "0.0.5",
-      "from": "uid-number@0.0.5"
     },
     "uniq": {
       "version": "1.0.1",
@@ -3802,7 +3573,7 @@
     "wp-calypso": {
       "version": "0.17.0",
       "from": "automattic/wp-calypso",
-      "resolved": "git://github.com/automattic/wp-calypso.git#84d32376de3e31d60062aca9b1b9cdbef864ba10",
+      "resolved": "git://github.com/automattic/wp-calypso.git#8556fc047ef035525d5d2bbc0d048b50c8bf8f3b",
       "dependencies": {
         "abbrev": {
           "version": "1.0.7",
@@ -3823,6 +3594,11 @@
           "version": "0.1.4",
           "from": "align-text@0.1.4",
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+        },
+        "alter": {
+          "version": "0.2.0",
+          "from": "alter@0.2.0",
+          "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz"
         },
         "amdefine": {
           "version": "1.0.0",
@@ -3909,10 +3685,25 @@
           "from": "asn1@0.2.3",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
         },
+        "assert": {
+          "version": "1.3.0",
+          "from": "assert@1.3.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+        },
         "assert-plus": {
           "version": "0.2.0",
           "from": "assert-plus@0.2.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+        },
+        "ast-traverse": {
+          "version": "0.1.1",
+          "from": "ast-traverse@0.1.1",
+          "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+        },
+        "ast-types": {
+          "version": "0.8.2",
+          "from": "ast-types@0.8.2",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.2.tgz"
         },
         "async": {
           "version": "0.9.0",
@@ -3950,9 +3741,9 @@
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
-          "version": "1.3.2",
-          "from": "aws4@1.3.2",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz"
+          "version": "1.4.1",
+          "from": "aws4@1.4.1",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
         },
         "babel": {
           "version": "5.8.12",
@@ -3961,17 +3752,22 @@
           "dependencies": {
             "commander": {
               "version": "2.9.0",
-              "from": "commander@>=2.6.0 <3.0.0",
+              "from": "commander@2.9.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "from": "glob@5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.2.0 <4.0.0",
+              "from": "lodash@3.10.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.0 <0.5.0",
+              "from": "source-map@0.4.4",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
             }
           }
@@ -3983,15 +3779,17 @@
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.10.0 <4.0.0"
+              "from": "lodash@3.10.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.0 <0.5.0"
+              "from": "source-map@0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
             },
             "source-map-support": {
               "version": "0.2.10",
-              "from": "source-map-support@>=0.2.10 <0.3.0",
+              "from": "source-map-support@0.2.10",
               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "dependencies": {
                 "source-map": {
@@ -4008,6 +3806,88 @@
           "from": "babel-loader@5.3.2",
           "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.3.2.tgz"
         },
+        "babel-plugin-constant-folding": {
+          "version": "1.0.1",
+          "from": "babel-plugin-constant-folding@1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+        },
+        "babel-plugin-dead-code-elimination": {
+          "version": "1.0.2",
+          "from": "babel-plugin-dead-code-elimination@1.0.2",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+        },
+        "babel-plugin-eval": {
+          "version": "1.0.1",
+          "from": "babel-plugin-eval@1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+        },
+        "babel-plugin-inline-environment-variables": {
+          "version": "1.0.1",
+          "from": "babel-plugin-inline-environment-variables@1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+        },
+        "babel-plugin-jscript": {
+          "version": "1.0.4",
+          "from": "babel-plugin-jscript@1.0.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+        },
+        "babel-plugin-member-expression-literals": {
+          "version": "1.0.1",
+          "from": "babel-plugin-member-expression-literals@1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+        },
+        "babel-plugin-property-literals": {
+          "version": "1.0.1",
+          "from": "babel-plugin-property-literals@1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+        },
+        "babel-plugin-proto-to-assign": {
+          "version": "1.0.4",
+          "from": "babel-plugin-proto-to-assign@1.0.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "3.10.1",
+              "from": "lodash@3.10.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+            }
+          }
+        },
+        "babel-plugin-react-constant-elements": {
+          "version": "1.0.3",
+          "from": "babel-plugin-react-constant-elements@1.0.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+        },
+        "babel-plugin-react-display-name": {
+          "version": "1.0.3",
+          "from": "babel-plugin-react-display-name@1.0.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+        },
+        "babel-plugin-remove-console": {
+          "version": "1.0.1",
+          "from": "babel-plugin-remove-console@1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+        },
+        "babel-plugin-remove-debugger": {
+          "version": "1.0.1",
+          "from": "babel-plugin-remove-debugger@1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+        },
+        "babel-plugin-runtime": {
+          "version": "1.0.7",
+          "from": "babel-plugin-runtime@1.0.7",
+          "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+        },
+        "babel-plugin-undeclared-variables-check": {
+          "version": "1.0.2",
+          "from": "babel-plugin-undeclared-variables-check@1.0.2",
+          "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz"
+        },
+        "babel-plugin-undefined-to-void": {
+          "version": "1.1.6",
+          "from": "babel-plugin-undefined-to-void@1.1.6",
+          "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+        },
         "babel-runtime": {
           "version": "5.8.12",
           "from": "babel-runtime@5.8.12",
@@ -4015,18 +3895,28 @@
         },
         "babylon": {
           "version": "5.8.38",
-          "from": "babylon@>=5.8.12 <6.0.0",
+          "from": "babylon@5.8.38",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz"
         },
         "balanced-match": {
-          "version": "0.3.0",
-          "from": "balanced-match@0.3.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+          "version": "0.4.1",
+          "from": "balanced-match@0.4.1",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
         },
         "base62": {
           "version": "0.1.1",
           "from": "base62@0.1.1",
           "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
+        },
+        "Base64": {
+          "version": "0.2.1",
+          "from": "Base64@0.2.1",
+          "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+        },
+        "base64-js": {
+          "version": "0.0.8",
+          "from": "base64-js@0.0.8",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
         },
         "basic-auth": {
           "version": "1.0.0",
@@ -4048,11 +3938,6 @@
           "from": "bl@1.1.2",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
             "readable-stream": {
               "version": "2.0.6",
               "from": "readable-stream@2.0.6",
@@ -4066,14 +3951,19 @@
           "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
         },
         "block-stream": {
-          "version": "0.0.8",
-          "from": "block-stream@0.0.8",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+          "version": "0.0.9",
+          "from": "block-stream@0.0.9",
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+        },
+        "bluebird": {
+          "version": "2.10.2",
+          "from": "bluebird@2.10.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
         },
         "body-parser": {
-          "version": "1.15.0",
-          "from": "body-parser@1.15.0",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
+          "version": "1.15.1",
+          "from": "body-parser@1.15.1",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.1.tgz",
           "dependencies": {
             "qs": {
               "version": "6.1.0",
@@ -4093,24 +3983,39 @@
           "resolved": "https://registry.npmjs.org/bounding-client-rect/-/bounding-client-rect-1.0.5.tgz"
         },
         "brace-expansion": {
-          "version": "1.1.3",
-          "from": "brace-expansion@1.1.3",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz"
+          "version": "1.1.4",
+          "from": "brace-expansion@1.1.4",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz"
         },
         "braces": {
-          "version": "1.8.3",
-          "from": "braces@1.8.3",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz"
+          "version": "1.8.4",
+          "from": "braces@1.8.4",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.4.tgz"
+        },
+        "breakable": {
+          "version": "1.0.0",
+          "from": "breakable@1.0.0",
+          "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
         },
         "browser-filesaver": {
           "version": "1.1.0",
           "from": "browser-filesaver@1.1.0",
           "resolved": "https://registry.npmjs.org/browser-filesaver/-/browser-filesaver-1.1.0.tgz"
         },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "from": "browserify-zlib@0.1.4",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
+        },
         "browserslist": {
           "version": "1.3.1",
           "from": "browserslist@1.3.1",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.1.tgz"
+        },
+        "buffer": {
+          "version": "3.6.0",
+          "from": "buffer@3.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz"
         },
         "builtin-modules": {
           "version": "1.1.1",
@@ -4123,9 +4028,9 @@
           "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz"
         },
         "bytes": {
-          "version": "2.2.0",
-          "from": "bytes@2.2.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+          "version": "2.3.0",
+          "from": "bytes@2.3.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
         },
         "camel-case": {
           "version": "0.1.0",
@@ -4150,9 +4055,9 @@
           }
         },
         "caniuse-db": {
-          "version": "1.0.30000452",
-          "from": "caniuse-db@1.0.30000452",
-          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000452.tgz"
+          "version": "1.0.30000466",
+          "from": "caniuse-db@1.0.30000466",
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000466.tgz"
         },
         "caseless": {
           "version": "0.11.0",
@@ -4199,14 +4104,14 @@
           "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz"
         },
         "chokidar": {
-          "version": "1.4.3",
-          "from": "chokidar@1.4.3",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz"
+          "version": "1.5.0",
+          "from": "chokidar@1.5.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.5.0.tgz"
         },
         "chrono-node": {
-          "version": "1.2.1",
-          "from": "chrono-node@1.2.1",
-          "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.2.1.tgz"
+          "version": "1.2.3",
+          "from": "chrono-node@1.2.3",
+          "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.2.3.tgz"
         },
         "classnames": {
           "version": "1.1.1",
@@ -4257,6 +4162,11 @@
           "from": "cliui@2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
         },
+        "clone": {
+          "version": "1.0.2",
+          "from": "clone@1.0.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+        },
         "closest": {
           "version": "0.0.1",
           "from": "closest@0.0.1",
@@ -4277,15 +4187,32 @@
           "from": "commander@2.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
+        "commoner": {
+          "version": "0.10.4",
+          "from": "commoner@0.10.4",
+          "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "2.9.0",
+              "from": "commander@2.9.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "from": "glob@5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+            },
+            "q": {
+              "version": "1.4.1",
+              "from": "q@1.4.1",
+              "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+            }
+          }
+        },
         "component-bind": {
           "version": "1.0.0",
           "from": "component-bind@1.0.0",
           "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
-        },
-        "component-classes": {
-          "version": "1.2.6",
-          "from": "component-classes@1.2.6",
-          "resolved": "https://registry.npmjs.org/component-classes/-/component-classes-1.2.6.tgz"
         },
         "component-closest": {
           "version": "0.1.4",
@@ -4326,11 +4253,6 @@
           "version": "0.2.1",
           "from": "component-file-picker@0.2.1",
           "resolved": "https://registry.npmjs.org/component-file-picker/-/component-file-picker-0.2.1.tgz"
-        },
-        "component-indexof": {
-          "version": "0.0.3",
-          "from": "component-indexof@0.0.3",
-          "resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz"
         },
         "component-matches-selector": {
           "version": "0.1.6",
@@ -4377,11 +4299,6 @@
           "from": "concat-stream@1.5.1",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
           "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
             "readable-stream": {
               "version": "2.0.6",
               "from": "readable-stream@2.0.6",
@@ -4394,10 +4311,20 @@
           "from": "config-chain@1.1.10",
           "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz"
         },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@1.1.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
+        },
         "constant-case": {
           "version": "1.1.2",
           "from": "constant-case@1.1.2",
           "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
+        },
+        "constants-browserify": {
+          "version": "0.0.1",
+          "from": "constants-browserify@0.0.1",
+          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "content-disposition": {
           "version": "0.5.0",
@@ -4405,9 +4332,9 @@
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
         },
         "content-type": {
-          "version": "1.0.1",
-          "from": "content-type@1.0.1",
-          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+          "version": "1.0.2",
+          "from": "content-type@1.0.2",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "convert-source-map": {
           "version": "1.2.0",
@@ -4436,7 +4363,7 @@
         },
         "core-js": {
           "version": "0.9.18",
-          "from": "core-js@>=0.9.0 <0.10.0",
+          "from": "core-js@0.9.18",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.9.18.tgz"
         },
         "core-util-is": {
@@ -4469,15 +4396,20 @@
           "from": "cryptiles@2.0.5",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
         },
+        "crypto-browserify": {
+          "version": "3.2.8",
+          "from": "crypto-browserify@3.2.8",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz"
+        },
         "d": {
           "version": "0.1.1",
           "from": "d@0.1.1",
           "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
         },
         "dashdash": {
-          "version": "1.13.0",
-          "from": "dashdash@1.13.0",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+          "version": "1.13.1",
+          "from": "dashdash@1.13.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -4486,9 +4418,15 @@
             }
           }
         },
+        "date-now": {
+          "version": "0.1.4",
+          "from": "date-now@0.1.4",
+          "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+        },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@2.2.0"
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "decamelize": {
           "version": "1.2.0",
@@ -4499,6 +4437,23 @@
           "version": "1.0.1",
           "from": "deep-equal@1.0.1",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+        },
+        "defined": {
+          "version": "1.0.0",
+          "from": "defined@1.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+        },
+        "defs": {
+          "version": "1.1.1",
+          "from": "defs@1.1.1",
+          "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+          "dependencies": {
+            "esprima-fb": {
+              "version": "15001.1001.0-dev-harmony-fb",
+              "from": "esprima-fb@15001.1001.0-dev-harmony-fb",
+              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+            }
+          }
         },
         "delayed-stream": {
           "version": "1.0.0",
@@ -4525,6 +4480,16 @@
           "from": "destroy@1.0.3",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
         },
+        "detect-indent": {
+          "version": "3.0.1",
+          "from": "detect-indent@3.0.1",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz"
+        },
+        "detective": {
+          "version": "4.3.1",
+          "from": "detective@4.3.1",
+          "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz"
+        },
         "dom-scroll-into-view": {
           "version": "1.0.1",
           "from": "dom-scroll-into-view@1.0.1",
@@ -4546,6 +4511,11 @@
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
             }
           }
+        },
+        "domain-browser": {
+          "version": "1.1.7",
+          "from": "domain-browser@1.1.7",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
         },
         "domelementtype": {
           "version": "1.3.0",
@@ -4600,14 +4570,26 @@
           "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz"
         },
         "emojis-list": {
-          "version": "1.0.1",
-          "from": "emojis-list@1.0.1",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
+          "version": "2.0.1",
+          "from": "emojis-list@2.0.1",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.0.1.tgz"
         },
         "encoding": {
           "version": "0.1.12",
           "from": "encoding@0.1.12",
           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "from": "enhanced-resolve@0.9.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.2.0",
+              "from": "memory-fs@0.2.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+            }
+          }
         },
         "entities": {
           "version": "1.0.0",
@@ -4618,6 +4600,11 @@
           "version": "3.4.0",
           "from": "envify@3.4.0",
           "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz"
+        },
+        "errno": {
+          "version": "0.1.4",
+          "from": "errno@0.1.4",
+          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
         },
         "error-ex": {
           "version": "1.3.0",
@@ -4691,10 +4678,15 @@
           "from": "escape-string-regexp@1.0.3",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
         },
-        "esmangle-evaluator": {
-          "version": "1.0.0",
-          "from": "esmangle-evaluator@1.0.0",
-          "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
+        "esprima-fb": {
+          "version": "13001.1.0-dev-harmony-fb",
+          "from": "esprima-fb@13001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1.0-dev-harmony-fb.tgz"
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "from": "esutils@2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         },
         "etag": {
           "version": "1.7.0",
@@ -4712,9 +4704,9 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
         },
         "expand-range": {
-          "version": "1.8.1",
-          "from": "expand-range@1.8.1",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz"
+          "version": "1.8.2",
+          "from": "expand-range@1.8.2",
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
         },
         "exports-loader": {
           "version": "0.6.2",
@@ -4757,11 +4749,6 @@
           "version": "1.0.2",
           "from": "extsprintf@1.0.2",
           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-        },
-        "falafel": {
-          "version": "1.2.0",
-          "from": "falafel@1.2.0",
-          "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz"
         },
         "fastparse": {
           "version": "1.1.1",
@@ -4880,11 +4867,6 @@
           "from": "for-own@0.1.4",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
         },
-        "foreach": {
-          "version": "2.0.5",
-          "from": "foreach@2.0.5",
-          "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-        },
         "foreachasync": {
           "version": "3.0.0",
           "from": "foreachasync@3.0.0",
@@ -4928,9 +4910,9 @@
           "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
         },
         "fstream": {
-          "version": "1.0.8",
-          "from": "fstream@1.0.8",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+          "version": "1.0.9",
+          "from": "fstream@1.0.9",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.9.tgz"
         },
         "gather-stream": {
           "version": "1.0.0",
@@ -4967,6 +4949,18 @@
           "from": "get-stdin@4.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
         },
+        "getpass": {
+          "version": "0.1.6",
+          "from": "getpass@0.1.6",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+            }
+          }
+        },
         "glob-base": {
           "version": "0.3.0",
           "from": "glob-base@0.3.0",
@@ -4979,7 +4973,7 @@
         },
         "globals": {
           "version": "6.4.1",
-          "from": "globals@>=6.4.0 <7.0.0",
+          "from": "globals@6.4.1",
           "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
         },
         "globby": {
@@ -4993,9 +4987,9 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
             },
             "object-assign": {
-              "version": "4.0.1",
-              "from": "object-assign@4.0.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+              "version": "4.1.0",
+              "from": "object-assign@4.1.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
             },
             "pinkie": {
               "version": "1.0.0",
@@ -5052,9 +5046,9 @@
           "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.1.7.tgz"
         },
         "graceful-fs": {
-          "version": "4.1.3",
-          "from": "graceful-fs@4.1.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+          "version": "4.1.4",
+          "from": "graceful-fs@4.1.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
         },
         "graceful-readlink": {
           "version": "1.0.1",
@@ -5129,9 +5123,14 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "hoist-non-react-statics": {
-          "version": "1.0.5",
-          "from": "hoist-non-react-statics@1.0.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.0.5.tgz"
+          "version": "1.0.6",
+          "from": "hoist-non-react-statics@1.0.6",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.0.6.tgz"
+        },
+        "home-or-tmp": {
+          "version": "1.0.0",
+          "from": "home-or-tmp@1.0.0",
+          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
         },
         "hosted-git-info": {
           "version": "2.1.4",
@@ -5149,14 +5148,14 @@
           "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.4.0.tgz",
           "dependencies": {
             "object-assign": {
-              "version": "4.0.1",
-              "from": "object-assign@4.0.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+              "version": "4.1.0",
+              "from": "object-assign@4.1.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
             },
             "source-map": {
-              "version": "0.5.3",
-              "from": "source-map@0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "version": "0.5.6",
+              "from": "source-map@0.5.6",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
             }
           }
         },
@@ -5182,12 +5181,22 @@
           "from": "htmlparser2@3.8.3",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
             "readable-stream": {
               "version": "1.1.14",
               "from": "readable-stream@1.1.14",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
             }
           }
+        },
+        "http-browserify": {
+          "version": "1.7.0",
+          "from": "http-browserify@1.7.0",
+          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz"
         },
         "http-errors": {
           "version": "1.4.0",
@@ -5199,10 +5208,20 @@
           "from": "http-signature@1.1.1",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
         },
+        "https-browserify": {
+          "version": "0.0.0",
+          "from": "https-browserify@0.0.0",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+        },
         "iconv-lite": {
           "version": "0.4.13",
           "from": "iconv-lite@0.4.13",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+        },
+        "ieee754": {
+          "version": "1.1.6",
+          "from": "ieee754@1.1.6",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
         },
         "immutable": {
           "version": "3.7.5",
@@ -5246,10 +5265,10 @@
           "from": "ini@1.3.4",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
         },
-        "inline-process-browser": {
-          "version": "2.0.1",
-          "from": "inline-process-browser@2.0.1",
-          "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz"
+        "interpret": {
+          "version": "0.6.6",
+          "from": "interpret@0.6.6",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
         },
         "invariant": {
           "version": "2.1.2",
@@ -5321,6 +5340,11 @@
           "from": "is-glob@2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
         },
+        "is-integer": {
+          "version": "1.0.6",
+          "from": "is-integer@1.0.6",
+          "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz"
+        },
         "is-lower-case": {
           "version": "1.1.3",
           "from": "is-lower-case@1.1.3",
@@ -5377,9 +5401,9 @@
           "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
         },
         "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "version": "1.0.0",
+          "from": "isarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "isexe": {
           "version": "1.1.2",
@@ -5387,9 +5411,9 @@
           "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
         },
         "isobject": {
-          "version": "2.0.0",
-          "from": "isobject@2.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
+          "version": "2.1.0",
+          "from": "isobject@2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
         },
         "isomorphic-fetch": {
           "version": "2.2.1",
@@ -5397,9 +5421,9 @@
           "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
           "dependencies": {
             "whatwg-fetch": {
-              "version": "0.11.0",
-              "from": "whatwg-fetch@0.11.0",
-              "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.11.0.tgz"
+              "version": "1.0.0",
+              "from": "whatwg-fetch@1.0.0",
+              "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz"
             }
           }
         },
@@ -5407,11 +5431,6 @@
           "version": "0.1.2",
           "from": "isstream@0.1.2",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-        },
-        "jade": {
-          "version": "1.11.0",
-          "from": "pugjs/jade#29784fd",
-          "resolved": "git://github.com/pugjs/jade.git#29784fd1ec6043397f4b43d45b4ee9e25177b940"
         },
         "jed": {
           "version": "1.0.2",
@@ -5442,6 +5461,11 @@
           "version": "0.1.0",
           "from": "jsbn@0.1.0",
           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+        },
+        "jsesc": {
+          "version": "0.5.0",
+          "from": "jsesc@0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
         },
         "jshashes": {
           "version": "1.0.5",
@@ -5511,19 +5535,34 @@
           "resolved": "https://registry.npmjs.org/keymaster/-/keymaster-1.6.2.tgz"
         },
         "kind-of": {
-          "version": "3.0.2",
-          "from": "kind-of@3.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+          "version": "3.0.3",
+          "from": "kind-of@3.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz"
         },
         "lazy-cache": {
-          "version": "1.0.3",
-          "from": "lazy-cache@1.0.3",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+          "version": "1.0.4",
+          "from": "lazy-cache@1.0.4",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
         },
         "lcid": {
           "version": "1.0.0",
           "from": "lcid@1.0.0",
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+        },
+        "left-pad": {
+          "version": "0.0.3",
+          "from": "left-pad@0.0.3",
+          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+        },
+        "leven": {
+          "version": "1.0.2",
+          "from": "leven@1.0.2",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+        },
+        "line-numbers": {
+          "version": "0.2.0",
+          "from": "line-numbers@0.2.0",
+          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz"
         },
         "load-json-file": {
           "version": "1.1.0",
@@ -5531,14 +5570,14 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
         },
         "loader-utils": {
-          "version": "0.2.14",
-          "from": "loader-utils@0.2.14",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz",
+          "version": "0.2.15",
+          "from": "loader-utils@0.2.15",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.15.tgz",
           "dependencies": {
             "object-assign": {
-              "version": "4.0.1",
-              "from": "object-assign@4.0.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+              "version": "4.1.0",
+              "from": "object-assign@4.1.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
             }
           }
         },
@@ -5569,6 +5608,11 @@
           "from": "lodash._baseslice@4.0.0",
           "resolved": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz"
         },
+        "lodash._basetostring": {
+          "version": "4.12.0",
+          "from": "lodash._basetostring@4.12.0",
+          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz"
+        },
         "lodash._getnative": {
           "version": "3.9.1",
           "from": "lodash._getnative@3.9.1",
@@ -5590,24 +5634,24 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
         },
         "lodash.pad": {
-          "version": "4.3.0",
-          "from": "lodash.pad@4.3.0",
-          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.3.0.tgz"
+          "version": "4.4.0",
+          "from": "lodash.pad@4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.4.0.tgz"
         },
         "lodash.padend": {
-          "version": "4.4.0",
-          "from": "lodash.padend@4.4.0",
-          "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.4.0.tgz"
+          "version": "4.5.0",
+          "from": "lodash.padend@4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.5.0.tgz"
         },
         "lodash.padstart": {
-          "version": "4.4.0",
-          "from": "lodash.padstart@4.4.0",
-          "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.4.0.tgz"
+          "version": "4.5.0",
+          "from": "lodash.padstart@4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.5.0.tgz"
         },
         "lodash.tostring": {
-          "version": "4.1.2",
-          "from": "lodash.tostring@4.1.2",
-          "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
+          "version": "4.1.3",
+          "from": "lodash.tostring@4.1.3",
+          "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.3.tgz"
         },
         "longest": {
           "version": "1.0.1",
@@ -5615,9 +5659,9 @@
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
         },
         "loose-envify": {
-          "version": "1.1.0",
-          "from": "loose-envify@1.1.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz"
+          "version": "1.2.0",
+          "from": "loose-envify@1.2.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz"
         },
         "loud-rejection": {
           "version": "1.3.0",
@@ -5665,9 +5709,9 @@
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
         },
         "memory-fs": {
-          "version": "0.2.0",
-          "from": "memory-fs@0.2.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+          "version": "0.3.0",
+          "from": "memory-fs@0.3.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz"
         },
         "meow": {
           "version": "3.7.0",
@@ -5675,9 +5719,9 @@
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "dependencies": {
             "object-assign": {
-              "version": "4.0.1",
-              "from": "object-assign@4.0.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+              "version": "4.1.0",
+              "from": "object-assign@4.1.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
             }
           }
         },
@@ -5692,9 +5736,9 @@
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
         },
         "micromatch": {
-          "version": "2.3.7",
-          "from": "micromatch@2.3.7",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz"
+          "version": "2.3.8",
+          "from": "micromatch@2.3.8",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.8.tgz"
         },
         "mime": {
           "version": "1.3.4",
@@ -5702,14 +5746,14 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "mime-db": {
-          "version": "1.22.0",
-          "from": "mime-db@1.22.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+          "version": "1.23.0",
+          "from": "mime-db@1.23.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
         },
         "mime-types": {
-          "version": "2.1.10",
-          "from": "mime-types@2.1.10",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
+          "version": "2.1.11",
+          "from": "mime-types@2.1.11",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
         },
         "minimatch": {
           "version": "2.0.10",
@@ -5766,9 +5810,9 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "nan": {
-          "version": "2.2.1",
-          "from": "nan@2.2.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.1.tgz"
+          "version": "2.3.3",
+          "from": "nan@2.3.3",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.3.tgz"
         },
         "ncname": {
           "version": "1.0.0",
@@ -5781,9 +5825,9 @@
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
         },
         "neo-async": {
-          "version": "1.8.0",
-          "from": "neo-async@1.8.0",
-          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-1.8.0.tgz"
+          "version": "1.8.2",
+          "from": "neo-async@1.8.2",
+          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-1.8.2.tgz"
         },
         "node-contains": {
           "version": "1.0.0",
@@ -5791,9 +5835,9 @@
           "resolved": "https://registry.npmjs.org/node-contains/-/node-contains-1.0.0.tgz"
         },
         "node-fetch": {
-          "version": "1.5.1",
-          "from": "node-fetch@1.5.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.5.1.tgz"
+          "version": "1.5.2",
+          "from": "node-fetch@1.5.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.5.2.tgz"
         },
         "node-gyp": {
           "version": "3.3.1",
@@ -5820,6 +5864,23 @@
               "version": "1.0.0",
               "from": "minimatch@1.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz"
+            }
+          }
+        },
+        "node-libs-browser": {
+          "version": "0.5.3",
+          "from": "node-libs-browser@0.5.3",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "from": "readable-stream@1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
             }
           }
         },
@@ -5913,19 +5974,14 @@
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
         },
         "oauth-sign": {
-          "version": "0.8.1",
-          "from": "oauth-sign@0.8.1",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
+          "version": "0.8.2",
+          "from": "oauth-sign@0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
+          "from": "object-assign@3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-        },
-        "object-keys": {
-          "version": "1.0.9",
-          "from": "object-keys@1.0.9",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
         },
         "object.omit": {
           "version": "2.0.0",
@@ -5941,6 +5997,23 @@
           "version": "1.3.3",
           "from": "once@1.3.3",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "os-browserify": {
+          "version": "0.1.2",
+          "from": "os-browserify@0.1.2",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "os-homedir": {
           "version": "1.0.1",
@@ -5977,12 +6050,22 @@
           "from": "page@1.6.4",
           "resolved": "https://registry.npmjs.org/page/-/page-1.6.4.tgz",
           "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
             "path-to-regexp": {
               "version": "1.2.1",
               "from": "path-to-regexp@1.2.1",
               "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz"
             }
           }
+        },
+        "pako": {
+          "version": "0.2.8",
+          "from": "pako@0.2.8",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
         },
         "param-case": {
           "version": "1.1.2",
@@ -6033,6 +6116,11 @@
           "from": "path-array@1.0.1",
           "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz"
         },
+        "path-browserify": {
+          "version": "0.0.0",
+          "from": "path-browserify@0.0.0",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+        },
         "path-case": {
           "version": "1.1.2",
           "from": "path-case@1.1.2",
@@ -6070,15 +6158,15 @@
           "from": "path-type@1.1.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
         },
+        "pbkdf2-compat": {
+          "version": "2.0.1",
+          "from": "pbkdf2-compat@2.0.1",
+          "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+        },
         "performance-now": {
           "version": "0.1.4",
           "from": "performance-now@0.1.4",
           "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.1.4.tgz"
-        },
-        "phone": {
-          "version": "1.0.4-3",
-          "from": "git+https://github.com/Automattic/node-phone.git#1.0.4-9",
-          "resolved": "git+https://github.com/Automattic/node-phone.git#8f012b153e968038c2ce758b7f34e5b8d792eb20"
         },
         "photon": {
           "version": "2.0.0",
@@ -6101,14 +6189,14 @@
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
         },
         "postcss": {
-          "version": "5.0.19",
-          "from": "postcss@5.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
+          "version": "5.0.21",
+          "from": "postcss@5.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.21.tgz",
           "dependencies": {
             "source-map": {
-              "version": "0.5.3",
-              "from": "source-map@0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "version": "0.5.6",
+              "from": "source-map@0.5.6",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
             }
           }
         },
@@ -6132,10 +6220,15 @@
           "from": "private@0.1.6",
           "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
         },
+        "process": {
+          "version": "0.11.3",
+          "from": "process@0.11.3",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.3.tgz"
+        },
         "process-nextick-args": {
-          "version": "1.0.6",
-          "from": "process-nextick-args@1.0.6",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+          "version": "1.0.7",
+          "from": "process-nextick-args@1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
         },
         "progress-event": {
           "version": "1.0.0",
@@ -6157,10 +6250,20 @@
           "from": "proxy-addr@1.0.10",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz"
         },
+        "prr": {
+          "version": "0.0.0",
+          "from": "prr@0.0.0",
+          "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+        },
         "pseudomap": {
           "version": "1.0.2",
           "from": "pseudomap@1.0.2",
           "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "from": "punycode@1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
         },
         "q": {
           "version": "1.0.1",
@@ -6182,6 +6285,16 @@
           "from": "qs@4.0.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
         },
+        "querystring": {
+          "version": "0.2.0",
+          "from": "querystring@0.2.0",
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "from": "querystring-es3@0.2.1",
+          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+        },
         "raf": {
           "version": "2.0.4",
           "from": "raf@2.0.4",
@@ -6200,14 +6313,7 @@
         "raw-body": {
           "version": "2.1.6",
           "from": "raw-body@2.1.6",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
-          "dependencies": {
-            "bytes": {
-              "version": "2.3.0",
-              "from": "bytes@2.3.0",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz"
         },
         "react": {
           "version": "0.14.3",
@@ -6252,9 +6358,9 @@
           "resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-2.1.0.tgz"
         },
         "react-day-picker": {
-          "version": "1.1.0",
-          "from": "react-day-picker@1.1.0",
-          "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-1.1.0.tgz"
+          "version": "1.3.2",
+          "from": "react-day-picker@1.3.2",
+          "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-1.3.2.tgz"
         },
         "react-dom": {
           "version": "0.14.3",
@@ -6279,9 +6385,9 @@
           "resolved": "https://registry.npmjs.org/react-pure-render/-/react-pure-render-1.0.2.tgz"
         },
         "react-redux": {
-          "version": "4.0.1",
-          "from": "react-redux@4.0.1",
-          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.0.1.tgz"
+          "version": "4.4.5",
+          "from": "react-redux@4.4.5",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.5.tgz"
         },
         "react-side-effect": {
           "version": "1.0.2",
@@ -6333,21 +6439,31 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
         },
         "readable-stream": {
-          "version": "2.1.0",
-          "from": "readable-stream@2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            }
-          }
+          "version": "2.1.2",
+          "from": "readable-stream@2.1.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz"
         },
         "readdirp": {
           "version": "2.0.0",
           "from": "readdirp@2.0.0",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz"
+        },
+        "recast": {
+          "version": "0.10.18",
+          "from": "recast@0.10.18",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.18.tgz",
+          "dependencies": {
+            "esprima-fb": {
+              "version": "14001.1.0-dev-harmony-fb",
+              "from": "esprima-fb@14001.1.0-dev-harmony-fb",
+              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-14001.1.0-dev-harmony-fb.tgz"
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+            }
+          }
         },
         "redent": {
           "version": "1.0.0",
@@ -6369,6 +6485,16 @@
           "from": "redux-thunk@1.0.0",
           "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-1.0.0.tgz"
         },
+        "regenerate": {
+          "version": "1.2.1",
+          "from": "regenerate@1.2.1",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+        },
+        "regenerator": {
+          "version": "0.8.34",
+          "from": "regenerator@0.8.34",
+          "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.34.tgz"
+        },
         "regex-cache": {
           "version": "0.4.3",
           "from": "regex-cache@0.4.3",
@@ -6378,6 +6504,28 @@
           "version": "0.0.0",
           "from": "regexp-quote@0.0.0",
           "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz"
+        },
+        "regexpu": {
+          "version": "1.3.0",
+          "from": "regexpu@1.3.0",
+          "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "2.7.2",
+              "from": "esprima@2.7.2",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+            }
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "from": "regjsgen@0.2.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "from": "regjsparser@0.1.5",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
         },
         "relateurl": {
           "version": "0.2.6",
@@ -6394,10 +6542,15 @@
           "from": "repeat-string@1.5.4",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
         },
+        "repeating": {
+          "version": "1.1.3",
+          "from": "repeating@1.1.3",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
+        },
         "request": {
-          "version": "2.71.0",
-          "from": "request@2.71.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.71.0.tgz",
+          "version": "2.72.0",
+          "from": "request@2.72.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
           "dependencies": {
             "qs": {
               "version": "6.1.0",
@@ -6426,6 +6579,11 @@
               "from": "glob@7.0.3"
             }
           }
+        },
+        "ripemd160": {
+          "version": "0.2.0",
+          "from": "ripemd160@0.2.0",
+          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
         },
         "rtlcss": {
           "version": "1.6.1",
@@ -6535,10 +6693,20 @@
             }
           }
         },
+        "sha.js": {
+          "version": "2.2.6",
+          "from": "sha.js@2.2.6",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+        },
         "shallowequal": {
           "version": "0.2.2",
           "from": "shallowequal@0.2.2",
           "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz"
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "from": "shebang-regex@1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
         },
         "sigmund": {
           "version": "1.0.1",
@@ -6549,6 +6717,16 @@
           "version": "2.1.2",
           "from": "signal-exit@2.1.2",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+        },
+        "simple-fmt": {
+          "version": "0.1.0",
+          "from": "simple-fmt@0.1.0",
+          "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+        },
+        "simple-is": {
+          "version": "0.2.0",
+          "from": "simple-is@0.2.0",
+          "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
         },
         "slash": {
           "version": "1.0.0",
@@ -6571,6 +6749,11 @@
           "version": "1.0.9",
           "from": "sntp@1.0.9",
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+        },
+        "source-list-map": {
+          "version": "0.1.6",
+          "from": "source-list-map@0.1.6",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz"
         },
         "source-map": {
           "version": "0.1.39",
@@ -6620,9 +6803,21 @@
           "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz"
         },
         "sshpk": {
-          "version": "1.7.4",
-          "from": "sshpk@1.7.4",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
+          "version": "1.8.3",
+          "from": "sshpk@1.8.3",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+            }
+          }
+        },
+        "stable": {
+          "version": "0.1.5",
+          "from": "stable@0.1.5",
+          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
         },
         "statuses": {
           "version": "1.2.1",
@@ -6634,10 +6829,37 @@
           "from": "store@1.3.16",
           "resolved": "https://registry.npmjs.org/store/-/store-1.3.16.tgz"
         },
+        "stream-browserify": {
+          "version": "1.0.0",
+          "from": "stream-browserify@1.0.0",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "from": "readable-stream@1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+            }
+          }
+        },
         "string_decoder": {
           "version": "0.10.31",
           "from": "string_decoder@0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
+        "stringmap": {
+          "version": "0.2.2",
+          "from": "stringmap@0.2.2",
+          "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+        },
+        "stringset": {
+          "version": "0.2.1",
+          "from": "stringset@0.2.1",
+          "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
@@ -6699,6 +6921,11 @@
               "from": "form-data@0.2.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
             },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
             "methods": {
               "version": "1.0.1",
               "from": "methods@1.0.1",
@@ -6736,6 +6963,11 @@
           "from": "swap-case@1.1.2",
           "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
         },
+        "tapable": {
+          "version": "0.1.10",
+          "from": "tapable@0.1.10",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+        },
         "tar": {
           "version": "2.2.1",
           "from": "tar@2.2.1",
@@ -6746,17 +6978,10 @@
           "from": "through@2.3.8",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.34",
-              "from": "readable-stream@1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-            }
-          }
+        "timers-browserify": {
+          "version": "1.4.2",
+          "from": "timers-browserify@1.4.2",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
         },
         "tiny-emitter": {
           "version": "1.0.2",
@@ -6764,9 +6989,9 @@
           "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.0.2.tgz"
         },
         "tinymce": {
-          "version": "4.3.8",
-          "from": "tinymce@4.3.8",
-          "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.3.8.tgz"
+          "version": "4.3.12",
+          "from": "tinymce@4.3.12",
+          "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.3.12.tgz"
         },
         "title-case": {
           "version": "1.1.2",
@@ -6794,6 +7019,11 @@
           "version": "0.1.1",
           "from": "to-capital-case@0.1.1",
           "resolved": "https://registry.npmjs.org/to-capital-case/-/to-capital-case-0.1.1.tgz"
+        },
+        "to-fast-properties": {
+          "version": "1.0.2",
+          "from": "to-fast-properties@1.0.2",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
         },
         "to-function": {
           "version": "2.0.6",
@@ -6825,10 +7055,30 @@
           "from": "trim-newlines@1.0.0",
           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
         },
+        "trim-right": {
+          "version": "1.0.1",
+          "from": "trim-right@1.0.1",
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+        },
+        "try-resolve": {
+          "version": "1.0.1",
+          "from": "try-resolve@1.0.1",
+          "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+        },
+        "tryor": {
+          "version": "0.1.2",
+          "from": "tryor@0.1.2",
+          "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "from": "tty-browserify@0.0.0",
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+        },
         "tunnel-agent": {
-          "version": "0.4.2",
-          "from": "tunnel-agent@0.4.2",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+          "version": "0.4.3",
+          "from": "tunnel-agent@0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         },
         "tv4": {
           "version": "1.2.7",
@@ -6841,9 +7091,9 @@
           "resolved": "https://registry.npmjs.org/tween.js/-/tween.js-16.3.1.tgz"
         },
         "tweetnacl": {
-          "version": "0.14.3",
-          "from": "tweetnacl@0.14.3",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+          "version": "0.13.3",
+          "from": "tweetnacl@0.13.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
         },
         "twemoji": {
           "version": "1.3.2",
@@ -6876,9 +7126,9 @@
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
-              "version": "0.5.3",
-              "from": "source-map@0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "version": "0.5.6",
+              "from": "source-map@0.5.6",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
             },
             "window-size": {
               "version": "0.1.0",
@@ -6912,33 +7162,6 @@
           "from": "unpipe@1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
         },
-        "unreachable-branch-transform": {
-          "version": "0.5.1",
-          "from": "unreachable-branch-transform@0.5.1",
-          "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
-          "dependencies": {
-            "ast-types": {
-              "version": "0.8.16",
-              "from": "ast-types@0.8.16",
-              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
-            },
-            "esprima": {
-              "version": "2.7.2",
-              "from": "esprima@2.7.2",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-            },
-            "recast": {
-              "version": "0.11.5",
-              "from": "recast@0.11.5",
-              "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz"
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "from": "source-map@0.5.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        },
         "upper-case": {
           "version": "1.1.3",
           "from": "upper-case@1.1.3",
@@ -6953,6 +7176,23 @@
           "version": "1.1.0",
           "from": "uppercamelcase@1.1.0",
           "resolved": "https://registry.npmjs.org/uppercamelcase/-/uppercamelcase-1.1.0.tgz"
+        },
+        "url": {
+          "version": "0.10.3",
+          "from": "url@0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "from": "punycode@1.3.2",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            }
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "from": "user-home@1.1.1",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
         },
         "util": {
           "version": "0.10.3",
@@ -6989,6 +7229,11 @@
           "from": "verror@1.3.6",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
         },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "from": "vm-browserify@0.0.4",
+          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+        },
         "walk": {
           "version": "2.3.4",
           "from": "walk@2.3.4",
@@ -6998,6 +7243,11 @@
           "version": "2.1.0",
           "from": "warning@2.1.0",
           "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz"
+        },
+        "watchpack": {
+          "version": "0.2.9",
+          "from": "watchpack@0.2.9",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz"
         },
         "webpack": {
           "version": "1.12.15",
@@ -7009,256 +7259,35 @@
               "from": "async@1.5.2",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             },
-            "clone": {
-              "version": "1.0.2",
-              "from": "clone@1.0.2"
-            },
-            "enhanced-resolve": {
-              "version": "0.9.1",
-              "from": "enhanced-resolve@0.9.1",
-              "dependencies": {
-                "memory-fs": {
-                  "version": "0.2.0",
-                  "from": "memory-fs@>=0.2.0 <0.3.0"
-                }
-              }
-            },
             "esprima": {
               "version": "2.7.2",
               "from": "esprima@2.7.2"
-            },
-            "interpret": {
-              "version": "0.6.6",
-              "from": "interpret@0.6.6"
-            },
-            "memory-fs": {
-              "version": "0.3.0",
-              "from": "memory-fs@0.3.0",
-              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
-              "dependencies": {
-                "errno": {
-                  "version": "0.1.4",
-                  "from": "errno@0.1.4",
-                  "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-                  "dependencies": {
-                    "prr": {
-                      "version": "0.0.0",
-                      "from": "prr@0.0.0",
-                      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "node-libs-browser": {
-              "version": "0.5.3",
-              "from": "node-libs-browser@0.5.3",
-              "dependencies": {
-                "assert": {
-                  "version": "1.3.0",
-                  "from": "assert@1.3.0"
-                },
-                "browserify-zlib": {
-                  "version": "0.1.4",
-                  "from": "browserify-zlib@0.1.4",
-                  "dependencies": {
-                    "pako": {
-                      "version": "0.2.8",
-                      "from": "pako@0.2.8"
-                    }
-                  }
-                },
-                "buffer": {
-                  "version": "3.6.0",
-                  "from": "buffer@3.6.0",
-                  "dependencies": {
-                    "base64-js": {
-                      "version": "0.0.8",
-                      "from": "base64-js@0.0.8"
-                    },
-                    "ieee754": {
-                      "version": "1.1.6",
-                      "from": "ieee754@1.1.6"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    }
-                  }
-                },
-                "console-browserify": {
-                  "version": "1.1.0",
-                  "from": "console-browserify@1.1.0",
-                  "dependencies": {
-                    "date-now": {
-                      "version": "0.1.4",
-                      "from": "date-now@0.1.4"
-                    }
-                  }
-                },
-                "constants-browserify": {
-                  "version": "0.0.1",
-                  "from": "constants-browserify@0.0.1"
-                },
-                "crypto-browserify": {
-                  "version": "3.2.8",
-                  "from": "crypto-browserify@3.2.8",
-                  "dependencies": {
-                    "pbkdf2-compat": {
-                      "version": "2.0.1",
-                      "from": "pbkdf2-compat@2.0.1"
-                    },
-                    "ripemd160": {
-                      "version": "0.2.0",
-                      "from": "ripemd160@0.2.0"
-                    },
-                    "sha.js": {
-                      "version": "2.2.6",
-                      "from": "sha.js@2.2.6"
-                    }
-                  }
-                },
-                "domain-browser": {
-                  "version": "1.1.7",
-                  "from": "domain-browser@1.1.7"
-                },
-                "http-browserify": {
-                  "version": "1.7.0",
-                  "from": "http-browserify@1.7.0",
-                  "dependencies": {
-                    "Base64": {
-                      "version": "0.2.1",
-                      "from": "Base64@0.2.1"
-                    }
-                  }
-                },
-                "https-browserify": {
-                  "version": "0.0.0",
-                  "from": "https-browserify@0.0.0"
-                },
-                "os-browserify": {
-                  "version": "0.1.2",
-                  "from": "os-browserify@0.1.2"
-                },
-                "path-browserify": {
-                  "version": "0.0.0",
-                  "from": "path-browserify@0.0.0"
-                },
-                "process": {
-                  "version": "0.11.2",
-                  "from": "process@0.11.2"
-                },
-                "punycode": {
-                  "version": "1.4.1",
-                  "from": "punycode@1.4.1"
-                },
-                "querystring-es3": {
-                  "version": "0.2.1",
-                  "from": "querystring-es3@0.2.1"
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-                },
-                "stream-browserify": {
-                  "version": "1.0.0",
-                  "from": "stream-browserify@1.0.0",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "from": "readable-stream@1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-                    }
-                  }
-                },
-                "timers-browserify": {
-                  "version": "1.4.2",
-                  "from": "timers-browserify@1.4.2"
-                },
-                "tty-browserify": {
-                  "version": "0.0.0",
-                  "from": "tty-browserify@0.0.0"
-                },
-                "url": {
-                  "version": "0.10.3",
-                  "from": "url@0.10.3",
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.3.2",
-                      "from": "punycode@1.3.2",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                    },
-                    "querystring": {
-                      "version": "0.2.0",
-                      "from": "querystring@0.2.0"
-                    }
-                  }
-                },
-                "vm-browserify": {
-                  "version": "0.0.4",
-                  "from": "vm-browserify@0.0.4"
-                }
-              }
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "from": "optimist@0.6.1",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10",
-                  "from": "minimist@0.0.10",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "3.1.2",
-              "from": "supports-color@3.1.2",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "from": "has-flag@1.0.0"
-                }
-              }
-            },
-            "tapable": {
-              "version": "0.1.10",
-              "from": "tapable@0.1.10"
-            },
-            "watchpack": {
-              "version": "0.2.9",
-              "from": "watchpack@0.2.9",
-              "dependencies": {
-                "async": {
-                  "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-                }
-              }
-            },
-            "webpack-core": {
-              "version": "0.6.8",
-              "from": "webpack-core@0.6.8",
-              "dependencies": {
-                "source-list-map": {
-                  "version": "0.1.6",
-                  "from": "source-list-map@0.1.6"
-                },
-                "source-map": {
-                  "version": "0.4.4",
-                  "from": "source-map@0.4.4",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
-                }
-              }
+            }
+          }
+        },
+        "webpack-core": {
+          "version": "0.6.8",
+          "from": "webpack-core@0.6.8",
+          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
             }
           }
         },
         "webpack-dev-middleware": {
           "version": "1.2.0",
           "from": "webpack-dev-middleware@1.2.0",
-          "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.2.0.tgz",
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.2.0",
+              "from": "memory-fs@0.2.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+            }
+          }
         },
         "whatwg-fetch": {
           "version": "0.9.0",
@@ -7266,9 +7295,9 @@
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
         },
         "which": {
-          "version": "1.2.4",
-          "from": "which@1.2.4",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz"
+          "version": "1.2.8",
+          "from": "which@1.2.8",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.8.tgz"
         },
         "window-size": {
           "version": "0.1.4",
@@ -7291,36 +7320,34 @@
           "resolved": "https://registry.npmjs.org/wp-error/-/wp-error-1.2.0.tgz"
         },
         "wpcom": {
-          "version": "4.9.7",
-          "from": "wpcom@4.9.7",
-          "resolved": "https://registry.npmjs.org/wpcom/-/wpcom-4.9.7.tgz",
+          "version": "4.9.12",
+          "from": "wpcom@4.9.12",
+          "resolved": "https://registry.npmjs.org/wpcom/-/wpcom-4.9.12.tgz",
           "dependencies": {
             "babel": {
               "version": "5.8.38",
               "from": "babel@5.8.38",
-              "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.38.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "2.9.0",
-                  "from": "commander@2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-                },
-                "glob": {
-                  "version": "5.0.15",
-                  "from": "glob@5.0.15",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-                },
-                "lodash": {
-                  "version": "3.10.1",
-                  "from": "lodash@3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "source-map": {
-                  "version": "0.5.3",
-                  "from": "source-map@0.5.3",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.38.tgz"
+            },
+            "commander": {
+              "version": "2.9.0",
+              "from": "commander@2.9.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "from": "glob@5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "from": "lodash@3.10.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "from": "source-map@0.5.6",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
             }
           }
         },
@@ -7345,9 +7372,9 @@
           "resolved": "https://registry.npmjs.org/xgettext-js/-/xgettext-js-0.3.0.tgz",
           "dependencies": {
             "acorn": {
-              "version": "3.0.4",
-              "from": "acorn@3.0.4",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.0.4.tgz"
+              "version": "3.1.0",
+              "from": "acorn@3.1.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.1.0.tgz"
             },
             "lodash": {
               "version": "2.4.2",
@@ -7421,6 +7448,18 @@
       "version": "3.32.0",
       "from": "yargs@>=3.32.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
+    },
+    "zip-stream": {
+      "version": "1.0.0",
+      "from": "zip-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.0.0.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.12.0",
+          "from": "lodash@>=4.8.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This PR seeks to replace the existing inline save/error notices and add global notices instead. It re-uses the Calypso `GlobalNotices` component and the associated state tree (reducer/actions). In order to get that to work properly, this PR also introduces some changes to the i18n boot/mixin system so that it works with `this.translate` in Calypso components properly.

Success:

![image](https://cloud.githubusercontent.com/assets/260253/15450331/26433e72-1f4d-11e6-8337-7a7710e0ff3f.png)

Error:

![image](https://cloud.githubusercontent.com/assets/260253/15450350/a42b0860-1f4d-11e6-92ad-8395dee1b102.png)

In addition, this PR upgrades Calypso and all its sub-dependencies to their latest versions, by upgrading our `npm-shrinkwrap.json`


To test:

* Option one is to just run `npm install`, in theory npm should do a good job of just upgrading what it needs to. Option two is to delete the `node_modules` folder and `npm cache clean && npm install`.
* Checkout this PR
* Ensure everything compiles as expected with `npm start` and `npm run dist`
* Ensure tests pass for `npm test`
* Save the USPS form with different conditions generating error and success states
* Ensure that notices are generated as expected
* Success notices should disappear after 2250ms
* Error notices persist for 7s. I chose this semi-arbitrarily, so definitely welcome to change this up.

cc @kellychoffman for a design review (there's definitely a few small css tweaks to be made here)

cc @nabsul @allendav @jeffstieler 

 Fixes #322