### PR TITLE
Translate measurement units

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -37,8 +37,8 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 
 			return array(
 				'currency_symbol' => $currency_symbol,
-				'dimension_unit' => $dimension_unit,
-				'weight_unit' => $weight_unit
+				'dimension_unit' => $this->translate_unit( $dimension_unit ),
+				'weight_unit' => $this->translate_unit( $weight_unit ),
 			);
 		}
 
@@ -159,6 +159,32 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			return 'woocommerce_' . $service_id . '_' . $service_instance . '_form_settings';
+		}
+
+		private function translate_unit( $value ) {
+			switch ( $value ) {
+				case 'kg':
+					return __('kg', 'woocommerce');
+				case 'g':
+					return __('g', 'woocommerce');
+				case 'lbs':
+					return __('lbs', 'woocommerce');
+				case 'oz':
+					return __('oz', 'woocommerce');
+				case 'm':
+					return __('m', 'woocommerce');
+				case 'cm':
+					return __('cm', 'woocommerce');
+				case 'mm':
+					return __('mm', 'woocommerce');
+				case 'in':
+					return __('in', 'woocommerce');
+				case 'yd':
+					return __('yd', 'woocommerce');
+				default:
+					error_log( 'Unexpected measurement unit: ' . $value );
+					return $value;
+			}
 		}
 	}
 }

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -182,7 +182,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				case 'yd':
 					return __('yd', 'woocommerce');
 				default:
-					error_log( 'Unexpected measurement unit: ' . $value );
+					$this->logger->log( 'Unexpected measurement unit: ' . $value, __FUNCTION__ );
 					return $value;
 			}
 		}

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -111,11 +111,26 @@
         float:left;
     }
 
-    .form-text-input {
-        width: 78%;
+    &:nth-child(2) {
+        width: 100%;
+        @include breakpoint( '>660px' ) {
+            width: 54%;
+        }
+    }
+
+    #box_weight,
+    #max_weight {
+        width: 82%;
+    }
+
+    #max_weight {
+        @include breakpoint( '>660px' ) {
+            width: 68%;
+        }
     }
 
     .wcc-shipping-add-package-weight-unit {
+        width: 32%;
         padding-left: 8px;
     }
 }

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -144,7 +144,6 @@
     .form-setting-explanation {
         @include breakpoint( '>660px' ) {
             clear: both;
-            margin-top: 68px;
         }
     }
 }

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -107,12 +107,12 @@
 
 .wcc-shipping-add-package-weight {
     margin-bottom: 8px;
-    @include breakpoint( '>480px' ) {
+    @include breakpoint( '>660px' ) {
         float:left;
     }
 
     .form-text-input {
-        width: 88%;
+        width: 78%;
     }
 
     .wcc-shipping-add-package-weight-unit {
@@ -127,8 +127,9 @@
 
 .wcc-shipping-add-package-weight-group {
     .form-setting-explanation {
-        @include breakpoint( '>480px' ) {
+        @include breakpoint( '>660px' ) {
             clear: both;
+            margin-top: 68px;
         }
     }
 }

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -125,12 +125,12 @@
 
     #max_weight {
         @include breakpoint( '>660px' ) {
-            width: 68%;
+            width: 66%;
         }
     }
 
     .wcc-shipping-add-package-weight-unit {
-        width: 32%;
+        width: 34%;
         padding-left: 8px;
     }
 }


### PR DESCRIPTION
Closes #359 

This will provide the WooCommerce translation of dimension and weight units.

To Test:
- Switch your site language to French (not all languages have translations of the units, French does)
- See that the new unit names are displayed in the box packer settings of USPS and CanadaPost

@jeffstieler @allendav @jkudish @DanReyLop 