### PR TITLE
Add fallback message on shipping settings page

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -219,3 +219,23 @@
     @import '../../client/views/shipping/style';
 
 }
+
+@-webkit-keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+@-moz-keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+#wc-connect-admin-container .form-troubles {
+	opacity: 0;
+	-webkit-animation: fadeIn ease-in 1;
+	-moz-animation: fadeIn ease-in 1;
+	animation: fadeIn ease-in 1;
+	-webkit-animation-fill-mode: forwards;
+	-moz-animation-fill-mode: forwards;
+	animation-fill-mode: forwards;
+	-webkit-animation-duration: .5s;
+	-moz-animation-duration: .5s;
+	animation-duration: .5s;
+	-webkit-animation-delay: 3s;
+	-moz-animation-delay: 3s;
+	animation-delay: 3s;
+}

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -314,11 +314,18 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			// hide WP native save button on settings page
 			global $hide_save_button;
 			$hide_save_button = true;
+			$debug_page_uri = esc_url( add_query_arg(
+				array(
+					'page' => 'wc-status',
+					'tab' => 'connect'
+				),
+				admin_url( 'admin.php' )
+			) );
 
 			do_action( 'wc_connect_service_admin_options', $this->id, $this->instance_id );
 
 			?>
-				<div id="wc-connect-admin-container"></div>
+				<div id="wc-connect-admin-container"><span class="form-troubles" style="opacity: 0"><?php printf( __( 'Settings not loading? Visit the WooCommerce Connect <a href="%s">debug page</a> to get some troubleshooting steps.', 'woocommerce' ), $debug_page_uri ); ?></span></div>
 			<?php
 		}
 


### PR DESCRIPTION
This PR seeks to add a fallback message that appears (via a css animation) on the shipping settings form if the form hasn't rendered within 3 seconds. The message prompts the user to visit
the debug page to find some troubleshooting steps.

![image](https://cloud.githubusercontent.com/assets/260253/15868808/473c911a-2c9e-11e6-8937-f8fbd0ca2057.png)

The easiest way to test it is to apply the following diff to `client/main.js`:

```
diff --git a/client/main.js b/client/main.js
index daa853c..d2bc95f 100644
--- a/client/main.js
+++ b/client/main.js
@@ -27,7 +27,7 @@ let render = () => {
        const WCCShippingSettings = require( 'views/shipping' );
        ReactDOM.render(
                <Provider store={ store }>
-                       <WCCShippingSettings
+                       <WCCShippingSetting
                                storeOptions={ storeOptions }
                                schema={ formSchema }
                                layout={ formLayout }
@@ -54,7 +54,7 @@ if ( module.hot ) {
                try {
                        renderApp();
                } catch ( error ) {
-                       renderError( error );
+                       // renderError( error );
                }
        };
```

Though anything that breaks the form from rendering (including changing the schema) is a good way to test this.

Fixes #338 

cc @kellychoffman for a design review (anything we should prettify here?)
cc @nabsul @allendav @jeffstieler @DanReyLop 