### PR TITLE
Moved the save form logic to a Redux action, using redux-thunk

### DIFF
--- a/client/components/wcc-settings-form/index.js
+++ b/client/components/wcc-settings-form/index.js
@@ -6,58 +6,19 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as FormActions from 'state/form/actions';
 import { successNotice, errorNotice } from 'state/notices/actions';
-import isString from 'lodash/isString';
-import isArray from 'lodash/isArray';
-import { translate as __ } from 'lib/mixins/i18n';
 import * as SettingsActions from 'state/settings/actions';
 import * as PackagesActions from 'state/form/packages/actions';
 import { getFormErrors } from 'state/selectors';
 
 const WCCSettingsForm = ( props ) => {
-	const {
-		layout,
-		saveFormData,
-		formActions,
-		noticeActions,
-	} = props;
-
-	const setIsSaving = ( value ) => formActions.setFormProperty( 'isSaving', value );
-	const setSuccess = ( value ) => {
-		formActions.setFormProperty( 'success', value );
-		if ( true === value ) {
-			noticeActions.successNotice( __( 'Your changes have been saved.' ), {
-				duration: 2250,
-			} );
-		}
-	};
-	const setError = ( value ) => {
-		formActions.setFormProperty( 'errors', value );
-
-		if ( isString( value ) ) {
-			noticeActions.errorNotice( value, {
-				duration: 7000,
-			} );
-		}
-
-		if ( isArray( value ) ) {
-			noticeActions.errorNotice( __( 'There was a problem with one or more entries. Please fix the errors below and try saving again.' ), {
-				duration: 7000,
-			} );
-		}
-	};
-
-	const filterStoreOnSave = ( store ) => {
-		return store.getState().settings;
-	};
-
-	const saveForm = () => saveFormData( setIsSaving, setSuccess, setError, filterStoreOnSave );
 	return (
 		<div>
 			<GlobalNotices id="notices" notices={ notices.list } />
-			{ layout.map( ( group, idx ) => (
+			{ props.layout.map( ( group, idx ) => (
 				<WCCSettingsGroup
 					{ ...props }
-					{ ...{ group, saveForm } }
+					group={ group }
+					saveForm={ props.settingsActions.submit }
 					key={ idx }
 				/>
 			) ) }
@@ -69,7 +30,6 @@ WCCSettingsForm.propTypes = {
 	storeOptions: PropTypes.object.isRequired,
 	schema: PropTypes.object.isRequired,
 	layout: PropTypes.array.isRequired,
-	saveFormData: PropTypes.func.isRequired,
 };
 
 function mapStateToProps( state ) {

--- a/client/main.js
+++ b/client/main.js
@@ -2,10 +2,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux'
+import thunk from 'redux-thunk';
 import configureStore from 'state';
 import '../assets/stylesheets/style.scss';
 import initializeState from './lib/initialize-state';
-import saveForm from './lib/save-form';
 import './lib/calypso-boot';
 import { translate as __ } from 'lib/mixins/i18n';
 
@@ -18,9 +18,7 @@ const {
 	nonce,
 } = wcConnectData;
 
-const store = configureStore( initializeState( formSchema, formData ) );
-
-const saveFormData = ( setIsSaving, setSuccess, setError, filterStoreOnSave ) => saveForm( setIsSaving, setSuccess, setError, callbackURL, nonce, filterStoreOnSave( store ) );
+const store = configureStore( initializeState( formSchema, formData ), thunk.withExtraArgument( { callbackURL, nonce } ) );
 
 window.addEventListener( 'beforeunload', ( event ) => {
 	if ( store.getState().form.pristine ) {
@@ -41,7 +39,6 @@ let render = () => {
 				storeOptions={ storeOptions }
 				schema={ formSchema }
 				layout={ formLayout }
-				saveFormData={ saveFormData }
 			/>
 		</Provider>,
 		rootEl

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -1,4 +1,4 @@
-import { createStore, combineReducers } from 'redux';
+import { applyMiddleware, createStore, combineReducers, compose } from 'redux';
 import settings from './settings/reducer';
 import form from './form/reducer';
 
@@ -11,11 +11,14 @@ const rootReducer = combineReducers( {
 	notices,
 } );
 
-const configureStore = ( initialState ) => {
+const configureStore = ( initialState, thunk ) => {
 	const store = createStore(
 		rootReducer,
 		initialState,
-		window.devToolsExtension ? window.devToolsExtension() : f => f
+		compose(
+			applyMiddleware( thunk ),
+			window.devToolsExtension ? window.devToolsExtension() : f => f
+		)
 	);
 
 	if ( module.hot ) {

--- a/client/state/settings/actions.js
+++ b/client/state/settings/actions.js
@@ -83,15 +83,15 @@ export const submit = ( silent ) => ( dispatch, getState, { callbackURL, nonce }
 
 		if ( ! silent ) {
 			if ( isString( value ) ) {
-				NoticeActions.errorNotice( value, {
+				dispatch( NoticeActions.errorNotice( value, {
 					duration: 7000,
-				} );
+				} ) );
 			}
 
 			if ( isArray( value ) ) {
-				NoticeActions.errorNotice( __( 'There was a problem with one or more entries. Please fix the errors below and try saving again.' ), {
+				dispatch( NoticeActions.errorNotice( __( 'There was a problem with one or more entries. Please fix the errors below and try saving again.' ), {
 					duration: 7000,
-				} );
+				} ) );
 			}
 		}
 	};

--- a/client/state/settings/actions.js
+++ b/client/state/settings/actions.js
@@ -1,3 +1,10 @@
+import saveForm from 'lib/save-form';
+import isString from 'lodash/isString';
+import isArray from 'lodash/isArray';
+import { translate as __ } from 'lib/mixins/i18n';
+import * as FormActions from 'state/form/actions';
+import * as NoticeActions from 'state/notices/actions';
+
 export const UPDATE_SETTINGS_FIELD = 'UPDATE_SETTINGS_FIELD';
 export const ADD_SETTINGS_OBJECT_FIELD = 'ADD_SETTINGS_OBJECT_FIELD';
 export const REMOVE_SETTINGS_OBJECT_FIELD = 'REMOVE_SETTINGS_OBJECT_FIELD';
@@ -59,3 +66,35 @@ export const updateSettingsArrayFieldItem = ( settings_key, index, item ) => ( {
 	index,
 	item,
 } );
+
+export const submit = ( silent ) => ( dispatch, getState, { callbackURL, nonce } ) => {
+	silent = ( true === silent );
+	const setIsSaving = ( value ) => dispatch( FormActions.setFormProperty( 'isSaving', value ) );
+	const setSuccess = ( value ) => {
+		dispatch( FormActions.setFormProperty( 'success', value ) );
+		if ( ! silent && true === value ) {
+			dispatch( NoticeActions.successNotice( __( 'Your changes have been saved.' ), {
+				duration: 2250,
+			} ) );
+		}
+	};
+	const setError = ( value ) => {
+		dispatch( FormActions.setFormProperty( 'errors', value ) );
+
+		if ( ! silent ) {
+			if ( isString( value ) ) {
+				NoticeActions.errorNotice( value, {
+					duration: 7000,
+				} );
+			}
+
+			if ( isArray( value ) ) {
+				NoticeActions.errorNotice( __( 'There was a problem with one or more entries. Please fix the errors below and try saving again.' ), {
+					duration: 7000,
+				} );
+			}
+		}
+	};
+
+	saveForm( setIsSaving, setSuccess, setError, callbackURL, nonce, getState().settings );
+};

--- a/client/views/shipping/index.js
+++ b/client/views/shipping/index.js
@@ -1,13 +1,12 @@
 import React, { PropTypes } from 'react';
 import WCCSettingsForm from 'components/wcc-settings-form';
 
-const Settings = ( { storeOptions, schema, layout, saveFormData } ) => {
+const Settings = ( { storeOptions, schema, layout } ) => {
 	return (
 		<WCCSettingsForm
 			storeOptions={ storeOptions }
 			schema={ schema }
 			layout={ layout }
-			saveFormData={ saveFormData }
 		/>
 	);
 };
@@ -16,7 +15,6 @@ Settings.propTypes = {
 	storeOptions: PropTypes.object.isRequired,
 	schema: PropTypes.object.isRequired,
 	layout: PropTypes.array.isRequired,
-	saveFormData: PropTypes.func.isRequired,
 };
 
 export default Settings;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3690,6 +3690,10 @@
       "from": "redux@3.5.2",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.5.2.tgz"
     },
+	"redux-thunk": {
+	  "version": "2.1.0",
+	  "from": "redux-thunk@>=2.1.0 <3.0.0"
+	},
     "regenerate": {
       "version": "1.3.0",
       "from": "regenerate@>=1.2.1 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react-dom": "0.14.7",
     "react-redux": "^4.4.1",
     "redux": "^3.3.1",
+    "redux-thunk": "^2.1.0",
     "reselect": "^2.5.1",
     "sprintf-js": "1.0.3",
     "wp-calypso": "github:automattic/wp-calypso"


### PR DESCRIPTION
In my series of "move everything possible away from the components" PRs, this is the last one :)

Instead of having the Settings component configure the `saveForm` logic and attaching all the callbacks, it's now done in the "Redux backend", using redux-thunk.

In last week's Calypso meeting `redux-thunk` was discussed (and quickly dismissed) as an approoach to async actions such as this one. Let's see if it can work for our case :)

@nabsul @jeffstieler @allendav 