### PR TITLE
Moved the form errors calculation to a selector

### DIFF
--- a/client/components/wcc-settings-form/index.js
+++ b/client/components/wcc-settings-form/index.js
@@ -8,12 +8,10 @@ import * as FormActions from 'state/form/actions';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import isString from 'lodash/isString';
 import isArray from 'lodash/isArray';
-import isEmpty from 'lodash/isEmpty';
 import { translate as __ } from 'lib/mixins/i18n';
-import validator from 'is-my-json-valid';
-import ObjectPath from 'objectpath';
 import * as SettingsActions from 'state/settings/actions';
 import * as PackagesActions from 'state/form/packages/actions';
+import { getFormErrors } from 'state/selectors';
 
 const WCCSettingsForm = ( props ) => {
 	const {
@@ -74,43 +72,11 @@ WCCSettingsForm.propTypes = {
 	saveFormData: PropTypes.func.isRequired,
 };
 
-/*
- * Errors from `is-my-json-valid` are paths to fields, all using `data` as the root.
- *
- * e.g.: `data.services.first_class_parcel.adjustment
- *
- * This removes the `data.` prepending all errors, to facilitate easier matching to form fields.
- */
-const removeErrorDataPathRoot = ( errantFields ) => {
-	if ( isEmpty( errantFields ) || ! isArray( errantFields ) ) {
-		return [];
-	}
-
-	return errantFields.map( ( field ) => {
-		const errorPath = ObjectPath.parse( field );
-		if ( 'data' === errorPath[ 0 ] ) {
-			return errorPath.slice( 1 );
-		}
-		return errorPath;
-	} );
-};
-
-const getFormErrors = ( schema, data ) => {
-	const validate = validator( schema, { greedy: true } );
-	const success = validate( data );
-
-	if ( ! success && validate.errors && validate.errors.length ) {
-		return validate.errors.map( ( error ) => error.field );
-	}
-
-	return [];
-};
-
-function mapStateToProps( state, props ) {
+function mapStateToProps( state ) {
 	return {
 		settings: state.settings,
 		form: state.form,
-		errors: removeErrorDataPathRoot( state.form.errors || getFormErrors( props.schema, state.settings ) ),
+		errors: getFormErrors( state ),
 	};
 }
 

--- a/client/lib/initialize-state/index.js
+++ b/client/lib/initialize-state/index.js
@@ -27,6 +27,7 @@ export default ( schema, values ) => {
 	return {
 		settings: formValues,
 		form: {
+			schema,
 			isSaving: false,
 			pristine: true,
 			packages: {

--- a/client/state/selectors.js
+++ b/client/state/selectors.js
@@ -1,0 +1,44 @@
+import { createSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+import isArray from 'lodash/isArray';
+import validator from 'is-my-json-valid';
+import ObjectPath from 'objectpath';
+
+/*
+ * Errors from `is-my-json-valid` are paths to fields, all using `data` as the root.
+ *
+ * e.g.: `data.services.first_class_parcel.adjustment
+ *
+ * This removes the `data.` prepending all errors, to facilitate easier matching to form fields.
+ */
+const removeErrorDataPathRoot = ( errantFields ) => {
+	if ( isEmpty( errantFields ) || ! isArray( errantFields ) ) {
+		return [];
+	}
+
+	return errantFields.map( ( field ) => {
+		const errorPath = ObjectPath.parse( field );
+		if ( 'data' === errorPath[ 0 ] ) {
+			return errorPath.slice( 1 );
+		}
+		return errorPath;
+	} );
+};
+
+const getRawFormErrors = ( schema, data ) => {
+	const validate = validator( schema, { greedy: true } );
+	const success = validate( data );
+
+	if ( ! success && validate.errors && validate.errors.length ) {
+		return validate.errors.map( ( error ) => error.field );
+	}
+
+	return [];
+};
+
+export const getFormErrors = createSelector(
+	( state ) => state.form.errors,
+	( state ) => state.form.schema,
+	( state ) => state.settings,
+	( errors, schema, data ) => removeErrorDataPathRoot( errors || getRawFormErrors( schema, data ) )
+);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3742,6 +3742,10 @@
       "version": "1.0.0",
       "from": "requires-port@>=1.0.0 <2.0.0"
     },
+	"reselect": {
+	  "version": "2.5.1",
+	  "from": "reselect@>=2.5.1 <3.0.0"
+	},
     "resolve": {
       "version": "1.1.7",
       "from": "resolve@>=1.1.6 <2.0.0"

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react-dom": "0.14.7",
     "react-redux": "^4.4.1",
     "redux": "^3.3.1",
+    "reselect": "^2.5.1",
     "sprintf-js": "1.0.3",
     "wp-calypso": "github:automattic/wp-calypso"
   }


### PR DESCRIPTION
In my ongoing quest to move as much logic as possible from the components to the Redux tree, I've moved the calculation of the form errors to a selector.

I'm working on moving the `formSchema` and `formLayout` to the Redux tree, to have most (if not all) of the complex logic needed for a multi-step form encapsulated in the reducers. If you have any objection about that better say it as soon as possible :)

@allendav @nabsul @jeffstieler