### PR TITLE
Fix rate adjustment input fields so they let the user write floats like "2.05"

### DIFF
--- a/client/components/shipping/services/entry.js
+++ b/client/components/shipping/services/entry.js
@@ -1,9 +1,9 @@
 import React, { PropTypes } from 'react';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormSelect from 'components/forms/form-select';
-import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
+import NumberInput from './number-input';
 
 const numberRegex = /^\d+(\.\d+)?$/;
 const parseNumber = ( value ) => {
@@ -38,7 +38,7 @@ const ShippingServiceEntry = ( props ) => {
 				{ name }
 			</label>
 			{ hasError ? <Gridicon icon="notice" /> : null }
-			<FormTextInput
+			<NumberInput
 				disabled={ ! enabled }
 				value={ adjustment }
 				onChange={ ( event ) => updateField( 'adjustment', parseNumber( event.target.value ) ) }

--- a/client/components/shipping/services/entry.js
+++ b/client/components/shipping/services/entry.js
@@ -5,9 +5,12 @@ import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import NumberInput from './number-input';
 
-const numberRegex = /^\d+(\.\d+)?$/;
 const parseNumber = ( value ) => {
-	return numberRegex.test( value ) ? Number.parseFloat( value ) : value;
+	if ( '' === value ) {
+		return 0;
+	}
+	const float = Number.parseFloat( value );
+	return isNaN( float ) ? value : float;
 };
 
 const ShippingServiceEntry = ( props ) => {

--- a/client/components/shipping/services/number-input.js
+++ b/client/components/shipping/services/number-input.js
@@ -1,0 +1,54 @@
+import React, { PropTypes } from 'react';
+import FormTextInput from 'components/forms/form-text-input';
+
+export default React.createClass( {
+	displayName: 'NumberInput',
+
+	propTypes: {
+		onChange: PropTypes.func,
+	},
+
+	getDefaultProps() {
+		return {
+			onChange: () => {},
+		}
+	},
+
+	getInitialState() {
+		return {
+			focused: false,
+			text: this.props.value,
+		};
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! this.state.focused && nextProps.value !== this.props.value ) {
+			this.setState( { text: nextProps.value } );
+		}
+	},
+
+	handleChange( event ) {
+		this.setState( { text: event.target.value } );
+		this.props.onChange( event );
+	},
+
+	handleBlur( event ) {
+		this.setState( {
+			focused: false,
+			text: this.props.value,
+		} );
+		this.props.onChange( event );
+	},
+
+	render() {
+		return (
+			<FormTextInput
+				{ ...this.props }
+				value={ this.state.text }
+				onChange={ this.handleChange }
+				onBlur={ this.handleBlur }
+				onFocus={ () => this.setState( { focused: true } ) }
+			/>
+		);
+	},
+} );


### PR DESCRIPTION
Fixes #381 

This is not an ideal solution. The input will only be validated when ```onBlur``` is fired, and the input value won't be reformatted, so the user can submit for example "04.10", the server will receive "4.1", but that change won't be reflected on the form until the user refreshes the page.

To test it, simply go to the USPS form, select one rate and type a value like "2.05" or "invalid123" into the "Adjustment" field.

To make this work flawlesly, the ```ShippingServiceEntry``` component (or a sub-component) would need to have state (and since our tree is fully stateless right now, that would be a bummer). Tell me if you want me to go that way, or if this solution is good enough.

@nabsul @jkudish @allendav @jeffstieler 