### PR TITLE
Add validation inside the add/edit packages Modal

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -96,6 +96,14 @@
         }
     }
 
+    .form-input-validation {
+        padding: 4px 0 4px 32px;
+        .gridicon {
+            float: none;
+            vertical-align: middle;
+        }
+    }
+
     // Cards
     .card.is-compact {
         &.settings-group-card {

--- a/client/components/shipping/packages/add-package-presets.js
+++ b/client/components/shipping/packages/add-package-presets.js
@@ -49,7 +49,31 @@ const handleSelectEvent = ( e, selectDefault, selectPreset, setSelectedPreset ) 
 	}
 };
 
-const AddPackagePresets = ( { selectedPreset, setSelectedPreset, presets, onSelectDefault, onSelectPreset } ) => {
+const AddPackagePresets = ( { selectedPreset, setSelectedPreset, presets, setModalErrors, updatePackagesField } ) => {
+	const onSelectPreset = ( idx ) => {
+		const preset = presets.boxes[idx];
+		setModalErrors( {} );
+		updatePackagesField( {
+			index: null,
+			is_user_defined: false,
+			...preset,
+		} );
+	};
+
+	const onSelectDefault = ( value ) => {
+		setModalErrors( {} );
+		updatePackagesField( {
+			index: null,
+			is_letter: 'envelope' === value,
+			name: null,
+			is_user_defined: true,
+			outer_dimensions: null,
+			inner_dimensions: null,
+			box_weight: null,
+			max_weight: null,
+		} );
+	};
+
 	return (
 		<FormFieldset>
 			<FormLabel htmlFor="package_type">Type of package</FormLabel>
@@ -67,8 +91,8 @@ AddPackagePresets.propTypes = {
 	selectedPreset: PropTypes.string,
 	setSelectedPreset: PropTypes.func.isRequired,
 	presets: PropTypes.object,
-	onSelectDefault: PropTypes.func.isRequired,
-	onSelectPreset: PropTypes.func.isRequired,
+	setModalErrors: PropTypes.func.isRequired,
+	updatePackagesField: PropTypes.func.isRequired,
 };
 
 export default AddPackagePresets;

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -3,6 +3,7 @@ import FormSectionHeading from 'components/forms/form-section-heading';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
+import FormInputValidation from 'components/forms/form-input-validation';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormButton from 'components/forms/form-button';
 import Dialog from 'components/dialog';
@@ -10,9 +11,9 @@ import AddPackagePresets from './add-package-presets';
 import { translate as __ } from 'lib/mixins/i18n';
 import { sprintf } from 'sprintf-js';
 
-const getDialogButtons = ( mode, dismissModal, savePackage, packageData ) => {
+const getDialogButtons = ( mode, dismissModal, savePackage, packageData, error ) => {
 	return [
-		<FormButton onClick={ () => savePackage( packageData ) }>
+		<FormButton onClick={ () => savePackage( packageData ) } disabled={ error }>
 			{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }
 		</FormButton>,
 		<FormButton onClick={ () => dismissModal() } isPrimary={ false }>
@@ -113,12 +114,14 @@ const AddPackageDialog = ( props ) => {
 		is_user_defined,
 	} = packageData;
 
+	const nameError = '' === name ? 'Name cannot be empty' : null;
+
 	return (
 		<Dialog
 			isVisible={ showModal }
 			additionalClassNames="wcc-modal wcc-shipping-add-edit-package-dialog"
 			onClose={ dismissModal }
-			buttons={ getDialogButtons( mode, dismissModal, savePackage, packageData ) }>
+			buttons={ getDialogButtons( mode, dismissModal, savePackage, packageData, nameError ) }>
 			<FormSectionHeading>{ ( 'edit' === mode ) ? __( 'Edit package' ) : __( 'Add a package' ) }</FormSectionHeading>
 			{ ( 'add' === mode ) ? (
 				<AddPackagePresets
@@ -137,7 +140,9 @@ const AddPackageDialog = ( props ) => {
 					placeholder={ __( 'The customer will see this during checkout' ) }
 					value={ name }
 					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
+					isError={ nameError }
 				/>
+				{ nameError ? <FormInputValidation isError text={ nameError } /> : '' }
 			</FormFieldset>
 			<FormFieldset>
 				<FormLabel>{ sprintf( __( 'Inner Dimensions (L x W x H) %s' ), dimensionUnit ) }</FormLabel>

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -12,6 +12,7 @@ import { translate as __ } from 'lib/mixins/i18n';
 import { sprintf } from 'sprintf-js';
 import modalErrors from './modal-errors';
 import difference from 'lodash/difference';
+import trim from 'lodash/trim';
 
 const getDialogButtons = ( mode, dismissModal, savePackage, packageData, error ) => {
 	return [
@@ -53,6 +54,12 @@ const updateFormTextField = ( event, updatePackagesField ) => {
 	updatePackagesField( { [name]: value } );
 };
 
+const FieldInfo = ( { isError, text } ) => {
+	return isError
+		? <FormInputValidation isError text={ text } />
+		: <FormInputValidation icon="info" text={ text } />;
+};
+
 const renderOuterDimensions = ( showOuterDimensions, dimensionUnit, packageData, value, updatePackagesField, is_user_defined, error ) => {
 	return ( showOuterDimensions || packageData.outer_dimensions ) ? (
 		<FormFieldset>
@@ -66,6 +73,7 @@ const renderOuterDimensions = ( showOuterDimensions, dimensionUnit, packageData,
 				disabled={ ! is_user_defined }
 				isError={ error }
 			/>
+			<FieldInfo isError={ error } text="Outer dimensions of the box are required" />
 		</FormFieldset>
 	) : null;
 };
@@ -122,6 +130,9 @@ const AddPackageDialog = ( props ) => {
 	const editName = packageData.index ? packages[packageData.index].name : null;
 	const boxNames = difference( packages.map( ( boxPackage ) => boxPackage.name ), [editName] );
 	const errors = modalErrors( packageData, boxNames, schema.items );
+	const nameFieldText = 0 < trim( packageData.name ).length && errors.name
+		? 'This package name must be unique'
+		: 'This field is required';
 
 	return (
 		<Dialog
@@ -149,7 +160,7 @@ const AddPackageDialog = ( props ) => {
 					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 					isError={ errors.name }
 				/>
-				{ errors.name ? <FormInputValidation isError text={ errors.name } /> : '' }
+				<FieldInfo isError={ errors.name } text={ nameFieldText } />
 			</FormFieldset>
 			<FormFieldset>
 				<FormLabel>{ sprintf( __( 'Inner Dimensions (L x W x H) %s' ), dimensionUnit ) }</FormLabel>
@@ -162,6 +173,7 @@ const AddPackageDialog = ( props ) => {
 					disabled={ ! is_user_defined }
 					isError={ errors.inner_dimensions }
 				/>
+				<FieldInfo isError={ errors.inner_dimensions } text="Inner dimensions of the box are required" />
 				{ renderOuterDimensionsToggle( showOuterDimensions, packageData, toggleOuterDimensions ) }
 			</FormFieldset>
 			{ renderOuterDimensions( showOuterDimensions, dimensionUnit, packageData, outer_dimensions, updatePackagesField, is_user_defined, errors.outer_dimensions ) }
@@ -178,6 +190,7 @@ const AddPackageDialog = ( props ) => {
 						disabled={ ! is_user_defined }
 						isError={ errors.box_weight }
 					/>
+					<FieldInfo isError={ errors.box_weight } text="This field is required" />
 				</div>
 				<div className="wcc-shipping-add-package-weight">
 					<FormLabel htmlFor="max_weight">{ __( 'Max weight' ) }</FormLabel>
@@ -192,6 +205,7 @@ const AddPackageDialog = ( props ) => {
 						isError={ errors.max_weight }
 					/>
 					<span className="wcc-shipping-add-package-weight-unit">{ weightUnit }</span>
+					<FieldInfo isError={ errors.max_weight } text="This field is required" />
 				</div>
 				<FormSettingExplanation>
 					{ __( 'Defines both the weight of the empty box and the max weight it can hold' ) }

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -13,7 +13,7 @@ import { sprintf } from 'sprintf-js';
 
 const getDialogButtons = ( mode, dismissModal, savePackage, packageData, error ) => {
 	return [
-		<FormButton onClick={ () => savePackage( packageData ) } disabled={ error }>
+		<FormButton onClick={ () => savePackage( packageData ) } disabled={ ! ! error }>
 			{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }
 		</FormButton>,
 		<FormButton onClick={ () => dismissModal() } isPrimary={ false }>

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -165,11 +165,12 @@ const AddPackageDialog = ( props ) => {
 	const onSave = () => {
 		errors = modalErrors( packageData, boxNames, schema.items );
 		if ( errors.any ) {
+			updatePackagesField( newPackage );
 			setModalError( true );
 			return;
 		}
 
-		savePackage( packageData );
+		savePackage( newPackage );
 	};
 
 	return (

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -106,6 +106,7 @@ const AddPackageDialog = ( props ) => {
 		selectedPreset,
 		setSelectedPreset,
 		packages,
+		schema,
 	} = props;
 
 	const {
@@ -118,7 +119,7 @@ const AddPackageDialog = ( props ) => {
 	} = packageData;
 
 	const boxNames = packages.map( ( boxPackage ) => boxPackage.name );
-	const errors = modalErrors( packageData, boxNames );
+	const errors = modalErrors( packageData, boxNames, schema.items );
 
 	return (
 		<Dialog
@@ -212,6 +213,7 @@ AddPackageDialog.propTypes = {
 	setSelectedPreset: PropTypes.func.isRequired,
 	selectedPreset: PropTypes.string,
 	packages: PropTypes.array.isRequired,
+	schema: PropTypes.object.isRequired,
 };
 
 AddPackageDialog.defaultProps = {

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -75,6 +75,7 @@ const AddPackageDialog = ( props ) => {
 		const editName = 'number' === typeof packageData.index ? packages[packageData.index].name : null;
 		const boxNames = difference( packages.map( ( boxPackage ) => boxPackage.name ), [editName] );
 		const filteredPackageData = Object.assign( {}, packageData, {
+			name: inputFilters.string( packageData.name ),
 			inner_dimensions: inputFilters.dimensions( packageData.inner_dimensions ),
 			outer_dimensions: inputFilters.dimensions( packageData.outer_dimensions ),
 			box_weight: inputFilters.number( packageData.box_weight ),

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -52,7 +52,7 @@ const updateFormTextField = ( event, updatePackagesField ) => {
 	updatePackagesField( { [name]: value } );
 };
 
-const renderOuterDimensions = ( showOuterDimensions, dimensionUnit, packageData, value, updatePackagesField, is_user_defined ) => {
+const renderOuterDimensions = ( showOuterDimensions, dimensionUnit, packageData, value, updatePackagesField, is_user_defined, error ) => {
 	return ( showOuterDimensions || packageData.outer_dimensions ) ? (
 		<FormFieldset>
 			<FormLabel>{ sprintf( __( 'Outer Dimensions (L x W x H) %s' ), dimensionUnit ) }</FormLabel>
@@ -63,6 +63,7 @@ const renderOuterDimensions = ( showOuterDimensions, dimensionUnit, packageData,
 				className={ is_user_defined ? '' : 'flat-rate-package__outer-dimensions__read-only' }
 				onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 				disabled={ ! is_user_defined }
+				isError={ error }
 			/>
 		</FormFieldset>
 	) : null;
@@ -156,10 +157,11 @@ const AddPackageDialog = ( props ) => {
 					className={ is_user_defined ? '' : 'flat-rate-package__inner-dimensions__read-only' }
 					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 					disabled={ ! is_user_defined }
+					isError={ errors.inner_dimensions }
 				/>
 				{ renderOuterDimensionsToggle( showOuterDimensions, packageData, toggleOuterDimensions ) }
 			</FormFieldset>
-			{ renderOuterDimensions( showOuterDimensions, dimensionUnit, packageData, outer_dimensions, updatePackagesField, is_user_defined ) }
+			{ renderOuterDimensions( showOuterDimensions, dimensionUnit, packageData, outer_dimensions, updatePackagesField, is_user_defined, errors.outer_dimensions ) }
 			<FormFieldset className="wcc-shipping-add-package-weight-group">
 				<div className="wcc-shipping-add-package-weight">
 					<FormLabel htmlFor="box_weight">{ __( 'Package weight' ) }</FormLabel>

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -139,27 +139,27 @@ const AddPackageDialog = ( props ) => {
 		is_user_defined,
 	} = packageData;
 
+	const filteredPackageData = Object.assign( {}, packageData, {
+		inner_dimensions: dimensionStringFilter( packageData.inner_dimensions ),
+		outer_dimensions: dimensionStringFilter( packageData.outer_dimensions ),
+	} );
+
 	const editName = 'number' === typeof packageData.index ? packages[packageData.index].name : null;
 	const boxNames = difference( packages.map( ( boxPackage ) => boxPackage.name ), [editName] );
-	let errors = isModalError ? modalErrors( packageData, boxNames, schema.items ) : {};
+	let errors = isModalError ? modalErrors( filteredPackageData, boxNames, schema.items ) : {};
 	const nameFieldText = errors.name && 0 < trim( packageData.name ).length
 		? __( 'This package name must be unique' )
 		: __( 'This field is required' );
 
 	const onSave = () => {
-		const newPackage = Object.assign( {}, packageData, {
-			inner_dimensions: dimensionStringFilter( packageData.inner_dimensions ),
-			outer_dimensions: dimensionStringFilter( packageData.outer_dimensions ),
-		} );
-
-		errors = modalErrors( newPackage, boxNames, schema.items );
+		errors = modalErrors( filteredPackageData, boxNames, schema.items );
 		if ( errors.any ) {
-			updatePackagesField( newPackage );
+			updatePackagesField( filteredPackageData );
 			setModalError( true );
 			return;
 		}
 
-		savePackage( newPackage );
+		savePackage( filteredPackageData );
 	};
 
 	return (

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -10,10 +10,11 @@ import Dialog from 'components/dialog';
 import AddPackagePresets from './add-package-presets';
 import { translate as __ } from 'lib/mixins/i18n';
 import { sprintf } from 'sprintf-js';
+import modalErrors from './modal-errors';
 
 const getDialogButtons = ( mode, dismissModal, savePackage, packageData, error ) => {
 	return [
-		<FormButton onClick={ () => savePackage( packageData ) } disabled={ ! ! error }>
+		<FormButton onClick={ () => savePackage( packageData ) } disabled={ error }>
 			{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }
 		</FormButton>,
 		<FormButton onClick={ () => dismissModal() } isPrimary={ false }>
@@ -103,6 +104,7 @@ const AddPackageDialog = ( props ) => {
 		updatePackagesField,
 		selectedPreset,
 		setSelectedPreset,
+		packages,
 	} = props;
 
 	const {
@@ -114,14 +116,15 @@ const AddPackageDialog = ( props ) => {
 		is_user_defined,
 	} = packageData;
 
-	const nameError = '' === name ? 'Name cannot be empty' : null;
+	const boxNames = packages.map( ( boxPackage ) => boxPackage.name );
+	const errors = modalErrors( packageData, boxNames );
 
 	return (
 		<Dialog
 			isVisible={ showModal }
 			additionalClassNames="wcc-modal wcc-shipping-add-edit-package-dialog"
 			onClose={ dismissModal }
-			buttons={ getDialogButtons( mode, dismissModal, savePackage, packageData, nameError ) }>
+			buttons={ getDialogButtons( mode, dismissModal, savePackage, packageData, errors.any ) }>
 			<FormSectionHeading>{ ( 'edit' === mode ) ? __( 'Edit package' ) : __( 'Add a package' ) }</FormSectionHeading>
 			{ ( 'add' === mode ) ? (
 				<AddPackagePresets
@@ -140,9 +143,9 @@ const AddPackageDialog = ( props ) => {
 					placeholder={ __( 'The customer will see this during checkout' ) }
 					value={ name }
 					onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
-					isError={ nameError }
+					isError={ errors.name }
 				/>
-				{ nameError ? <FormInputValidation isError text={ nameError } /> : '' }
+				{ errors.name ? <FormInputValidation isError text={ errors.name } /> : '' }
 			</FormFieldset>
 			<FormFieldset>
 				<FormLabel>{ sprintf( __( 'Inner Dimensions (L x W x H) %s' ), dimensionUnit ) }</FormLabel>
@@ -204,6 +207,7 @@ AddPackageDialog.propTypes = {
 	packageData: PropTypes.object,
 	setSelectedPreset: PropTypes.func.isRequired,
 	selectedPreset: PropTypes.string,
+	packages: PropTypes.array.isRequired,
 };
 
 AddPackageDialog.defaultProps = {

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -73,7 +73,7 @@ const renderOuterDimensions = ( showOuterDimensions, dimensionUnit, packageData,
 				disabled={ ! is_user_defined }
 				isError={ error }
 			/>
-			{ fieldInfo( error, 'Outer dimensions of the box are required' ) }
+			{ fieldInfo( error, __( 'Outer dimensions of the box are required' ) ) }
 		</FormFieldset>
 	) : null;
 };
@@ -133,8 +133,8 @@ const AddPackageDialog = ( props ) => {
 	const boxNames = difference( packages.map( ( boxPackage ) => boxPackage.name ), [editName] );
 	let errors = isModalError ? modalErrors( packageData, boxNames, schema.items ) : {};
 	const nameFieldText = errors.name && 0 < trim( packageData.name ).length
-		? 'This package name must be unique'
-		: 'This field is required';
+		? __( 'This package name must be unique' )
+		: __( 'This field is required' );
 
 	const onSave = () => {
 		errors = modalErrors( packageData, boxNames, schema.items );
@@ -185,7 +185,7 @@ const AddPackageDialog = ( props ) => {
 					disabled={ ! is_user_defined }
 					isError={ errors.inner_dimensions }
 				/>
-				{ fieldInfo( errors.inner_dimensions, 'Inner dimensions of the box are required' ) }
+				{ fieldInfo( errors.inner_dimensions, __( 'Inner dimensions of the box are required' ) ) }
 				{ renderOuterDimensionsToggle( showOuterDimensions, packageData, toggleOuterDimensions ) }
 			</FormFieldset>
 			{ renderOuterDimensions( showOuterDimensions, dimensionUnit, packageData, outer_dimensions, updatePackagesField, is_user_defined, errors.outer_dimensions ) }
@@ -202,7 +202,7 @@ const AddPackageDialog = ( props ) => {
 						disabled={ ! is_user_defined }
 						isError={ errors.box_weight }
 					/>
-					{ fieldInfo( errors.box_weight, 'This field is required' ) }
+					{ fieldInfo( errors.box_weight, __( 'This field is required' ) ) }
 				</div>
 				<div className="wcc-shipping-add-package-weight">
 					<FormLabel htmlFor="max_weight">{ __( 'Max weight' ) }</FormLabel>
@@ -217,7 +217,7 @@ const AddPackageDialog = ( props ) => {
 						isError={ errors.max_weight }
 					/>
 					<span className="wcc-shipping-add-package-weight-unit">{ weightUnit }</span>
-					{ fieldInfo( errors.max_weight, 'This field is required' ) }
+					{ fieldInfo( errors.max_weight, __( 'This field is required' ) ) }
 				</div>
 				<FormSettingExplanation>
 					{ __( 'Defines both the weight of the empty box and the max weight it can hold' ) }

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -14,9 +14,9 @@ import modalErrors from './modal-errors';
 import difference from 'lodash/difference';
 import trim from 'lodash/trim';
 
-const getDialogButtons = ( mode, dismissModal, savePackage, error ) => {
+const getDialogButtons = ( mode, dismissModal, savePackage ) => {
 	return [
-		<FormButton onClick={ () => savePackage() } disabled={ error }>
+		<FormButton onClick={ () => savePackage() }>
 			{ ( 'add' === mode ) ? __( 'Add package' ) : __( 'Apply changes' ) }
 		</FormButton>,
 		<FormButton onClick={ () => dismissModal() } isPrimary={ false }>
@@ -99,8 +99,17 @@ const useDefaultField = ( value, updatePackagesField ) => {
 	} );
 };
 
+const incompleteNumberRegex = /^\.\d+$/;
+const filterNumber = ( number ) => {
+	if ( incompleteNumberRegex.test( number ) ) {
+		number = '0' + number;
+	}
+
+	return number;
+};
+
 const dimensionRegex = /^(\S+)\s*x\s*(\S+)\s*x\s*(\S+)$/;
-const dimensionStringFilter = ( dims ) => {
+const filterDimensions = ( dims ) => {
 	const result = dimensionRegex.exec( dims );
 	if ( result ) {
 		return result[1] + ' x ' + result[2] + ' x ' + result[3];
@@ -140,8 +149,10 @@ const AddPackageDialog = ( props ) => {
 	} = packageData;
 
 	const filteredPackageData = Object.assign( {}, packageData, {
-		inner_dimensions: dimensionStringFilter( packageData.inner_dimensions ),
-		outer_dimensions: dimensionStringFilter( packageData.outer_dimensions ),
+		inner_dimensions: filterDimensions( packageData.inner_dimensions ),
+		outer_dimensions: filterDimensions( packageData.outer_dimensions ),
+		box_weight: filterNumber( packageData.box_weight ),
+		max_weight: filterNumber( packageData.max_weight ),
 	} );
 
 	const editName = 'number' === typeof packageData.index ? packages[packageData.index].name : null;

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -27,20 +27,17 @@ const getDialogButtons = ( mode, dismissModal, savePackage ) => {
 	];
 };
 
-const renderOuterDimensionsToggle = ( showOuterDimensions, toggleOuterDimensions ) => {
-	if ( ! showOuterDimensions ) {
-		return (
-			<a
-				href="#"
-				className="form-setting-explanation"
-				onClick={ ( evt ) => {
-					evt.preventDefault();
-					toggleOuterDimensions();
-				} }>
-				{ __( 'View exterior dimensions' ) }
-			</a>
-		);
-	}
+const OuterDimensionsToggle = ( { toggleOuterDimensions } ) => {
+	const onClick = ( evt ) => {
+		evt.preventDefault();
+		toggleOuterDimensions();
+	};
+
+	return (
+		<a href="#" className="form-setting-explanation" onClick={ onClick }>
+			{ __( 'View exterior dimensions' ) }
+		</a>
+	);
 };
 
 const AddPackageDialog = ( props ) => {
@@ -141,7 +138,7 @@ const AddPackageDialog = ( props ) => {
 					isError={ modalErrors.inner_dimensions }
 				/>
 				{ fieldInfo( 'inner_dimensions' ) }
-				{ renderOuterDimensionsToggle( isOuterDimensionsVisible, toggleOuterDimensions ) }
+				{ ! isOuterDimensionsVisible ? <OuterDimensionsToggle { ...{ toggleOuterDimensions } }/> : '' }
 			</FormFieldset>
 			{ isOuterDimensionsVisible
 				? ( <FormFieldset>

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -162,6 +162,16 @@ const AddPackageDialog = ( props ) => {
 		savePackage( filteredPackageData );
 	};
 
+	const onSave = () => {
+		errors = modalErrors( packageData, boxNames, schema.items );
+		if ( errors.any ) {
+			setModalError( true );
+			return;
+		}
+
+		savePackage( packageData );
+	};
+
 	return (
 		<Dialog
 			isVisible={ showModal }

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -11,6 +11,7 @@ import AddPackagePresets from './add-package-presets';
 import { translate as __ } from 'lib/mixins/i18n';
 import { sprintf } from 'sprintf-js';
 import modalErrors from './modal-errors';
+import difference from 'lodash/difference';
 
 const getDialogButtons = ( mode, dismissModal, savePackage, packageData, error ) => {
 	return [
@@ -118,7 +119,8 @@ const AddPackageDialog = ( props ) => {
 		is_user_defined,
 	} = packageData;
 
-	const boxNames = packages.map( ( boxPackage ) => boxPackage.name );
+	const editName = packageData.index ? packages[packageData.index].name : null;
+	const boxNames = difference( packages.map( ( boxPackage ) => boxPackage.name ), [editName] );
 	const errors = modalErrors( packageData, boxNames, schema.items );
 
 	return (

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -173,6 +173,7 @@ const AddPackageDialog = ( props ) => {
 						className={ is_user_defined ? '' : 'flat-rate-package__package-weight__read-only' }
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 						disabled={ ! is_user_defined }
+						isError={ errors.box_weight }
 					/>
 				</div>
 				<div className="wcc-shipping-add-package-weight">
@@ -185,6 +186,7 @@ const AddPackageDialog = ( props ) => {
 						className={ is_user_defined ? '' : 'flat-rate-package__max-weight__read-only' }
 						onChange={ ( event ) => updateFormTextField( event, updatePackagesField ) }
 						disabled={ ! is_user_defined }
+						isError={ errors.max_weight }
 					/>
 					<span className="wcc-shipping-add-package-weight-unit">{ weightUnit }</span>
 				</div>

--- a/client/components/shipping/packages/add-package.js
+++ b/client/components/shipping/packages/add-package.js
@@ -67,7 +67,7 @@ const AddPackageDialog = ( props ) => {
 		is_user_defined,
 	} = packageData;
 
-	const fieldClassName = is_user_defined ? '' : 'flat-rate-package__inner-dimensions__read-only';
+	const fieldClassName = is_user_defined ? null : 'flat-rate-package__inner-dimensions__read-only';
 	const isOuterDimensionsVisible = showOuterDimensions || outer_dimensions;
 	const exampleDimensions = [100.25, 25, 5.75].map( ( val ) => val.toLocaleString() ).join( ' x ' );
 
@@ -101,7 +101,7 @@ const AddPackageDialog = ( props ) => {
 	const fieldInfo = ( field, nonEmptyText ) => {
 		const altText = nonEmptyText || __( 'Invalid value' );
 		const text = '' === trim( packageData[field] ) ? __( 'This field is required' ) : altText;
-		return modalErrors[field] ? <FormInputValidation isError text={ text } /> : '';
+		return modalErrors[field] ? <FormInputValidation isError text={ text } /> : null;
 	};
 
 	return (
@@ -138,7 +138,7 @@ const AddPackageDialog = ( props ) => {
 					isError={ modalErrors.inner_dimensions }
 				/>
 				{ fieldInfo( 'inner_dimensions' ) }
-				{ ! isOuterDimensionsVisible ? <OuterDimensionsToggle { ...{ toggleOuterDimensions } }/> : '' }
+				{ ! isOuterDimensionsVisible ? <OuterDimensionsToggle { ...{ toggleOuterDimensions } }/> : null }
 			</FormFieldset>
 			{ isOuterDimensionsVisible
 				? ( <FormFieldset>
@@ -154,7 +154,7 @@ const AddPackageDialog = ( props ) => {
 						/>
 						{ fieldInfo( 'outer_dimensions' ) }
 					</FormFieldset> )
-				: ''
+				: null
 			}
 			<FormFieldset className="wcc-shipping-add-package-weight-group">
 				<div className="wcc-shipping-add-package-weight">

--- a/client/components/shipping/packages/input-filters.js
+++ b/client/components/shipping/packages/input-filters.js
@@ -1,0 +1,26 @@
+const leftPoint = /^\.\d+$/;
+const rightPoint = /^\d+\.$/;
+const number = ( value ) => {
+	if ( leftPoint.test( value ) ) {
+		value = '0' + value;
+	} else if ( rightPoint.test( value ) ) {
+		value = value.slice( 0, value.length - 1 );
+	}
+
+	return value;
+};
+
+const dimensionRegex = /^(\S+)\s*x\s*(\S+)\s*x\s*(\S+)$/;
+const dimensions = ( value ) => {
+	const result = dimensionRegex.exec( value );
+	if ( result ) {
+		return result.splice( 1, 4 ).map( number ).join( ' x ' );
+	}
+
+	return value;
+};
+
+export default {
+	number,
+	dimensions,
+};

--- a/client/components/shipping/packages/input-filters.js
+++ b/client/components/shipping/packages/input-filters.js
@@ -1,6 +1,10 @@
+import trim from 'lodash/trim';
+
 const leftPoint = /^\.\d+$/;
 const rightPoint = /^\d+\.$/;
+
 const number = ( value ) => {
+	value = trim( value );
 	if ( leftPoint.test( value ) ) {
 		value = '0' + value;
 	} else if ( rightPoint.test( value ) ) {
@@ -10,11 +14,12 @@ const number = ( value ) => {
 	return value;
 };
 
-const dimensionRegex = /^(\S+)\s*x\s*(\S+)\s*x\s*(\S+)$/;
+const dimensionRegex = /^\s*(\S+)\s*x\s*(\S+)\s*x\s*(\S+)\s*$/;
 const dimensions = ( value ) => {
 	const result = dimensionRegex.exec( value );
 	if ( result ) {
-		return result.splice( 1, 4 ).map( number ).join( ' x ' );
+		const dims = [result[1], result[2], result[3]];
+		return dims.map( number ).join( ' x ' );
 	}
 
 	return value;

--- a/client/components/shipping/packages/input-filters.js
+++ b/client/components/shipping/packages/input-filters.js
@@ -1,5 +1,9 @@
 import trim from 'lodash/trim';
 
+const string = ( value ) => {
+	return trim( value );
+};
+
 const leftPoint = /^\.\d+$/;
 const rightPoint = /^\d+\.$/;
 
@@ -26,6 +30,7 @@ const dimensions = ( value ) => {
 };
 
 export default {
+	string,
 	number,
 	dimensions,
 };

--- a/client/components/shipping/packages/modal-errors.js
+++ b/client/components/shipping/packages/modal-errors.js
@@ -5,7 +5,6 @@ import reduce from 'lodash/reduce';
 import validator from 'is-my-json-valid';
 
 const processErrors = ( errors ) => {
-	console.log( 'errors', errors );
 	return reduce( errors, ( result, value ) => {
 		if ( value.field ) {
 			const key = value.field.replace( 'data.', '' );
@@ -49,7 +48,6 @@ const preProcessPackageData = ( data, boxNames ) => {
 const getErrors = ( packageData, boxNames, schema ) => {
 	const validate = validator( schema, { greedy: true } );
 	const data = preProcessPackageData( packageData, boxNames );
-	console.log( data );
 	validate( data );
 	return processErrors( validate.errors );
 };

--- a/client/components/shipping/packages/modal-errors.js
+++ b/client/components/shipping/packages/modal-errors.js
@@ -1,4 +1,5 @@
 import some from 'lodash/some';
+import { translate as __ } from 'lib/mixins/i18n';
 
 const addError = ( key, message ) => {
 	return { [key]: message, any: true };
@@ -8,11 +9,11 @@ const isNullOrEmpty = ( value ) => ! value || '' === value;
 
 const checkNameField = ( value, boxNames ) => {
 	if ( isNullOrEmpty( value ) ) {
-		return addError( 'name', 'field is required' );
+		return addError( 'name', __( 'field is required' ) );
 	}
 
 	if ( some( boxNames, ( boxName ) => boxName === value ) ) {
-		return addError( 'name', 'a box with this name already exists' );
+		return addError( 'name', __( 'a box with this name already exists' ) );
 	}
 
 	return {};
@@ -24,7 +25,7 @@ const checkOuterDimensions = ( value, regex ) => {
 	}
 
 	if ( ! regex.test( value ) ) {
-		return addError( 'outer_dimensions', 'invalid dimension format' );
+		return addError( 'outer_dimensions', __( 'invalid dimension format' ) );
 	}
 
 	return {}
@@ -32,11 +33,11 @@ const checkOuterDimensions = ( value, regex ) => {
 
 const checkInnerDimensions = ( value, regex ) => {
 	if ( isNullOrEmpty( value ) ) {
-		return addError( 'inner_dimensions', 'field is required' );
+		return addError( 'inner_dimensions', __( 'field is required' ) );
 	}
 
 	if ( ! regex.test( value ) ) {
-		return addError( 'inner_dimensions', 'invalid dimension format' );
+		return addError( 'inner_dimensions', __( 'invalid dimension format' ) );
 	}
 
 	return {}
@@ -45,7 +46,7 @@ const checkInnerDimensions = ( value, regex ) => {
 const numberRegex = /^\d+(\.\d+)?$/;
 const checkWeightField = ( key, value ) => {
 	if ( ! numberRegex.test( value ) ) {
-		return addError( key, 'must be a number' );
+		return addError( key, __( 'must be a number' ) );
 	}
 
 	return {}

--- a/client/components/shipping/packages/modal-errors.js
+++ b/client/components/shipping/packages/modal-errors.js
@@ -1,0 +1,27 @@
+import { some, values} from 'lodash';
+
+const getNameError = ( name, boxNames ) => {
+	if ( ! name || '' === name ) {
+		return 'Name cannot be empty';
+	}
+
+	if ( some( boxNames, ( boxName ) => boxName === name ) ) {
+		return 'This name is already in use in your package list';
+	}
+
+	return null;
+};
+
+const anyErrors = ( errors ) => {
+	return some( values( errors ), ( value ) => null !== value );
+};
+
+const getErrors = ( packageData, boxNames ) => {
+	const errors = {
+		name: getNameError( packageData.name, boxNames ),
+	};
+
+	return Object.assign( errors, { any: anyErrors( errors ) } );
+};
+
+module.exports = getErrors;

--- a/client/components/shipping/packages/modal-errors.js
+++ b/client/components/shipping/packages/modal-errors.js
@@ -33,6 +33,19 @@ const checkInnerDimensions = ( dimensions ) => {
 	return checkOuterDimensions( dimensions );
 };
 
+const isNumber = ( value ) => /^\d+$/.test( value );
+const checkWeight = ( value ) => {
+	if ( ! value || '' === value ) {
+		return 'Cannot be blank';
+	}
+
+	if ( ! isNumber( value ) ) {
+		return 'Must be a number';
+	}
+
+	return null;
+};
+
 const anyErrors = ( errors ) => {
 	return some( values( errors ), ( value ) => null !== value );
 };
@@ -42,6 +55,8 @@ const getErrors = ( packageData, boxNames ) => {
 		name: checkName( packageData.name, boxNames ),
 		inner_dimensions: checkInnerDimensions( packageData.inner_dimensions ),
 		outer_dimensions: checkOuterDimensions( packageData.outer_dimensions ),
+		box_weight: checkWeight( packageData.box_weight ),
+		max_weight: checkWeight( packageData.max_weight ),
 	};
 
 	return Object.assign( errors, { any: anyErrors( errors ) } );

--- a/client/components/shipping/packages/modal-errors.js
+++ b/client/components/shipping/packages/modal-errors.js
@@ -1,6 +1,6 @@
 import { some, values} from 'lodash';
 
-const getNameError = ( name, boxNames ) => {
+const checkName = ( name, boxNames ) => {
 	if ( ! name || '' === name ) {
 		return 'Name cannot be empty';
 	}
@@ -12,13 +12,36 @@ const getNameError = ( name, boxNames ) => {
 	return null;
 };
 
+const dimensionRegex = /^\d+ x \d+ x \d+$/
+const checkOuterDimensions = ( dimensions ) => {
+	if ( ! dimensions || '' === dimensions ) {
+		return null;
+	}
+
+	if ( ! dimensionRegex.test( dimensions ) ) {
+		return 'Invalid format for dimensions';
+	};
+
+	return null;
+};
+
+const checkInnerDimensions = ( dimensions ) => {
+	if ( ! dimensions || '' === dimensions ) {
+		return 'Cannot be blank';
+	}
+
+	return checkOuterDimensions( dimensions );
+};
+
 const anyErrors = ( errors ) => {
 	return some( values( errors ), ( value ) => null !== value );
 };
 
 const getErrors = ( packageData, boxNames ) => {
 	const errors = {
-		name: getNameError( packageData.name, boxNames ),
+		name: checkName( packageData.name, boxNames ),
+		inner_dimensions: checkInnerDimensions( packageData.inner_dimensions ),
+		outer_dimensions: checkOuterDimensions( packageData.outer_dimensions ),
 	};
 
 	return Object.assign( errors, { any: anyErrors( errors ) } );

--- a/client/components/shipping/packages/modal-errors.js
+++ b/client/components/shipping/packages/modal-errors.js
@@ -5,6 +5,7 @@ import reduce from 'lodash/reduce';
 import validator from 'is-my-json-valid';
 
 const processErrors = ( errors ) => {
+	console.log( 'errors', errors );
 	return reduce( errors, ( result, value ) => {
 		if ( value.field ) {
 			const key = value.field.replace( 'data.', '' );
@@ -42,12 +43,13 @@ const preProcessPackageData = ( data, boxNames ) => {
 		max_weight: checkAndConvertNumber( data.max_weight ),
 	};
 
-	return omitBy( result, ( value ) => ! value );
+	return omitBy( result, ( value ) => null === value );
 };
 
 const getErrors = ( packageData, boxNames, schema ) => {
 	const validate = validator( schema, { greedy: true } );
 	const data = preProcessPackageData( packageData, boxNames );
+	console.log( data );
 	validate( data );
 	return processErrors( validate.errors );
 };

--- a/client/components/shipping/packages/modal-errors.js
+++ b/client/components/shipping/packages/modal-errors.js
@@ -1,66 +1,55 @@
 import some from 'lodash/some';
-import { translate as __ } from 'lib/mixins/i18n';
+import trim from 'lodash/trim';
+import omitBy from 'lodash/omitBy';
+import reduce from 'lodash/reduce';
+import validator from 'is-my-json-valid';
 
-const addError = ( key, message ) => {
-	return { [key]: message, any: true };
+const processErrors = ( errors ) => {
+	return reduce( errors, ( result, value ) => {
+		if ( value.field ) {
+			const key = value.field.replace( 'data.', '' );
+			Object.assign( result, { [key]: true, any: true } );
+		}
+
+		return result;
+	}, {} );
 };
 
-const isNullOrEmpty = ( value ) => ! value || '' === value;
-
-const checkNameField = ( value, boxNames ) => {
-	if ( isNullOrEmpty( value ) ) {
-		return addError( 'name', __( 'field is required' ) );
-	}
-
-	if ( some( boxNames, ( boxName ) => boxName === value ) ) {
-		return addError( 'name', __( 'a box with this name already exists' ) );
-	}
-
-	return {};
+const checkNullOrWhitespace = ( value ) => {
+	return value && '' !== trim( value ) ? value : null;
 };
 
-const checkOuterDimensions = ( value, regex ) => {
-	if ( isNullOrEmpty( value ) ) {
-		return {};
-	}
-
-	if ( ! regex.test( value ) ) {
-		return addError( 'outer_dimensions', __( 'invalid dimension format' ) );
-	}
-
-	return {}
-};
-
-const checkInnerDimensions = ( value, regex ) => {
-	if ( isNullOrEmpty( value ) ) {
-		return addError( 'inner_dimensions', __( 'field is required' ) );
-	}
-
-	if ( ! regex.test( value ) ) {
-		return addError( 'inner_dimensions', __( 'invalid dimension format' ) );
-	}
-
-	return {}
+const checkDuplicateName = ( name, boxNames ) => {
+	name = checkNullOrWhitespace( name );
+	return some( boxNames, ( boxName ) => boxName === name ) ? null : name;
 };
 
 const numberRegex = /^\d+(\.\d+)?$/;
-const checkWeightField = ( key, value ) => {
+const checkAndConvertNumber = ( value ) => {
 	if ( ! numberRegex.test( value ) ) {
-		return addError( key, __( 'must be a number' ) );
+		return 'fail';
 	}
 
-	return {}
+	return Number.parseFloat( value );
+};
+
+const preProcessPackageData = ( data, boxNames ) => {
+	const result = {
+		name: checkDuplicateName( data.name, boxNames ),
+		inner_dimensions: data.inner_dimensions,
+		outer_dimensions: checkNullOrWhitespace( data.outer_dimensions ),
+		box_weight: checkAndConvertNumber( data.box_weight ),
+		max_weight: checkAndConvertNumber( data.max_weight ),
+	};
+
+	return omitBy( result, ( value ) => ! value );
 };
 
 const getErrors = ( packageData, boxNames, schema ) => {
-	const regex = new RegExp( schema.properties.inner_dimensions.pattern );
-	return Object.assign( {}
-		, checkNameField( packageData.name, boxNames )
-		, checkInnerDimensions( packageData.inner_dimensions, regex )
-		, checkOuterDimensions( packageData.outer_dimensions, regex )
-		, checkWeightField( 'box_weight', packageData.box_weight )
-		, checkWeightField( 'max_weight', packageData.max_weight )
-	);
+	const validate = validator( schema, { greedy: true } );
+	const data = preProcessPackageData( packageData, boxNames );
+	validate( data );
+	return processErrors( validate.errors );
 };
 
 module.exports = getErrors;

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -125,6 +125,14 @@
     width: 100%;
 }
 
+.wcc-shipping-add-package-weight-group {
+    .form-setting-explanation {
+        @include breakpoint( '>480px' ) {
+            clear: both;
+        }
+    }
+}
+
 & .wcc-shipping-add-edit-package-dialog {
     .form-setting-explanation {
         display: inline-block;

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -125,14 +125,6 @@
     width: 100%;
 }
 
-.wcc-shipping-add-package-weight-group {
-    .form-setting-explanation {
-        @include breakpoint( '>480px' ) {
-            margin-top: 68px;
-        }
-    }
-}
-
 & .wcc-shipping-add-edit-package-dialog {
     .form-setting-explanation {
         display: inline-block;

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -62,6 +62,7 @@ const SettingsItem = ( {
 					savePackage={ savePackage }
 					weightUnit={ storeOptions.weight_unit }
 					errors={ errors }
+					schema={ fieldSchema }
 				/>
 			);
 

--- a/client/lib/initialize-state/index.js
+++ b/client/lib/initialize-state/index.js
@@ -27,6 +27,9 @@ export default ( schema, values ) => {
 		settings: formValues,
 		form: {
 			isSaving: false,
+			packages: {
+				modalErrors: {},
+			},
 		},
 	};
 };

--- a/client/state/form/packages/actions.js
+++ b/client/state/form/packages/actions.js
@@ -1,6 +1,7 @@
 export const ADD_PACKAGE = 'ADD_PACKAGE';
 export const EDIT_PACKAGE = 'EDIT_PACKAGE';
 export const DISMISS_MODAL = 'DISMISS_MODAL';
+export const SET_MODAL_ERROR = 'SET_MODAL_ERROR';
 export const SET_SELECTED_PRESET = 'SET_SELECTED_PRESET';
 export const SAVE_PACKAGE = 'SAVE_PACKAGE';
 export const UPDATE_PACKAGES_FIELD = 'UPDATE_PACKAGES_FIELD';
@@ -37,4 +38,9 @@ export const updatePackagesField = ( newValues ) => ( {
 
 export const toggleOuterDimensions = () => ( {
 	type: TOGGLE_OUTER_DIMENSIONS,
+} );
+
+export const setModalError = ( value ) => ( {
+	type: SET_MODAL_ERROR,
+	value,
 } );

--- a/client/state/form/packages/actions.js
+++ b/client/state/form/packages/actions.js
@@ -1,7 +1,7 @@
 export const ADD_PACKAGE = 'ADD_PACKAGE';
 export const EDIT_PACKAGE = 'EDIT_PACKAGE';
 export const DISMISS_MODAL = 'DISMISS_MODAL';
-export const SET_MODAL_ERROR = 'SET_MODAL_ERROR';
+export const SET_MODAL_ERRORS = 'SET_MODAL_ERROR';
 export const SET_SELECTED_PRESET = 'SET_SELECTED_PRESET';
 export const SAVE_PACKAGE = 'SAVE_PACKAGE';
 export const UPDATE_PACKAGES_FIELD = 'UPDATE_PACKAGES_FIELD';
@@ -40,7 +40,7 @@ export const toggleOuterDimensions = () => ( {
 	type: TOGGLE_OUTER_DIMENSIONS,
 } );
 
-export const setModalError = ( value ) => ( {
-	type: SET_MODAL_ERROR,
+export const setModalErrors = ( value ) => ( {
+	type: SET_MODAL_ERRORS,
 	value,
 } );

--- a/client/state/form/packages/reducer.js
+++ b/client/state/form/packages/reducer.js
@@ -2,7 +2,7 @@ import {
 	ADD_PACKAGE,
 	EDIT_PACKAGE,
 	DISMISS_MODAL,
-	SET_MODAL_ERROR,
+	SET_MODAL_ERRORS,
 	SET_SELECTED_PRESET,
 	UPDATE_PACKAGES_FIELD,
 	SAVE_PACKAGE,
@@ -40,14 +40,14 @@ reducers[EDIT_PACKAGE] = ( state, action ) => {
 
 reducers[DISMISS_MODAL] = ( state ) => {
 	return Object.assign( {}, state, {
-		isModalError: false,
+		modalErrors: {},
 		showModal: false,
 	} );
 };
 
-reducers[SET_MODAL_ERROR] = ( state, action ) => {
+reducers[SET_MODAL_ERRORS] = ( state, action ) => {
 	return Object.assign( {}, state, {
-		isModalError: action.value,
+		modalErrors: action.value,
 	} );
 };
 

--- a/client/state/form/packages/reducer.js
+++ b/client/state/form/packages/reducer.js
@@ -2,6 +2,7 @@ import {
 	ADD_PACKAGE,
 	EDIT_PACKAGE,
 	DISMISS_MODAL,
+	SET_MODAL_ERROR,
 	SET_SELECTED_PRESET,
 	UPDATE_PACKAGES_FIELD,
 	SAVE_PACKAGE,
@@ -39,7 +40,14 @@ reducers[EDIT_PACKAGE] = ( state, action ) => {
 
 reducers[DISMISS_MODAL] = ( state ) => {
 	return Object.assign( {}, state, {
+		isModalError: false,
 		showModal: false,
+	} );
+};
+
+reducers[SET_MODAL_ERROR] = ( state, action ) => {
+	return Object.assign( {}, state, {
+		isModalError: action.value,
 	} );
 };
 

--- a/client/state/form/packages/test/actions.js
+++ b/client/state/form/packages/test/actions.js
@@ -6,6 +6,7 @@ import {
 	savePackage,
 	updatePackagesField,
 	toggleOuterDimensions,
+	setModalError,
 	ADD_PACKAGE,
 	EDIT_PACKAGE,
 	DISMISS_MODAL,
@@ -13,6 +14,7 @@ import {
 	SAVE_PACKAGE,
 	UPDATE_PACKAGES_FIELD,
 	TOGGLE_OUTER_DIMENSIONS,
+	SET_MODAL_ERROR,
 } from '../actions';
 
 describe( 'Packages state actions', () => {
@@ -81,6 +83,18 @@ describe( 'Packages state actions', () => {
 	it( '#toggleOuterDimensions()', () => {
 		expect( toggleOuterDimensions() ).to.eql( {
 			type: TOGGLE_OUTER_DIMENSIONS,
+		} );
+	} );
+
+	it( '#setModalError()', () => {
+		expect( setModalError( true ) ).to.eql( {
+			type: SET_MODAL_ERROR,
+			value: true,
+		} );
+
+		expect( setModalError( false ) ).to.eql( {
+			type: SET_MODAL_ERROR,
+			value: false,
 		} );
 	} );
 } );

--- a/client/state/form/packages/test/actions.js
+++ b/client/state/form/packages/test/actions.js
@@ -6,7 +6,7 @@ import {
 	savePackage,
 	updatePackagesField,
 	toggleOuterDimensions,
-	setModalError,
+	setModalErrors,
 	ADD_PACKAGE,
 	EDIT_PACKAGE,
 	DISMISS_MODAL,
@@ -14,7 +14,7 @@ import {
 	SAVE_PACKAGE,
 	UPDATE_PACKAGES_FIELD,
 	TOGGLE_OUTER_DIMENSIONS,
-	SET_MODAL_ERROR,
+	SET_MODAL_ERRORS,
 } from '../actions';
 
 describe( 'Packages state actions', () => {
@@ -86,15 +86,20 @@ describe( 'Packages state actions', () => {
 		} );
 	} );
 
-	it( '#setModalError()', () => {
-		expect( setModalError( true ) ).to.eql( {
-			type: SET_MODAL_ERROR,
+	it( '#setModalErrors()', () => {
+		expect( setModalErrors( true ) ).to.eql( {
+			type: SET_MODAL_ERRORS,
 			value: true,
 		} );
 
-		expect( setModalError( false ) ).to.eql( {
-			type: SET_MODAL_ERROR,
+		expect( setModalErrors( false ) ).to.eql( {
+			type: SET_MODAL_ERRORS,
 			value: false,
+		} );
+
+		expect( setModalErrors( { any: true } ) ).to.eql( {
+			type: SET_MODAL_ERRORS,
+			value: { any: true },
 		} );
 	} );
 } );

--- a/client/state/form/packages/test/reducer.js
+++ b/client/state/form/packages/test/reducer.js
@@ -7,6 +7,7 @@ import {
 	updatePackagesField,
 	toggleOuterDimensions,
 	savePackage,
+	setModalError,
 } from '../actions';
 
 const initialState = {
@@ -84,7 +85,7 @@ describe( 'Packages form reducer', () => {
 	it( 'DISMISS_MODAL', () => {
 		const visibleModalState = {
 			showModal: true,
-		}
+		};
 		const action = dismissModal();
 		const state = reducer( visibleModalState, action );
 
@@ -171,6 +172,31 @@ describe( 'Packages form reducer', () => {
 			},
 			showOuterDimensions: false,
 			selectedPreset: null,
+		} );
+	} );
+
+	it( 'SET_MODAL_ERROR', () => {
+		const initialSavePackageState = {
+			showModal: true,
+			mode: 'edit',
+			showOuterDimensions: false,
+		};
+		const action = setModalError( true );
+
+		const state = reducer( initialSavePackageState, action );
+		expect( state ).to.eql( {
+			showModal: true,
+			mode: 'edit',
+			showOuterDimensions: false,
+			isModalError: true,
+		} );
+
+		const newState = reducer( initialSavePackageState, setModalError( false ) );
+		expect( newState ).to.eql( {
+			showModal: true,
+			mode: 'edit',
+			showOuterDimensions: false,
+			isModalError: false,
 		} );
 	} );
 } );

--- a/client/state/form/packages/test/reducer.js
+++ b/client/state/form/packages/test/reducer.js
@@ -7,7 +7,7 @@ import {
 	updatePackagesField,
 	toggleOuterDimensions,
 	savePackage,
-	setModalError,
+	setModalErrors,
 } from '../actions';
 
 const initialState = {
@@ -90,7 +90,7 @@ describe( 'Packages form reducer', () => {
 		const state = reducer( visibleModalState, action );
 
 		expect( state ).to.eql( {
-			isModalError: false,
+			modalErrors: {},
 			showModal: false,
 		} );
 	} );
@@ -181,22 +181,22 @@ describe( 'Packages form reducer', () => {
 			mode: 'edit',
 			showOuterDimensions: false,
 		};
-		const action = setModalError( true );
+		const action = setModalErrors( true );
 
 		const state = reducer( initialSavePackageState, action );
 		expect( state ).to.eql( {
 			showModal: true,
 			mode: 'edit',
 			showOuterDimensions: false,
-			isModalError: true,
+			modalErrors: true,
 		} );
 
-		const newState = reducer( initialSavePackageState, setModalError( false ) );
+		const newState = reducer( initialSavePackageState, setModalErrors( { any: true } ) );
 		expect( newState ).to.eql( {
 			showModal: true,
 			mode: 'edit',
 			showOuterDimensions: false,
-			isModalError: false,
+			modalErrors: { any: true },
 		} );
 	} );
 } );

--- a/client/state/form/packages/test/reducer.js
+++ b/client/state/form/packages/test/reducer.js
@@ -89,6 +89,7 @@ describe( 'Packages form reducer', () => {
 		const state = reducer( visibleModalState, action );
 
 		expect( state ).to.eql( {
+			isModalError: false,
 			showModal: false,
 		} );
 	} );


### PR DESCRIPTION
I've added validation to the add/edit packages modal. It does the following:
1) Check if name field is empty 
2) Check if box name already exists in the list of boxes
3) requires inner dimensions and checks the format
4) if outer dimensions are provided, checks the format
5) makes sure box and max weights are numbers and not empty
6) Auto-correct spacing around "x" in the dimensions definitions

To Test:

1) Open USPS or Canada Post settings
2) Make sure you have a few boxes entered
3) Try to add a new box
4) Make sure it follows all the rules above
5) Try editing an existing box
6) Make sure it follows the rules above
7) Make sure you're able to save data after making changes
8) Experiment with variations of spacing around the "x" in the dimensions. It should be auto-corrected.

@kellychoffman @jeffstieler @allendav @jkudish

Closes #297 
Closes #306 
Closes #324  