### PR TITLE
Allow non-float values to be entered into service adjustment inputs.

### DIFF
--- a/client/components/shipping/services/entry.js
+++ b/client/components/shipping/services/entry.js
@@ -64,7 +64,7 @@ ShippingServiceEntry.propTypes = {
 	adjustment: PropTypes.oneOfType( [
 		PropTypes.string,
 		PropTypes.number,
-	] ).isRequired,
+	] ),
 	adjustment_type: PropTypes.string.isRequired,
 	currencySymbol: PropTypes.string.isRequired,
 	updateValue: PropTypes.func.isRequired,

--- a/client/components/shipping/services/entry.js
+++ b/client/components/shipping/services/entry.js
@@ -28,9 +28,20 @@ const ShippingServiceEntry = ( {
 				disabled={ ! enabled }
 				value={ adjustment }
 				onChange={ ( event ) => {
-					const value = event.target.value ? event.target.value : 0;
-					if ( ! isNaN( value ) ) {
-						updateValue( 'adjustment', Number.parseFloat( value ) );
+					const value = event.target.value || null;
+					const floatValue = Number.parseFloat( value );
+
+					/*
+					 * If the adjustment value isn't a valid float, or ends in a non-integer, pass
+					 * the value through unmodified and let the schema validation catch it.
+					 *
+					 * If the adjustment *is* a valid float, update the settings value with the
+					 * parsed version so it doesn't fail schema validation.
+					 */
+					if ( isNaN( floatValue ) || value.match( /.*[^\d]$/ ) ) {
+						updateValue( 'adjustment', value );
+					} else {
+						updateValue( 'adjustment', floatValue );
 					}
 				} }
 				isError={ hasError }

--- a/client/components/shipping/services/entry.js
+++ b/client/components/shipping/services/entry.js
@@ -61,7 +61,10 @@ const ShippingServiceEntry = ( {
 ShippingServiceEntry.propTypes = {
 	enabled: PropTypes.bool.isRequired,
 	title: PropTypes.string.isRequired,
-	adjustment: PropTypes.number.isRequired,
+	adjustment: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.number,
+	] ).isRequired,
 	adjustment_type: PropTypes.string.isRequired,
 	currencySymbol: PropTypes.string.isRequired,
 	updateValue: PropTypes.func.isRequired,

--- a/client/components/shipping/services/group.js
+++ b/client/components/shipping/services/group.js
@@ -67,7 +67,10 @@ ShippingServiceGroup.propTypes = {
 		id: PropTypes.string.isRequired,
 		name: PropTypes.string.isRequired,
 		enabled: PropTypes.bool,
-		adjustment: PropTypes.number,
+		adjustment: PropTypes.oneOfType( [
+			PropTypes.string,
+			PropTypes.number,
+		] ),
 		adjustment_type: PropTypes.string,
 	} ) ).isRequired,
 	currencySymbol: PropTypes.string.isRequired,


### PR DESCRIPTION
This provides a more natural experience to a user that might be typing a decimal number, or who accidentally enters a non-digit character.

Fixes #188.

**Note: test with a USPS instance, there is currently a bug with Canada Post showing errors on service fields.**

To test:
* Enter the value `a` into a service adjustment input
* Verify that the input is marked with an error icon, and the "save changes" button is disabled
* Clear the input
* Verify that the input is marked with an error icon, and the "save changes" button is disabled
* Enter `1`
* Verify that the input is **not** marked with an error icon, and the "save changes" button is **enabled**
* Enter `1.`
* Verify that the input is marked with an error icon, and the "save changes" button is disabled
* Enter `1.1`
* Verify that the input is **not** marked with an error icon, and the "save changes" button is **enabled**