### PR TITLE
Add/debug services

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -224,6 +224,7 @@
     // WCC Components
     @import '../../client/components/shipping/packages/style';
     @import '../../client/components/indicators/style';
+		@import '../../client/components/text/style';
     @import '../../client/components/text-area/style';
     @import '../../client/components/toggle/style';
     @import '../../client/views/shipping/style';

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -224,7 +224,7 @@
     // WCC Components
     @import '../../client/components/shipping/packages/style';
     @import '../../client/components/indicators/style';
-		@import '../../client/components/text/style';
+    @import '../../client/components/text/style';
     @import '../../client/components/text-area/style';
     @import '../../client/components/toggle/style';
     @import '../../client/views/shipping/style';

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -266,7 +266,8 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 
 			foreach ( (array) $enabled_services as $enabled_service ) {
 				$indicator_key = "{$enabled_service->method_id}_{$enabled_service->instance_id}_1";
-				$last_failed_request_timestamp = intval( get_option( 'wc_connect_last_rate_request_failure', -1 ) );
+				$failure_timestamp_key = $this->service_settings_store->get_service_failure_timestamp_key( $enabled_service->method_id, $enabled_service->instance_id );
+				$last_failed_request_timestamp = intval( get_option( $failure_timestamp_key, -1 ) );
 
 				$service_settings_url = esc_url( add_query_arg(
 					array(

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -304,8 +304,6 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 
 				// Figure out if the service has any settings saved at all
 				$service_settings = $this->service_settings_store->get_service_settings( $enabled_service->method_id, $enabled_service->instance_id );
-				error_log( "service settings:" );
-				error_log( print_r( $service_settings, true ) );
 				if ( empty( $service_settings ) ) {
 					$indicator = $this->build_indicator(
 						$indicator_key,

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -265,7 +265,7 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 			}
 
 			foreach ( (array) $enabled_services as $enabled_service ) {
-				$indicator_key = "{$enabled_service->method_id}_{$enabled_service->instance_id}_1";
+				$indicator_key = "{$enabled_service->method_id}_{$enabled_service->instance_id}";
 				$failure_timestamp_key = $this->service_settings_store->get_service_failure_timestamp_key( $enabled_service->method_id, $enabled_service->instance_id );
 				$last_failed_request_timestamp = intval( get_option( $failure_timestamp_key, -1 ) );
 

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -298,7 +298,7 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 						_x( 'Request was made %1$s ago - <a href="%2$s">edit service settings</a>', 'e.g. two hours', 'woocommerce' ),
 						array( 'a' => array( 'href' => array() ) )
 					),
-					esc_html( human_time_diff( current_time( 'timestamp' ) - $last_failed_request_timestamp ) ),
+					esc_html( human_time_diff( $last_failed_request_timestamp ) ),
 					esc_url( $service_settings_url )
 				);
 

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -341,15 +341,15 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 				}
 
 				$items_key = "{$enabled_service->method_id}_{$enabled_service->instance_id}_items";
-				$items_title = sprintf(
-					_x( '%s (%s Shipping Zone)', 'e.g. US Post Office (Domestic Shipping Zone)', 'woocommerce' ),
-					$enabled_service->title,
+				$subtitle = sprintf(
+					__( '%s Shipping Zone', 'woocommerce' ),
 					$enabled_service->zone_name
 				);
 
 				$service_items[] = (object) array(
 					'key' => $items_key,
-					'title' => $items_title,
+					'title' => $enabled_service->title,
+					'subtitle' => $subtitle,
 					'type' => 'indicators',
 					'items' => array(
 						$indicator_key => $indicator
@@ -527,6 +527,10 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 							'definition' => $fieldsetitem->key . '_definitions',
 							'items' => $this->get_indicator_schema()
 						);
+
+						if ( property_exists( $fieldsetitem, 'subtitle' ) ) {
+							$form_properties[ $fieldsetitem->key ][ 'subtitle' ] = $fieldsetitem->subtitle;
+						}
 
 						foreach ( $fieldsetitem->items as $item ) {
 							$form_definitions[ $fieldsetitem->key . '_definitions' ][] = (object) array(

--- a/classes/class-wc-connect-help-provider.php
+++ b/classes/class-wc-connect-help-provider.php
@@ -249,6 +249,17 @@ if ( ! class_exists( 'WC_Connect_Help_Provider' ) ) {
 		}
 
 		protected function get_services_items() {
+
+			$enabled_services = $this->service_settings_store->get_enabled_services();
+
+			// Iterate over each shipping zone
+			// For each WCC shipping method found in a zone
+			// see if the most recent rate request succeeded or not
+			// if successful, display that it was successful (have some details maybe?)
+			// if not, display why it failed if we can figure it out with a link to the instance's settings
+			// if no rate request has ever been done and no settings have been saved, display that
+			// if no rate request has ever been done but settings exist, validate them and save that state
+
 			return array();
 		}
 

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -197,6 +197,24 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			return 'woocommerce_' . $service_id . '_' . $service_instance . '_form_settings';
 		}
 
+		/**
+		 * Based on the service id and optional instance, generates the options key that
+		 * should be used to get/set the service's last failure timestamp
+		 *
+		 * @param string $service_id
+		 * @param integer $service_instance
+		 *
+		 * @return string
+		 */
+		public function get_service_failure_timestamp_key( $service_id, $service_instance = false ) {
+			if ( ! $service_instance ) {
+				return 'woocommerce_' . $service_id . '_failure_timestamp';
+			}
+
+			return 'woocommerce_' . $service_id . '_' . $service_instance . '_failure_timestamp';
+		}
+
+
 		private function translate_unit( $value ) {
 			switch ( $value ) {
 				case 'kg':

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -87,9 +87,18 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			foreach ( (array) $methods as $method ) {
+				$service_schema = $this->service_schemas_store->get_service_schema_by_id( $method->method_id );
+				$service_settings = $this->get_service_settings( $method->method_id, $method->instance_id );
+				if ( is_object( $service_settings ) && property_exists( $service_settings, 'title' ) ) {
+					$title = $service_settings->title;
+				} else if ( is_object( $service_schema ) && property_exists( $service_schema, 'method_title' ) ) {
+					$title = $this->method_title;
+				} else {
+					$title = _x( 'Unknown', 'A service with an unknown title and unknown method_title', 'woocommerce' );
+				}
 				$method->service_type = 'shipping';
+				$method->title = $title;
 				$enabled_services[] = $method;
-				// TODO - as a convenience to the caller, add method_title and title too
 			}
 
 			error_log( print_r( $enabled_services, true ) );

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -73,12 +73,22 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			}
 
 			global $wpdb;
+			$zone_names = $wpdb->get_results(
+				"SELECT zone_id, zone_name FROM {$wpdb->prefix}woocommerce_shipping_zones " .
+				"ORDER BY zone_order " .
+				";",
+				OBJECT_K
+			);
+
+			$zone_names[0] = (object) array(
+				'zone_id' => 0,
+				'zone_name' => __( 'Rest of the World', 'woocommerce' )
+			);
+
 			$methods = $wpdb->get_results(
 				"SELECT * FROM {$wpdb->prefix}woocommerce_shipping_zone_methods " .
-				"INNER JOIN {$wpdb->prefix}woocommerce_shipping_zones " .
-				"ON {$wpdb->prefix}woocommerce_shipping_zone_methods.zone_id = {$wpdb->prefix}woocommerce_shipping_zones.zone_id " .
 				"WHERE method_id IN ({$escaped_list}) " .
-				"ORDER BY zone_order, method_order " .
+				"ORDER BY method_order " .
 				";"
 			);
 
@@ -98,6 +108,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				}
 				$method->service_type = 'shipping';
 				$method->title = $title;
+				$method->zone_name = $zone_names[ $method->zone_id ]->zone_name;
 				$enabled_services[] = $method;
 			}
 

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -92,7 +92,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				if ( is_object( $service_settings ) && property_exists( $service_settings, 'title' ) ) {
 					$title = $service_settings->title;
 				} else if ( is_object( $service_schema ) && property_exists( $service_schema, 'method_title' ) ) {
-					$title = $this->method_title;
+					$title = $service_schema->method_title;
 				} else {
 					$title = _x( 'Unknown', 'A service with an unknown title and unknown method_title', 'woocommerce' );
 				}
@@ -100,8 +100,6 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 				$method->title = $title;
 				$enabled_services[] = $method;
 			}
-
-			error_log( print_r( $enabled_services, true ) );
 
 			return $enabled_services;
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -319,7 +319,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				$timestamp = time();
 			}
 
-			update_option( 'wc_connect_last_rate_request_failure', $timestamp );
+			update_option( $this->service_settings_store->get_service_failure_timestamp_key( $this->id, $this->instance_id ), $timestamp );
 		}
 
 		public function admin_options() {

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -263,11 +263,14 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 					__FUNCTION__
 				);
 
+				$this->set_last_request_failed();
+
 				$this->log( $response_body, __FUNCTION__ );
 				return;
 			}
 
 			if ( ! property_exists( $response_body, 'rates' ) ) {
+				$this->set_last_request_failed();
 				return;
 			}
 			$instances = $response_body->rates;
@@ -300,6 +303,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			}
 
 			$this->update_last_rate_request_timestamp();
+			$this->set_last_request_failed( 0 );
 		}
 
 		public function update_last_rate_request_timestamp() {
@@ -308,6 +312,14 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				( time() - HOUR_IN_SECONDS ) > $previous_timestamp ) {
 				update_option( 'wc_connect_last_rate_request', time() );
 			}
+		}
+
+		public function set_last_request_failed( $timestamp = null ) {
+			if ( is_null( $timestamp ) ) {
+				$timestamp = time();
+			}
+
+			update_option( 'wc_connect_last_rate_request_failure', $timestamp );
 		}
 
 		public function admin_options() {

--- a/client/components/indicators/index.js
+++ b/client/components/indicators/index.js
@@ -37,10 +37,20 @@ const Indicator = ( { icon, className, message, lastUpdated } ) => {
 	);
 };
 
+const renderSubTitle = ( subtitle ) => {
+	if ( ! subtitle ) {
+		return null;
+	}
+
+	return (
+		<span className="indicators__subtitle">{ subtitle }</span>
+	);
+};
+
 const Indicators = ( { schema, indicators } ) => {
 	return (
 		<FormFieldset>
-			<FormLegend>{ schema.title }</FormLegend>
+			<FormLegend>{ schema.title }{ renderSubTitle( schema.subtitle ) }</FormLegend>
 			{ indicators.map( indicator => (
 				<Indicator
 					key={ indicator.id }

--- a/client/components/indicators/index.js
+++ b/client/components/indicators/index.js
@@ -3,6 +3,23 @@ import classNames from 'classnames';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import Gridicon from 'components/gridicon';
+import { sanitize } from 'dompurify';
+
+const renderLastUpdated = ( lastUpdated ) => {
+	if ( ! lastUpdated ) {
+		return null;
+	}
+
+	/* for dangerouslySetInnerHTML we need to pause linting for a narrow scope */
+	/* eslint-disable */
+	return (
+		<div className="form-setting-explanation indicator__last-updated">
+			<span dangerouslySetInnerHTML={ { __html: sanitize( lastUpdated, { ADD_ATTR: ['target'] } ) } } >
+			</span>
+		</div>
+	);
+	/* eslint-enable */
+};
 
 const Indicator = ( { icon, className, message, lastUpdated } ) => {
 	return (
@@ -15,11 +32,7 @@ const Indicator = ( { icon, className, message, lastUpdated } ) => {
 					{ message }
 				</div>
 			</div>
-			{ lastUpdated
-				? <div className="form-setting-explanation indicator__last-updated">
-						<span>{ lastUpdated }</span>
-					</div>
-				: null }
+			{ renderLastUpdated( lastUpdated ) }
 		</div>
 	);
 };

--- a/client/components/indicators/style.scss
+++ b/client/components/indicators/style.scss
@@ -45,12 +45,11 @@
 }
 
 .indicators__subtitle {
-	background: $gray;
+	background: lighten( $gray, 30% );
 	border-radius: 2px;
-	color: $gray-light;
+	color: darken( $gray, 30% );
 	font-size: 11px;
-	font-weight: 200;
-	margin-left: 5px;
-	padding: 1px 5px;
-	text-transform: uppercase;
+	font-weight: 400;
+	margin-left: 8px;
+	padding: 2px 8px;
 }

--- a/client/components/indicators/style.scss
+++ b/client/components/indicators/style.scss
@@ -43,3 +43,14 @@
 		fill: $alert-red;
 	}
 }
+
+.indicators__subtitle {
+	background: $gray;
+	border-radius: 2px;
+	color: $gray-light;
+	font-size: 11px;
+	font-weight: 200;
+	margin-left: 5px;
+	padding: 1px 5px;
+	text-transform: uppercase;
+}

--- a/client/components/indicators/style.scss
+++ b/client/components/indicators/style.scss
@@ -18,6 +18,10 @@
 
 .form-setting-explanation.indicator__last-updated {
 	margin-top: 0;
+
+	a {
+		font-style: normal;
+	}
 }
 
 .indicator-success .indicator__icon-and-message {

--- a/client/components/text/index.js
+++ b/client/components/text/index.js
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react';
 import FormFieldset from 'components/forms/form-fieldset';
 
 const Text = ( { id, layout, value } ) => {
-	console.log( layout );
 	return (
 		<FormFieldset>
 			<p id={ id } className={ layout.class } >

--- a/client/components/text/index.js
+++ b/client/components/text/index.js
@@ -1,0 +1,23 @@
+import React, { PropTypes } from 'react';
+import FormFieldset from 'components/forms/form-fieldset';
+
+const Text = ( { id, layout, value } ) => {
+	console.log( layout );
+	return (
+		<FormFieldset>
+			<p id={ id } className={ layout.class } >
+				{ value }
+			</p>
+		</FormFieldset>
+	);
+};
+
+Text.propTypes = {
+	id: PropTypes.string.isRequired,
+	layout: PropTypes.shape( {
+		class: PropTypes.string,
+	} ),
+	value: PropTypes.string.isRequired,
+};
+
+export default Text;

--- a/client/components/text/style.scss
+++ b/client/components/text/style.scss
@@ -1,0 +1,5 @@
+.form_text_body_copy {
+	font-size: '14px';
+	font-weight: '400';
+	line-height: '1.5';
+}

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import Indicators from 'components/indicators';
+import Text from 'components/text';
 import TextArea from 'components/text-area';
 import TextField from 'components/text-field';
 import Toggle from 'components/toggle';
@@ -74,6 +75,15 @@ const SettingsItem = ( {
 				<Indicators
 					schema={ schema.properties[id] }
 					indicators={ Object.values( settings[id] ) }
+				/>
+			);
+
+		case 'text':
+			return (
+				<Text
+					id={ id }
+					layout={ layout }
+					value={ fieldValue }
 				/>
 			);
 


### PR DESCRIPTION
Adds indicators for each shipping method instance to the services section in wp-admin > WooCommerce > System Status >  WooCommerce Connect

To test:
Add one or two WCC methods to one or two zones
Try different combinations of different methods
Add at least one method to a zone but never set up its settings
Have at least one method have good settings (e.g. origin, a few selected services set)
Add an item to the cart and allow a rate request for that method to succeed
Kill the local server and have a rate request for a method fail

Ensure all of this is reflected in the UI, e.g.:

![screen shot 2016-06-15 at 10 12 54 am](https://cloud.githubusercontent.com/assets/1595739/16089933/352f39b0-32e2-11e6-8d4c-6c0e7f839720.png)

Note: I did NOT implement it exactly per the original mocks (we aren't numbering identically named Shipping Zones since the methods setting links will go to the correct settings anyways.)

cc @kellychoffman @DanReyLop @nabsul @jeffstieler for review