### PR TITLE
hide packing method when there are no packages

### DIFF
--- a/client/components/wcc-settings-form/index.js
+++ b/client/components/wcc-settings-form/index.js
@@ -10,18 +10,18 @@ import isString from 'lodash/isString';
 import { translate as __ } from 'lib/mixins/i18n';
 import validator from 'is-my-json-valid';
 import ObjectPath from 'objectpath';
+import * as SettingsActions from 'state/settings/actions';
+import * as PackagesActions from 'state/form/packages/actions';
 
-const WCCSettingsForm = ( {
-	storeOptions,
-	schema,
-	layout,
-	settings,
-	form,
-	saveFormData,
-	formActions,
-	noticeActions,
-	errors,
-} ) => {
+const WCCSettingsForm = ( props ) => {
+	const {
+		layout,
+		settings,
+		saveFormData,
+		formActions,
+		noticeActions,
+	} = props;
+
 	const setIsSaving = ( value ) => formActions.setField( 'isSaving', value );
 	const setSuccess = ( value ) => {
 		formActions.setField( 'success', value );
@@ -38,22 +38,16 @@ const WCCSettingsForm = ( {
 				duration: 7000,
 			} );
 		}
-	}
+	};
 	const saveForm = () => saveFormData( setIsSaving, setSuccess, setError, settings );
 	return (
 		<div>
 			<GlobalNotices id="notices" notices={ notices.list } />
 			{ layout.map( ( group, idx ) => (
 				<WCCSettingsGroup
+					{ ...props }
+					{ ...{ group, saveForm } }
 					key={ idx }
-					{ ...{
-						group,
-						schema,
-						storeOptions,
-						saveForm,
-						form,
-						errors,
-					} }
 				/>
 			) ) }
 		</div>
@@ -103,6 +97,8 @@ function mapDispatchToProps( dispatch ) {
 	return {
 		formActions: bindActionCreators( FormActions, dispatch ),
 		noticeActions: bindActionCreators( { successNotice, errorNotice }, dispatch ),
+		packagesActions: bindActionCreators( PackagesActions, dispatch ),
+		settingsActions: bindActionCreators( SettingsActions, dispatch ),
 	};
 }
 

--- a/client/components/wcc-settings-form/settings-group.js
+++ b/client/components/wcc-settings-form/settings-group.js
@@ -17,27 +17,24 @@ const filterErrorsForItem = ( groupErrors, itemKey ) => {
 	return itemErrors;
 };
 
-const SettingsGroup = ( {
-	group,
-	schema,
-	storeOptions,
-	form,
-	saveForm,
-	errors,
-} ) => {
+const SettingsGroup = ( props ) => {
+	const {
+		group,
+		form,
+		saveForm,
+		errors,
+	} = props;
+
 	const renderSettingsItem = ( item ) => {
 		const key = item.key ? item.key : item;
 		const itemErrors = filterErrorsForItem( errors, key );
 
 		return (
 			<SettingsItem
+				{ ...props }
+				{ ...{ key } }
 				layout={ item }
 				errors={ itemErrors }
-				{ ...{
-					key,
-					schema,
-					storeOptions,
-				} }
 			/>
 		);
 	};
@@ -82,6 +79,8 @@ SettingsGroup.propTypes = {
 	storeOptions: PropTypes.object.isRequired,
 	saveForm: PropTypes.func.isRequired,
 	form: PropTypes.object.isRequired,
+	errors: PropTypes.array,
+	settings: PropTypes.object.isRequired,
 };
 
 export default SettingsGroup;

--- a/client/components/wcc-settings-form/settings-group.js
+++ b/client/components/wcc-settings-form/settings-group.js
@@ -23,10 +23,15 @@ const SettingsGroup = ( props ) => {
 		form,
 		saveForm,
 		errors,
+		settings,
 	} = props;
 
 	const renderSettingsItem = ( item ) => {
 		const key = item.key ? item.key : item;
+		if ( 'packing_method' === key && ( ! settings.boxes || 0 === settings.boxes.length ) ) {
+			return '';
+		}
+
 		const itemErrors = filterErrorsForItem( errors, key );
 
 		return (

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -3,10 +3,6 @@ import Indicators from 'components/indicators';
 import TextField from 'components/text-field';
 import RadioButtons from 'components/radio-buttons';
 import ShippingServiceGroups from 'components/shipping/services';
-import { connect } from 'react-redux';
-import * as SettingsActions from 'state/settings/actions';
-import * as PackagesActions from 'state/form/packages/actions';
-import { bindActionCreators } from 'redux';
 import Packages from 'components/shipping/packages';
 
 const SettingsItem = ( {
@@ -101,23 +97,10 @@ SettingsItem.propTypes = {
 	schema: PropTypes.object.isRequired,
 	settings: PropTypes.object.isRequired,
 	storeOptions: PropTypes.object.isRequired,
+	form: PropTypes.object.isRequired,
+	settingsActions: PropTypes.object.isRequired,
+	packagesActions: PropTypes.object.isRequired,
+	errors: PropTypes.array,
 };
 
-function mapStateToProps( state ) {
-	return {
-		settings: state.settings,
-		form: state.form,
-	};
-}
-
-function mapDispatchToProps( dispatch ) {
-	return {
-		packagesActions: bindActionCreators( PackagesActions, dispatch ),
-		settingsActions: bindActionCreators( SettingsActions, dispatch ),
-	};
-}
-
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( SettingsItem );
+export default SettingsItem;


### PR DESCRIPTION
closes #361 

This change hides the packing method radio buttons when there are no boxes defined. The reason is that this parameter has no effect on settings unless there is at least one package defined in packages.

I also went ahead and did some cleanup to the React component:
- redux `connect()` is now only done once in index.js
- Update proptypes to properly reflect properties used by the subcomponents`

To Test:
1) Go to settings page (Canada Post or USPS)
2) Observer that the radio buttons are hidden if there are no packages defined
3) Try saving, refreshing the page, and cancelling a few actions
4) Make sure unit tests pass and no errors are thrown in the console.

Here are sample images of what you should see:
![image](https://cloud.githubusercontent.com/assets/11143071/15620053/c9557f3a-240c-11e6-9829-96df7108df08.png)
![image](https://cloud.githubusercontent.com/assets/11143071/15620060/d9da5178-240c-11e6-898d-97488939efb0.png)
