### PR TITLE
Add the i18n folder to the build list

### DIFF
--- a/tasks/release.js
+++ b/tasks/release.js
@@ -12,6 +12,7 @@ const dirsToCopy = [
 	'assets',
 	'classes',
 	'dist',
+	'i18n',
 	'vendor',
 ];
 


### PR DESCRIPTION
Fixes #421 

To test:

Clear out the release subfolder if it exists
Run npm run release
Take the resulting zip and upload it via wp-admin > Plugins > Add New > Upload
Activate the plugin and, after activating it, navigate to wp-admin > Plugins again
Verify no required file missing errors occur
