### PR TITLE
Disable bumping stats when the site is a Jetpack staging site

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -193,6 +193,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				'last_heartbeat' => get_option( 'wc_connect_last_heartbeat', 0 ),
 				'last_rate_request' => get_option( 'wc_connect_last_rate_request', 0 ),
 				'active_services' => $this->wc_connect_loader->get_active_services(),
+				'disable_stats' => Jetpack::is_staging_site(),
 			) );
 
 			$body = wp_json_encode( apply_filters( 'wc_connect_api_client_body', $body ) );

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -145,6 +145,14 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 					__( 'Please connect Jetpack to WordPress.com', 'woocommerce' ),
 					''
 				);
+			} else if ( Jetpack::is_staging_site() ) {
+				$health_item = $this->build_indicator(
+					'jetpack_indicator',
+					'notice',
+					'indicator-warning',
+					__( 'This is a Jetpack staging site', 'woocommerce' ),
+					''
+				);
 			} else {
 				$health_item = $this->build_indicator(
 					'jetpack_indicator',


### PR DESCRIPTION
Solves #336

When the site is a Jetpack staging site (```Jetpack::is_staging_site()``` returns ```true```), the requests sent to the WCC server will have a flag to prevent stats to be bumped for the site.

Also, a notice in the health page will be displayed.

I'm not sure how to test this, since I don't know how to put a site in "staging" mode, I just put a ```return true;``` at the start of ```Jetpack::is_staging_site()``` and check that the notice on the Health page is shown, and that all the requests that the client sends to the WCC server have ```settings.enable_stats = false```.

@jeffstieler @allendav @nabsul 