### PR TITLE
Update webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "cross-env NODE_ENV=development webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
     "dist": "cross-env NODE_ENV=production webpack -p --config webpack.production.config.js",
     "eslint": "eslint tasks/ client/",
-    "test": "mocha-webpack --webpack-config webpack.test.config.js client/**/test/*.js && npm run eslint",
+    "test": "mocha-webpack --webpack-config webpack.test.config.js client/**/test/*.js",
     "release": "node tasks/release.js"
   },
   "repository": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 const webpack = require( 'webpack' ),
 	path = require( 'path' ),
-	ExtractTextPlugin = require( 'extract-text-webpack-plugin' ),
-	nodeExternals = require( 'webpack-node-externals' );
+	ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 
 const babelSettings = {
 	cacheDirectory: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
-const webpack = require( 'webpack' ),
-	path = require( 'path' ),
-	ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
+const webpack = require( 'webpack' );
+const path = require( 'path' );
+const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 
 const babelSettings = {
 	cacheDirectory: true,

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -1,65 +1,12 @@
-var webpack = require( 'webpack' ),
-	path = require( 'path' ),
-	nodeExternals = require( 'webpack-node-externals' );
+const webpack = require( 'webpack' );
+const path = require( 'path' );
+const nodeExternals = require( 'webpack-node-externals' );
+const webpackBaseConfig = require( './webpack.config' );
 
-module.exports = {
-	cache: true,
-	module: {
-		loaders: [
-			{
-				test: /\.json$/,
-				loader: 'json-loader'
-			},
-			{
-				test: /\.html$/,
-				loader: 'html-loader'
-			},
-			{
-				test: /\.scss$/,
-				loader: 'noop-loader',
-			},
-			{
-				test: /\.jsx?$/,
-				loader: 'babel-loader',
-				query: {
-					cacheDirectory: true,
-					presets: [
-						'es2015',
-						'stage-1',
-						'react'
-					],
-					plugins: [
-						"add-module-exports",
-					],
-					babelrc: false,
-				}
-			}
-		]
-	},
-	resolve: {
-		alias: {
-			'react': path.join( __dirname, 'node_modules', 'react' ),
-			'react-dom': path.join( __dirname, 'node_modules', 'react-dom' ),
-			'redux': path.join( __dirname, 'node_modules', 'redux' ),
-			'lib/mixins/i18n': path.join( __dirname, 'client', 'lib', 'mixins', 'i18n' )
-		},
-		extensions: [ '', '.json', '.js', '.jsx' ],
-		root: [
-			path.join( __dirname, 'client' ),
-			path.join( __dirname, 'node_modules' ),
-			path.join( __dirname, 'node_modules', 'wp-calypso', 'client' )
-		],
-		fallback: [
-			path.join( __dirname, 'node_modules', 'wp-calypso', 'node_modules' )
-		]
-	},
-	resolveLoader: {
-		modulesDirectories: [ __dirname + '/node_modules' ]
-	},
-	target: 'node',
-	externals: [
-		nodeExternals( {
-			whitelist: [ 'wp-calypso' ]
-		} )
-	]
-};
+const webpackTestConfig = Object.assign( {}, webpackBaseConfig, {
+	externals: nodeExternals( {
+		whitelist: [ 'wp-calypso' ],
+	} ),
+} );
+
+module.exports = webpackTestConfig;


### PR DESCRIPTION
This PR seeks to simplify the test webpack config so that it inherits from the main one instead and adds the only required change (node externals) by extending that base config. This helps us reduce duplication and make future maintenance easier.

In addition, this PR:

* Remove `npm run lint` from `npm test` command since webpack runs the linter already
* Remove nodeExternals require from base webpack config. It wasn't used.

To test:

* Make sure tests pass `npm run test`
* Make sure things compile correctly `npm start` and `npm run dist`

Fixes #278