### PR TITLE
Add Number support to text fields (in preparation for fallback rate support)

### DIFF
--- a/client/components/shipping/services/entry.js
+++ b/client/components/shipping/services/entry.js
@@ -4,11 +4,7 @@ import FormSelect from 'components/forms/form-select';
 import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
-
-const numberRegex = /^\d+(\.\d+)?$/;
-const parseNumber = ( value ) => {
-	return numberRegex.test( value ) ? Number.parseFloat( value ) : value;
-};
+import parseNumber from 'lib/utils/parse-number';
 
 const ShippingServiceEntry = ( props ) => {
 	const {

--- a/client/components/text-field/index.js
+++ b/client/components/text-field/index.js
@@ -5,6 +5,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormInputValidation from 'components/forms/form-input-validation';
 import { sanitize } from 'dompurify';
+import parseNumber from 'lib/utils/parse-number';
 
 const renderFieldDescription = ( description ) => {
 	return (
@@ -19,7 +20,14 @@ const renderFieldError = ( validationHint ) => {
 }
 
 const TextField = ( { id, schema, value, placeholder, updateValue, error } ) => {
-	const handleChangeEvent = event => updateValue( event.target.value );
+	const handleChangeEvent = ( event ) => {
+		let newValue = event.target.value;
+		if ( 'number' === schema.type ) {
+			// TODO: allow this value to be empty instead of zero
+			newValue = parseNumber( newValue ) || 0;
+		}
+		updateValue( newValue );
+	};
 
 	return (
 		<FormFieldset>
@@ -45,7 +53,10 @@ TextField.propTypes = {
 		description: PropTypes.string,
 		default: PropTypes.string,
 	} ).isRequired,
-	value: PropTypes.string.isRequired,
+	value: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.number,
+	] ),
 	updateValue: PropTypes.func,
 	error: PropTypes.oneOfType( [
 		PropTypes.string,

--- a/client/lib/utils/parse-number.js
+++ b/client/lib/utils/parse-number.js
@@ -1,0 +1,6 @@
+const numberRegex = /^\d+(\.\d+)?$/;
+const parseNumber = ( value ) => {
+	return numberRegex.test( value ) ? Number.parseFloat( value ) : value;
+};
+
+export default parseNumber;


### PR DESCRIPTION
This PR seeks to add `Number` support to the `textField` component, in preparation for supporting the fallback rate setting.

This PR should be tested in conjunction with https://github.com/Automattic/woocommerce-connect-server/pull/300 -- where full testing instructions are included.

See https://github.com/Automattic/woocommerce-connect-client/issues/265

cc @nabsul @allendav @jeffstieler @DanReyLop 