### PR TITLE
Added the possibility to display a validation error on the Services fieldset

### DIFF
--- a/assets/stylesheets/shipping-services.scss
+++ b/assets/stylesheets/shipping-services.scss
@@ -8,8 +8,20 @@
 	}
 }
 
-.wcc-shipping-services-groups-inner.is-error {
-	border: 1px solid $alert-red;
+.wcc-shipping-services-groups-inner.is-error .card {
+	border-top: 1px;
+	border-right: 1px;
+	border-left: 1px;
+	border-color: $alert-red;
+	border-style: solid;
+
+	&:last-child {
+		border-bottom: 1px solid $alert-red;
+	}
+	
+	&.is-expanded {
+		border: 1px solid $alert-red;
+	}
 }
 
 .wcc-shipping-services-group {

--- a/assets/stylesheets/shipping-services.scss
+++ b/assets/stylesheets/shipping-services.scss
@@ -8,6 +8,10 @@
 	}
 }
 
+.wcc-shipping-services-groups-inner.is-error {
+	border: 1px solid $alert-red;
+}
+
 .wcc-shipping-services-group {
 	border: 1px solid lighten( $gray, 20% );
 	margin-bottom: 16px;

--- a/client/components/shipping/services/index.js
+++ b/client/components/shipping/services/index.js
@@ -2,6 +2,14 @@ import React, { PropTypes } from 'react';
 import groupBy from 'lodash/groupBy';
 import ShippingServiceGroup from './group';
 import map from 'lodash/map';
+import classNames from 'classnames';
+import FormInputValidation from 'components/forms/form-input-validation';
+
+const renderFieldError = ( validationHint ) => {
+	return (
+		<FormInputValidation isError text={ validationHint } />
+	);
+};
 
 const ShippingServiceGroups = ( {
 	services,
@@ -10,6 +18,7 @@ const ShippingServiceGroups = ( {
 	updateValue,
 	settingsKey,
 	errors,
+	generalError,
 } ) => {
 	// Some shippers have so many services that it is helpful to organize them
 	// into groups.  This code iterates over the services and extracts the group(s)
@@ -36,7 +45,10 @@ const ShippingServiceGroups = ( {
 
 	return (
 		<div className="wcc-shipping-services-groups">
-			{ Object.keys( serviceGroups ).sort().map( renderServiceGroup ) }
+			<div className={ classNames( 'wcc-shipping-services-groups-inner', { 'is-error': generalError } ) }>
+				{ Object.keys( serviceGroups ).sort().map( renderServiceGroup ) }
+			</div>
+			{ generalError ? renderFieldError( generalError ) : null }
 		</div>
 	);
 };

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import some from 'lodash/some';
 import Indicators from 'components/indicators';
 import TextArea from 'components/text-area';
 import TextField from 'components/text-field';
@@ -26,7 +27,10 @@ const SettingsItem = ( {
 	const fieldRequired = ( -1 !== schema.required.indexOf( id ) );
 	const fieldValue = settings[ id ];
 	const fieldSchema = schema.properties[ id ];
-	const fieldError = ( errors && errors.length ) ? ( layout.validation_hint || '' ) : false;
+
+	// Check if the response has an error for this concrete field (not any subfields)
+	const hasDirectError = errors && some( errors, error => ! error.length );
+	const fieldError = hasDirectError ? ( layout.validation_hint || '' ) : false;
 
 	switch ( layout.type ) {
 		case 'radios':
@@ -49,6 +53,7 @@ const SettingsItem = ( {
 					updateValue={ updateSubSubValue }
 					settingsKey={ id }
 					errors={ errors }
+					generalError={ fieldError }
 				/>
 			);
 

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -29,8 +29,8 @@ const SettingsItem = ( {
 	const fieldSchema = schema.properties[ id ];
 
 	// Check if the response has an error for this concrete field (not any subfields)
-	const hasDirectError = errors && some( errors, error => ! error.length );
-	const fieldError = hasDirectError ? ( layout.validation_hint || '' ) : false;
+	const hasFieldError = errors && some( errors, error => ! error.length );
+	const fieldError = hasFieldError ? ( layout.validation_hint || '' ) : false;
 
 	switch ( layout.type ) {
 		case 'radios':


### PR DESCRIPTION
Allows the Services entire fieldset to have an error state as a whole (not only for sub-fields), and a ```validation_hint```.

Server-side PR: https://github.com/Automattic/woocommerce-connect-server/pull/301

How to test: You will to update your server to https://github.com/Automattic/woocommerce-connect-server/pull/301 , after that just go to configure a USPS provider and leave all the Services unchecked. After you submit the changes you should see an error in the Service fieldset.

cc/ @allendav @nabsul @jeffstieler 

cc/ @kellychoffman if you want to tweak the design for the error field