### PR TITLE
Packages: Update box icon to `product` gridicon

### DIFF
--- a/client/components/shipping/packages/packages-list-item.js
+++ b/client/components/shipping/packages/packages-list-item.js
@@ -9,7 +9,7 @@ const renderIcon = ( isLetter, isError, onClick ) => {
 	if ( isError ) {
 		icon = 'notice';
 	} else {
-		icon = isLetter ? 'mail' : 'flip-horizontal';
+		icon = isLetter ? 'mail' : 'product';
 	}
 	return (
 		<a href="#" onClick={ onClick }>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4324,7 +4324,7 @@
     "wp-calypso": {
       "version": "0.17.0",
       "from": "automattic/wp-calypso",
-      "resolved": "git://github.com/automattic/wp-calypso.git#d8e00f0ad45193172e82a296d18f80e46e1f8604",
+      "resolved": "git://github.com/automattic/wp-calypso.git#2db6c43aee4832ca02d86331c2acd2e35cb8c07a",
       "dependencies": {
         "abbrev": {
           "version": "1.0.7",


### PR DESCRIPTION
Fixes: https://github.com/Automattic/woocommerce-connect-client/issues/379

We were temporarily using an image icon for box packages. This updates to use an actual box. 

<img width="316" alt="screen shot 2016-06-17 at 4 56 38 pm" src="https://cloud.githubusercontent.com/assets/5835847/16164496/7ba96cdc-34ac-11e6-9efd-c797db1594e8.png">

To test:
* npm cache clear
* rm -rf node_modules/
* npm install
* npm start
* Go to the instance page for a service instance and add a box. Make sure you get a box icon, e.g.:

<img width="519" alt="screen shot 2016-06-27 at 4 50 36 pm" src="https://cloud.githubusercontent.com/assets/1595739/16399443/4ff8e85a-3c87-11e6-9a42-a1dc7471ca49.png">
