### PR TITLE
Improved error handling

### DIFF
--- a/client/components/wcc-settings-form/index.js
+++ b/client/components/wcc-settings-form/index.js
@@ -8,6 +8,7 @@ import * as FormActions from 'state/form/actions';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import isString from 'lodash/isString';
 import isArray from 'lodash/isArray';
+import isEmpty from 'lodash/isEmpty';
 import { translate as __ } from 'lib/mixins/i18n';
 import validator from 'is-my-json-valid';
 import ObjectPath from 'objectpath';
@@ -77,6 +78,10 @@ WCCSettingsForm.propTypes = {
  * This removes the `data.` prepending all errors, to facilitate easier matching to form fields.
  */
 const removeErrorDataPathRoot = ( errantFields ) => {
+	if ( isEmpty( errantFields ) || ! isArray( errantFields ) ) {
+		return [];
+	}
+
 	return errantFields.map( ( field ) => {
 		const errorPath = ObjectPath.parse( field );
 		if ( 'data' === errorPath[0] ) {

--- a/client/lib/save-form/index.js
+++ b/client/lib/save-form/index.js
@@ -19,8 +19,18 @@ const saveForm = ( setIsSaving, setSuccess, setError, url, nonce, formData ) => 
 				return setSuccess( true );
 			}
 
-			if ( json.data && 'validation_failure' === json.data.error ) {
-				return setError( json.data.data.fields );
+			if ( json.data &&
+				'validation_failure' === json.data.error &&
+				json.data.data &&
+				json.data.data.fields
+			) {
+				if ( json.data.data.fields ) {
+					return setError( json.data.data.fields );
+				}
+			}
+
+			if ( json.data.message ) {
+				return setError( json.data.message );
 			}
 
 			return setError( JSON.stringify( json ) )


### PR DESCRIPTION
This PR seeks to improve the catching of errors on the client. Specifically, it adds support for errors returned from the WP-API endpoint as strings, such as problems with communicating with
the server and other errors that are returned directly from that endpoint. This makes sure these errors do not produce a javascript warning and output the error as a notice.

To test:

* Checkout this branch
* `npm start`
* Define `define( 'WOOCOMMERCE_CONNECT_SERVER_URL', ' https://fake.url' );` in your `wp-config.php`
* Attempt to save settings. Verify that you get the following (and no javascript errors):

![image](https://cloud.githubusercontent.com/assets/260253/15871493/b632b4e0-2ca9-11e6-98b9-0d530773c18f.png)


Fixes #386

cc @allendav @nabsul @DanReyLop @jeffstieler 