### PR TITLE
Add hook to update schemas when woocommerce settings are updated

### DIFF
--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -238,6 +238,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				add_action( 'woocommerce_shipping_zone_method_status_toggled', array( $this, 'shipping_zone_method_status_toggled' ), 10, 4 );
 			}
 
+			add_action( 'woocommerce_settings_saved', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_action( 'wc_connect_fetch_service_schemas', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 
 		}


### PR DESCRIPTION
closes #261 

If settings any woo commerce settings are changed, we should re-fetch settings from the server. This is because the default values and settings will change if for example the units of measurements are changed.

To Test:

- Load this branch
- Enable logging
- Make sure your frequent fetch flag is NOT enabled
- Save your woocommerce settings (you don't need to change the settings)
- Observer that a `fetch_service_schemas_from_connect_server` event is logged in the logs

@allendav @jkudish @jeffstieler @DanReyLop 