### PR TITLE
Fix "add package" modal state issues. 

### DIFF
--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -77,12 +77,12 @@ const useDefaultField = ( value, updatePackagesField ) => {
 	updatePackagesField( {
 		index: null,
 		is_letter: 'envelope' === value,
-		name: '',
+		name: null,
 		is_user_defined: true,
-		outer_dimensions: '',
-		inner_dimensions: '',
-		box_weight: '',
-		max_weight: '',
+		outer_dimensions: null,
+		inner_dimensions: null,
+		box_weight: null,
+		max_weight: null,
 	} );
 };
 

--- a/client/state/form/packages/reducer.js
+++ b/client/state/form/packages/reducer.js
@@ -59,8 +59,11 @@ reducers[SAVE_PACKAGE] = ( state ) => {
 	return Object.assign( {}, state, {
 		showModal: false,
 		mode: 'add',
-		packageData: {},
+		packageData: {
+			is_user_defined: true,
+		},
 		showOuterDimensions: false,
+		selectedPreset: null,
 	} );
 };
 

--- a/client/state/form/packages/test/reducer.js
+++ b/client/state/form/packages/test/reducer.js
@@ -7,6 +7,7 @@ import {
 	setSelectedPreset,
 	updatePackagesField,
 	toggleOuterDimensions,
+	savePackage,
 } from '../actions';
 
 const initialState = {
@@ -144,6 +145,32 @@ describe( 'Packages form reducer', () => {
 		expect( state ).to.eql( {
 			showModal: true,
 			showOuterDimensions: true,
+		} );
+	} );
+
+	it( 'SAVE_PACKAGE', () => {
+		const packageData = {
+			is_user_defined: true,
+			index: 1,
+			name: 'Test Box',
+		};
+		const initialSavePackageState = {
+			showModal: true,
+			mode: 'edit',
+			packageData,
+			showOuterDimensions: false,
+		};
+		const action = savePackage( 'boxes', packageData );
+		const state = reducer( initialSavePackageState, action );
+
+		expect( state ).to.eql( {
+			showModal: false,
+			mode: 'add',
+			packageData: {
+				is_user_defined: true,
+			},
+			showOuterDimensions: false,
+			selectedPreset: null,
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #325 and #346.

To test:
_#325_
* Click "add package" to open modal
* Toggle package type to "envelope"
* Toggle package type back to "box"
* Fill all fields *except for outer dimensions*
* Click "add package" to save new package
* Click "save changes"
* Verify that no errors are returned for `outer_dimensions`

_#346_
* Click "add package" to open modal
* Choose a preset package
* Click "add package" to save new package
* Click "add package" to open modal again
* Verify that the default "box" is selected as type, all fields are empty an *not* read only