### PR TITLE
wp_kses the placeholder

### DIFF
--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -332,7 +332,17 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			do_action( 'wc_connect_service_admin_options', $this->id, $this->instance_id );
 
 			?>
-				<div id="wc-connect-admin-container"><span class="form-troubles" style="opacity: 0"><?php printf( __( 'Settings not loading? Visit the WooCommerce Connect <a href="%s">debug page</a> to get some troubleshooting steps.', 'woocommerce' ), $debug_page_uri ); ?></span></div>
+				<div id="wc-connect-admin-container">
+					<span class="form-troubles" style="opacity: 0">
+						<?php printf(
+							wp_kses(
+								__( 'Settings not loading? Visit the WooCommerce Connect <a href="%s">debug page</a> to get some troubleshooting steps.', 'woocommerce' ),
+								array( 'a' => array( 'href' => array() ) )
+							),
+						$debug_page_uri
+						); ?>
+					</span>
+				</div>
 			<?php
 		}
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -339,7 +339,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 								__( 'Settings not loading? Visit the WooCommerce Connect <a href="%s">debug page</a> to get some troubleshooting steps.', 'woocommerce' ),
 								array( 'a' => array( 'href' => array() ) )
 							),
-						$debug_page_uri
+							$debug_page_uri
 						); ?>
 					</span>
 				</div>


### PR DESCRIPTION
Fixes #403 

To test, change

```
<div id="wc-connect-admin-container">
```

to

```
<div id="wc-connect-admin-ponies">
```

and

```
<span class="form-troubles" style="opacity: 0">
```

to

```
<span class="form-troubles" style="opacity: 1">
```

So you can see the message and click the link.