### PR TITLE
Add select all in services selection

### DIFF
--- a/assets/stylesheets/shipping-services.scss
+++ b/assets/stylesheets/shipping-services.scss
@@ -32,13 +32,24 @@
 	}
 
 	&.multi-select-header {
+		display: flex;
+		box-sizing: border-box;
 		border-bottom: 1px solid lighten( $gray, 30% );
 		padding-bottom: 8px;
 		margin-bottom: 4px;
 
 		.wcc-shipping-service-header {
+			display: inline-block;
+			margin-left: 0;
 			padding: 0 0 0 8px;
 			font-weight: bold;
+		}
+
+		.price-adjustment {
+			float: right;
+			@include breakpoint( '>480px' ) {
+				padding-right: 8px;
+			}
 		}
 	}
 

--- a/assets/stylesheets/shipping-services.scss
+++ b/assets/stylesheets/shipping-services.scss
@@ -13,12 +13,6 @@
 	margin-bottom: 16px;
 }
 
-.wcc-shipping-service-header {
-	padding: 16px;
-	border-bottom: 1px solid lighten( $gray, 30% );
-	font-size: 14px;
-}
-
 .wcc-shipping-service-content {
 	padding: 8px 16px;
 }
@@ -37,6 +31,17 @@
 		}
 	}
 
+	&.multi-select-header {
+		border-bottom: 1px solid lighten( $gray, 30% );
+		padding-bottom: 8px;
+		margin-bottom: 4px;
+
+		.wcc-shipping-service-header {
+			padding: 0 0 0 8px;
+			font-weight: bold;
+		}
+	}
+
 	.wcc-shipping-service-entry-title {
 		flex-grow: 1;
 	}
@@ -48,7 +53,7 @@
 		font-size: 13px;
 		min-width: 42px;
 	}
-	
+
 	.form-select {
 		padding: 6px 32px 5px 14px;
 		font-size: 13px;

--- a/client/components/shipping/services/entry.js
+++ b/client/components/shipping/services/entry.js
@@ -5,67 +5,68 @@ import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 
-const ShippingServiceEntry = ( {
-	enabled,
-	title,
-	adjustment,
-	adjustment_type,
-	currencySymbol,
-	updateValue,
-	hasError,
-} ) => {
+const numberRegex = /^\d+(\.\d+)?$/;
+const parseNumber = ( value ) => {
+	return numberRegex.test( value ) ? Number.parseFloat( value ) : value;
+};
+
+const ShippingServiceEntry = ( props ) => {
+	const {
+		currencySymbol,
+		updateValue,
+		errors,
+		service,
+	} = props;
+
+	const {
+		enabled,
+		name,
+		adjustment,
+		adjustment_type,
+	} = service;
+
+	const updateField = ( key, value ) => updateValue( service.id, key, value );
+	const hasError = errors.find( ( error ) => error.length && ( error[0] === service.id ) );
+
 	return (
 		<div className={ classNames( 'wcc-shipping-service-entry', { 'wcc-error': hasError } ) }>
 			<label className="wcc-shipping-service-entry-title">
 				<FormCheckbox
 					checked={ enabled }
-					onChange={ ( event ) => updateValue( 'enabled', event.target.checked ) }
+					onChange={ ( event ) => updateField( 'enabled', event.target.checked ) }
 				/>
-				{ title }
+				{ name }
 			</label>
 			{ hasError ? <Gridicon icon="notice" /> : null }
 			<FormTextInput
 				disabled={ ! enabled }
 				value={ adjustment }
-				onChange={ ( event ) => {
-					const value = event.target.value || null;
-					const floatValue = Number.parseFloat( value );
-
-					/*
-					 * If the adjustment value isn't a valid float, or ends in a non-integer, pass
-					 * the value through unmodified and let the schema validation catch it.
-					 *
-					 * If the adjustment *is* a valid float, update the settings value with the
-					 * parsed version so it doesn't fail schema validation.
-					 */
-					if ( isNaN( floatValue ) || value.match( /.*[^\d]$/ ) ) {
-						updateValue( 'adjustment', value );
-					} else {
-						updateValue( 'adjustment', floatValue );
-					}
-				} }
+				onChange={ ( event ) => updateField( 'adjustment', parseNumber( event.target.value ) ) }
 				isError={ hasError }
 			/>
 			<FormSelect
 				disabled={ ! enabled }
 				value={ adjustment_type }
-				onChange={ ( event ) => updateValue( 'adjustment_type', event.target.value ) }
+				onChange={ ( event ) => updateField( 'adjustment_type', event.target.value ) }
 			>
 				<option value="flat">{ currencySymbol }</option>
 				<option value="percentage">%</option>
 			</FormSelect>
 		</div>
 	);
-}
+};
 
 ShippingServiceEntry.propTypes = {
-	enabled: PropTypes.bool.isRequired,
-	title: PropTypes.string.isRequired,
-	adjustment: PropTypes.oneOfType( [
-		PropTypes.string,
-		PropTypes.number,
-	] ),
-	adjustment_type: PropTypes.string.isRequired,
+	service: PropTypes.shape( {
+		id: PropTypes.string.isRequired,
+		name: PropTypes.string.isRequired,
+		enabled: PropTypes.bool,
+		adjustment: PropTypes.oneOfType( [
+			PropTypes.string,
+			PropTypes.number,
+		] ),
+		adjustment_type: PropTypes.string,
+	} ),
 	currencySymbol: PropTypes.string.isRequired,
 	updateValue: PropTypes.func.isRequired,
 	settingsKey: PropTypes.string.isRequired,

--- a/client/components/shipping/services/group.js
+++ b/client/components/shipping/services/group.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import ShippingServiceEntry from './entry';
 import FoldableCard from 'components/foldable-card';
+import CheckBox from 'components/forms/form-checkbox';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'lib/mixins/i18n';
 import { sprintf } from 'sprintf-js';
@@ -14,6 +15,10 @@ const summaryLabel = ( services ) => {
 	}
 	const format = ( 1 === numSelected ) ? __( '%d service selected' ) : __( '%d services selected' );
 	return sprintf( format, numSelected );
+};
+
+const getCheckbox = ( title ) => {
+	return <div><CheckBox />{ title }</div>
 };
 
 const ShippingServiceGroup = ( {
@@ -33,7 +38,7 @@ const ShippingServiceGroup = ( {
 	);
 	return (
 		<FoldableCard
-			header={ title }
+			header={ getCheckbox( title ) }
 			summary={ summary }
 			expandedSummary={ summary }
 			clickableHeader={ true }

--- a/client/components/shipping/services/group.js
+++ b/client/components/shipping/services/group.js
@@ -17,8 +17,19 @@ const summaryLabel = ( services ) => {
 	return sprintf( format, numSelected );
 };
 
-const getCheckbox = ( title ) => {
-	return <div><CheckBox />{ title }</div>
+const updateAll = ( updateValue, services, value ) => {
+	services.forEach( ( service ) => {
+		updateValue( service.id, 'enabled', value );
+	} )
+};
+
+const getCheckbox = ( title, updateValue, services ) => {
+	return (
+		<div>
+			<CheckBox onClick={ ( event ) => updateAll( updateValue, services, event.target.checked ) }/>
+			{ title }
+		</div>
+	);
 };
 
 const ShippingServiceGroup = ( {
@@ -38,7 +49,7 @@ const ShippingServiceGroup = ( {
 	);
 	return (
 		<FoldableCard
-			header={ getCheckbox( title ) }
+			header={ getCheckbox( title, updateValue, services ) }
 			summary={ summary }
 			expandedSummary={ summary }
 			clickableHeader={ true }

--- a/client/components/shipping/services/group.js
+++ b/client/components/shipping/services/group.js
@@ -58,7 +58,8 @@ const ShippingServiceGroup = ( props ) => {
 						onChange={ ( event ) => updateAll( event, updateValue, services ) }
 						checked={ allChecked }
 					/>
-				<span className="wcc-shipping-service-header">Service</span>
+					<span className="wcc-shipping-service-header">{ __( 'Service' ) }</span>
+					<span className="wcc-shipping-service-header">{ __( 'Price adjustment' ) }</span>
 				</label>
 			</div>
 

--- a/client/components/shipping/services/group.js
+++ b/client/components/shipping/services/group.js
@@ -51,14 +51,14 @@ const ShippingServiceGroup = ( props ) => {
 			actionButtonExpanded={ actionButton }
 			expanded={ Boolean( errors && errors.length ) }
 		>
-			<div className="wcc-shipping-service-entry">
+			<div className="wcc-shipping-service-entry multi-select-header">
 				<label className="wcc-shipping-service-entry-title">
 					<CheckBox
 						onClick={ ( event ) => event.stopPropagation() }
 						onChange={ ( event ) => updateAll( event, updateValue, services ) }
 						checked={ allChecked }
 					/>
-					<strong>Service</strong>
+				<span className="wcc-shipping-service-header">Service</span>
 				</label>
 			</div>
 

--- a/client/components/shipping/services/group.js
+++ b/client/components/shipping/services/group.js
@@ -58,8 +58,8 @@ const ShippingServiceGroup = ( props ) => {
 						onChange={ ( event ) => updateAll( event, updateValue, services ) }
 						checked={ allChecked }
 					/>
-					<span className="wcc-shipping-service-header">{ __( 'Service' ) }</span>
-					<span className="wcc-shipping-service-header">{ __( 'Price adjustment' ) }</span>
+				<span className="wcc-shipping-service-header service-name">{ __( 'Service' ) }</span>
+					<span className="wcc-shipping-service-header price-adjustment">{ __( 'Price adjustment' ) }</span>
 				</label>
 			</div>
 

--- a/client/components/shipping/services/group.js
+++ b/client/components/shipping/services/group.js
@@ -5,6 +5,7 @@ import CheckBox from 'components/forms/form-checkbox';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'lib/mixins/i18n';
 import { sprintf } from 'sprintf-js';
+import every from 'lodash/every';
 
 const summaryLabel = ( services ) => {
 	const numSelected = services.reduce( ( count, service ) => (
@@ -17,16 +18,21 @@ const summaryLabel = ( services ) => {
 	return sprintf( format, numSelected );
 };
 
-const updateAll = ( updateValue, services, value ) => {
+const updateAll = ( event, updateValue, services ) => {
 	services.forEach( ( service ) => {
-		updateValue( service.id, 'enabled', value );
+		updateValue( service.id, 'enabled', event.target.checked );
 	} )
 };
 
 const getCheckbox = ( title, updateValue, services ) => {
+	const allChecked = every( services, ( service ) => service.enabled );
 	return (
 		<div>
-			<CheckBox onClick={ ( event ) => updateAll( updateValue, services, event.target.checked ) }/>
+			<CheckBox
+				onClick={ ( event ) => event.stopPropagation() }
+				onChange={ ( event ) => updateAll( event, updateValue, services ) }
+				checked={ allChecked }
+			/>
 			{ title }
 		</div>
 	);

--- a/client/components/shipping/services/group.js
+++ b/client/components/shipping/services/group.js
@@ -24,28 +24,13 @@ const updateAll = ( event, updateValue, services ) => {
 	} )
 };
 
-const getCheckbox = ( title, updateValue, services ) => {
-	const allChecked = every( services, ( service ) => service.enabled );
-	return (
-		<div>
-			<CheckBox
-				onClick={ ( event ) => event.stopPropagation() }
-				onChange={ ( event ) => updateAll( event, updateValue, services ) }
-				checked={ allChecked }
-			/>
-			{ title }
-		</div>
-	);
-};
-
-const ShippingServiceGroup = ( {
-	title,
-	services,
-	currencySymbol,
-	updateValue,
-	settingsKey,
-	errors,
-} ) => {
+const ShippingServiceGroup = ( props ) => {
+	const {
+		title,
+		services,
+		updateValue,
+		errors,
+	} = props;
 	const summary = summaryLabel( services );
 	const actionButton = (
 		<button className="foldable-card__action foldable-card__expand" type="button">
@@ -53,9 +38,11 @@ const ShippingServiceGroup = ( {
 			<Gridicon icon="chevron-down" size={ 24 } />
 		</button>
 	);
+	const allChecked = every( services, ( service ) => service.enabled );
+
 	return (
 		<FoldableCard
-			header={ getCheckbox( title, updateValue, services ) }
+			header={ title }
 			summary={ summary }
 			expandedSummary={ summary }
 			clickableHeader={ true }
@@ -64,23 +51,18 @@ const ShippingServiceGroup = ( {
 			actionButtonExpanded={ actionButton }
 			expanded={ Boolean( errors && errors.length ) }
 		>
-			{ services.map( service => {
-				return (
-					<ShippingServiceEntry
-						key={ service.id }
-						enabled={ service.enabled }
-						title={ service.name }
-						adjustment={ service.adjustment }
-						adjustment_type={ service.adjustment_type }
-						currencySymbol={ currencySymbol }
-						updateValue={ ( key, val ) => updateValue( service.id, key, val ) }
-						settingsKey={ settingsKey }
-						hasError={ errors.find( ( error ) => (
-							error.length && ( error[0] === service.id ) )
-						) }
+			<div className="wcc-shipping-service-entry">
+				<label className="wcc-shipping-service-entry-title">
+					<CheckBox
+						onClick={ ( event ) => event.stopPropagation() }
+						onChange={ ( event ) => updateAll( event, updateValue, services ) }
+						checked={ allChecked }
 					/>
-				);
-			} ) }
+					<strong>Service</strong>
+				</label>
+			</div>
+
+			{ services.map( ( service, idx ) => <ShippingServiceEntry { ...props } { ...{ service } } key={ idx }/> ) }
 		</FoldableCard>
 	);
 };
@@ -97,9 +79,7 @@ ShippingServiceGroup.propTypes = {
 		] ),
 		adjustment_type: PropTypes.string,
 	} ) ).isRequired,
-	currencySymbol: PropTypes.string.isRequired,
 	updateValue: PropTypes.func.isRequired,
-	settingsKey: PropTypes.string.isRequired,
 };
 
 export default ShippingServiceGroup;


### PR DESCRIPTION
closes #198 

This adds a "select-all" checkbox in the header of the service foldable card, like so:
![image](https://cloud.githubusercontent.com/assets/11143071/15715842/f27f0450-27d4-11e6-8b15-eb05e2710548.png)

To Test: Check out his branch and try some of the following scenarios:
- Check-all when none/some/all services are already checked
- Un-check-all
- Saving the form and making sure the check-all renders correctly upon initialization

@DanReyLop @jeffstieler @jkudish @allendav @kellychoffman 