### PR TITLE
Show errors from the server inline.

### DIFF
--- a/client/lib/save-form/index.js
+++ b/client/lib/save-form/index.js
@@ -1,4 +1,3 @@
-
 const saveForm = ( setIsSaving, setSuccess, setError, url, nonce, formData ) => {
 	setIsSaving( true );
 	const request = {
@@ -21,7 +20,7 @@ const saveForm = ( setIsSaving, setSuccess, setError, url, nonce, formData ) => 
 			}
 
 			if ( json.data && 'validation_failure' === json.data.error ) {
-				return setError( json.data.message );
+				return setError( json.data.data.fields );
 			}
 
 			return setError( JSON.stringify( json ) )

--- a/client/state/form/reducer.js
+++ b/client/state/form/reducer.js
@@ -4,6 +4,7 @@ import {
 } from './actions';
 import packages from './packages/reducer';
 import * as packagesActions from './packages/actions';
+import * as settingsActions from '../settings/actions';
 
 const reducers = {};
 
@@ -28,9 +29,14 @@ export default function form( state = {}, action ) {
 	}
 
 	if ( state.hasOwnProperty( 'packages' ) || packagesActions.hasOwnProperty( action.type ) ) {
-		newState = Object.assign( {}, newState, {
+		newState = Object.assign( newState, {
 			packages: packages( state.packages || {}, action ),
 		} );
+	}
+
+	// Allow client-side form validation to take over error state when inputs change
+	if ( settingsActions.hasOwnProperty( action.type ) && newState.hasOwnProperty( 'errors' ) ) {
+		delete newState.errors;
 	}
 
 	return newState;

--- a/client/state/form/test/reducer.js
+++ b/client/state/form/test/reducer.js
@@ -4,6 +4,7 @@ import {
 	updateFormElementField,
 	setField,
 } from '../actions';
+import { updateSettingsField } from '../../settings/actions';
 
 const initialState = {
 	textObj: {
@@ -67,5 +68,13 @@ describe( 'Settings reducer', () => {
 				newfield: 'some new value',
 			},
 		} );
+	} );
+
+	it( 'Clears errors on settings state change', () => {
+		const initialErrorState = Object.assign( { errors: ['data.title'] }, initialState );
+		const action = updateSettingsField( 'some_key', 'some value' );
+		const state = reducer( initialErrorState, action );
+
+		expect( state ).to.eql( initialState );
 	} );
 } );


### PR DESCRIPTION
This overrides the calculated client errors with values from state (which are from the server).

This PR seeks to display errors returned from the server inline on the client form.

It changes the form state `error` property to `errors` and sets the value to the array returned by the server during validation failure.

The form component's error property now defaults to this `form.errors` state, falling back to any calculated client-side errors if none are found in state.

Upon interacting with the form and causing a `state.settings` update, the `form.errors` state is cleared, allowing client-side validation to take over.

To test:
- Use this testing branch of the server (forces "title" to error) https://github.com/Automattic/woocommerce-connect-server/tree/test/205-server-errors-on-client
- Submit an error-free settings form
- Verify that an error notice is displayed and the title field shows a validation message
- Add a character to the title field
- Verify that the title error disappears