### PR TITLE
Added the possibility to display a title and a description for the "Services" field

### DIFF
--- a/assets/stylesheets/shipping-services.scss
+++ b/assets/stylesheets/shipping-services.scss
@@ -8,19 +8,23 @@
 	}
 }
 
-.wcc-shipping-services-groups-inner.is-error .card {
-	border-top: 1px;
-	border-right: 1px;
-	border-left: 1px;
-	border-color: $alert-red;
-	border-style: solid;
+.wcc-shipping-services-groups-inner {
+	margin-top: 8px;
 
-	&:last-child {
-		border-bottom: 1px solid $alert-red;
-	}
-	
-	&.is-expanded {
-		border: 1px solid $alert-red;
+	&.is-error .card {
+		border-top: 1px;
+		border-right: 1px;
+		border-left: 1px;
+		border-color: $alert-red;
+		border-style: solid;
+
+		&:last-child {
+			border-bottom: 1px solid $alert-red;
+		}
+
+		&.is-expanded {
+			border: 1px solid $alert-red;
+		}
 	}
 }
 

--- a/assets/stylesheets/shipping-services.scss
+++ b/assets/stylesheets/shipping-services.scss
@@ -9,7 +9,7 @@
 }
 
 .wcc-shipping-services-groups-inner {
-	margin-top: 8px;
+	margin-top: 16px;
 
 	&.is-error .card {
 		border-top: 1px;

--- a/client/components/shipping/services/index.js
+++ b/client/components/shipping/services/index.js
@@ -4,6 +4,15 @@ import ShippingServiceGroup from './group';
 import map from 'lodash/map';
 import classNames from 'classnames';
 import FormInputValidation from 'components/forms/form-input-validation';
+import FormLegend from 'components/forms/form-legend';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import { sanitize } from 'dompurify';
+
+const renderFieldDescription = ( description ) => {
+	return (
+		description ? <FormSettingExplanation dangerouslySetInnerHTML={ { __html: sanitize( description, { ADD_ATTR: [ 'target' ] } ) } } /> : null
+	);
+};
 
 const renderFieldError = ( validationHint ) => {
 	return (
@@ -12,6 +21,7 @@ const renderFieldError = ( validationHint ) => {
 };
 
 const ShippingServiceGroups = ( {
+	schema,
 	services,
 	settings,
 	currencySymbol,
@@ -45,6 +55,8 @@ const ShippingServiceGroups = ( {
 
 	return (
 		<div className="wcc-shipping-services-groups">
+			<FormLegend>{ schema.title }</FormLegend>
+			{ renderFieldDescription( schema.description ) }
 			<div className={ classNames( 'wcc-shipping-services-groups-inner', { 'is-error': generalError } ) }>
 				{ Object.keys( serviceGroups ).sort().map( renderServiceGroup ) }
 			</div>
@@ -54,6 +66,11 @@ const ShippingServiceGroups = ( {
 };
 
 ShippingServiceGroups.propTypes = {
+	schema: PropTypes.shape( {
+		type: PropTypes.string.valueOf( 'string' ),
+		title: PropTypes.string.isRequired,
+		description: PropTypes.string,
+	} ).isRequired,
 	services: PropTypes.array.isRequired,
 	settings: PropTypes.object.isRequired,
 	currencySymbol: PropTypes.string,

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -49,6 +49,7 @@ const SettingsItem = ( {
 			return (
 				<ShippingServiceGroups
 					services={ schema.definitions.services }
+					schema={ fieldSchema }
 					settings={ fieldValue }
 					currencySymbol={ storeOptions.currency_symbol }
 					updateValue={ updateSubSubValue }


### PR DESCRIPTION
Fixes #404 

To test this, just go to the settings page of USPS or Canada Post, you should see that now the Services component has a title and a description, like in this screenshot:

![services_title](https://cloud.githubusercontent.com/assets/1715800/16165950/e3f3f848-34de-11e6-9bc0-513df5fac669.png)

@allendav @nabsul @kellychoffman 