### PR TITLE
Add unit measurements for the L x W x H label displayed in modal

### DIFF
--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -8,6 +8,7 @@ import FormButton from 'components/forms/form-button';
 import Dialog from 'components/dialog';
 import AddPackagePresets from './add-package-presets';
 import { translate as __ } from 'lib/mixins/i18n';
+import { sprintf } from 'sprintf-js';
 
 const getDialogButtons = ( mode, dismissModal, savePackage, packageData ) => {
 	return [
@@ -52,7 +53,7 @@ const updateFormTextField = ( event, updatePackagesField ) => {
 const renderOuterDimensions = ( showOuterDimensions, dimensionUnit, packageData, value, updatePackagesField, is_user_defined ) => {
 	return ( showOuterDimensions || packageData.outer_dimensions ) ? (
 		<FormFieldset>
-			<FormLabel>{ __( 'Outer Dimensions (L x W x H)' + ' ' + dimensionUnit ) }</FormLabel>
+			<FormLabel>{ sprintf( __( 'Outer Dimensions (L x W x H) %s' ), dimensionUnit ) }</FormLabel>
 			<FormTextInput
 				name="outer_dimensions"
 				placeholder={ exampleDimensions( 100.25, 25.25, 5.75 ) }
@@ -139,7 +140,7 @@ const AddPackageDialog = ( props ) => {
 				/>
 			</FormFieldset>
 			<FormFieldset>
-				<FormLabel>{ __( 'Inner Dimensions (L x W x H)' ) + ' ' + dimensionUnit }</FormLabel>
+				<FormLabel>{ sprintf( __( 'Inner Dimensions (L x W x H) %s' ), dimensionUnit ) }</FormLabel>
 				<FormTextInput
 					name="inner_dimensions"
 					placeholder={ exampleDimensions( 100, 25, 5.5 ) }

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -49,10 +49,10 @@ const updateFormTextField = ( event, updatePackagesField ) => {
 	updatePackagesField( { [name]: value } );
 };
 
-const renderOuterDimensions = ( showOuterDimensions, packageData, value, updatePackagesField, is_user_defined ) => {
+const renderOuterDimensions = ( showOuterDimensions, dimensionUnit, packageData, value, updatePackagesField, is_user_defined ) => {
 	return ( showOuterDimensions || packageData.outer_dimensions ) ? (
 		<FormFieldset>
-			<FormLabel>{ __( 'Outer Dimensions (L x W x H)' ) }</FormLabel>
+			<FormLabel>{ __( 'Outer Dimensions (L x W x H)' + ' ' + dimensionUnit ) }</FormLabel>
 			<FormTextInput
 				name="outer_dimensions"
 				placeholder={ exampleDimensions( 100.25, 25.25, 5.75 ) }
@@ -92,6 +92,7 @@ const AddPackageDialog = ( props ) => {
 		dismissModal,
 		mode,
 		presets,
+		dimensionUnit,
 		weightUnit,
 		packageData,
 		showOuterDimensions,
@@ -138,7 +139,7 @@ const AddPackageDialog = ( props ) => {
 				/>
 			</FormFieldset>
 			<FormFieldset>
-				<FormLabel>{ __( 'Inner Dimensions (L x W x H)' ) }</FormLabel>
+				<FormLabel>{ __( 'Inner Dimensions (L x W x H)' ) + ' ' + dimensionUnit }</FormLabel>
 				<FormTextInput
 					name="inner_dimensions"
 					placeholder={ exampleDimensions( 100, 25, 5.5 ) }
@@ -149,7 +150,7 @@ const AddPackageDialog = ( props ) => {
 				/>
 				{ renderOuterDimensionsToggle( showOuterDimensions, packageData, toggleOuterDimensions ) }
 			</FormFieldset>
-			{ renderOuterDimensions( showOuterDimensions, packageData, outer_dimensions, updatePackagesField, is_user_defined ) }
+			{ renderOuterDimensions( showOuterDimensions, dimensionUnit, packageData, outer_dimensions, updatePackagesField, is_user_defined ) }
 			<FormFieldset className="wcc-shipping-add-package-weight-group">
 				<div className="wcc-shipping-add-package-weight">
 					<FormLabel htmlFor="box_weight">{ __( 'Package weight' ) }</FormLabel>
@@ -187,6 +188,7 @@ const AddPackageDialog = ( props ) => {
 AddPackageDialog.propTypes = {
 	dismissModal: PropTypes.func.isRequired,
 	presets: PropTypes.object,
+	dimensionUnit: PropTypes.string.isRequired,
 	weightUnit: PropTypes.string.isRequired,
 	mode: PropTypes.string.isRequired,
 	updatePackagesField: PropTypes.func.isRequired,


### PR DESCRIPTION
closes #311 

Adds the dimension unit at the end of (LxWxH) in the add-package modal.

To test: Open the modal. 

@kellychoffman @allendav @jkudish @jeffstieler 

