### PR TITLE
Enables Javascript minification in production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "cross-env NODE_ENV=development webpack-dev-server --hot --inline --watch --content-base dist --port 8085",
-    "dist": "cross-env NODE_ENV=production webpack -p --config webpack.production.config.js",
+    "dist": "cross-env NODE_ENV=production webpack --config webpack.production.config.js",
     "eslint": "eslint tasks/ client/",
     "test": "karma start --single-run --no-auto-watch",
     "test-watch": "karma start --auto-watch --no-single-run",

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -1,16 +1,22 @@
 var webpack = require( 'webpack' ),
-	webpackBaseConfig = require( './webpack.config.js' ),
-	plugins = webpackBaseConfig.plugins || [],
-	output = webpackBaseConfig.output || {};
+	config = require( './webpack.config.js' );
 
-delete output.publicPath;
+delete config.output.publicPath;
+delete config.devtool;
 
-var productionConfig = Object.assign( {}, webpackBaseConfig, {
-		output,
-		plugins
-	} );
+config.plugins.push( new webpack.DefinePlugin( {
+	'process.env.NODE_ENV': '"production"'
+} ) );
 
-productionConfig.plugins.push( new webpack.optimize.UglifyJsPlugin() );
-productionConfig.plugins.push( new webpack.optimize.DedupePlugin() );
+config.plugins.push( new webpack.optimize.OccurrenceOrderPlugin( false ) );
 
-module.exports = productionConfig;
+config.plugins.push( new webpack.optimize.UglifyJsPlugin( {
+	compress: {
+		warnings: false,
+		unsafe: true,
+	},
+} ) );
+
+config.plugins.push( new webpack.optimize.DedupePlugin() );
+
+module.exports = config;


### PR DESCRIPTION
Production builds weren't minifying the Javascript properly. It was because in the development webpack config it was specified that modules were contatenated using `eval` calls, and that couldn't be minified, since the entire modules were strings.

I've also cleaned-up the webpack production config file, it was way more complex than it needs to be, I'm not sure if it was an historical reason for that.

To test this, just run `npm run dist`, check that the JS is now less than 500KB, and try to use the client in "production" mode (without the Webpack dev server).

cc @allendav @nabsul @jkudish @jeffstieler 