### PR TITLE
Removed form schema from the Redux state tree

### DIFF
--- a/client/components/wcc-settings-form/index.js
+++ b/client/components/wcc-settings-form/index.js
@@ -32,11 +32,11 @@ WCCSettingsForm.propTypes = {
 	layout: PropTypes.array.isRequired,
 };
 
-function mapStateToProps( state ) {
+function mapStateToProps( state, props ) {
 	return {
 		settings: state.settings,
 		form: state.form,
-		errors: getFormErrors( state ),
+		errors: getFormErrors( state, props ),
 	};
 }
 

--- a/client/lib/initialize-state/index.js
+++ b/client/lib/initialize-state/index.js
@@ -27,7 +27,6 @@ export default ( schema, values ) => {
 	return {
 		settings: formValues,
 		form: {
-			schema,
 			isSaving: false,
 			pristine: true,
 			packages: {

--- a/client/state/selectors.js
+++ b/client/state/selectors.js
@@ -38,7 +38,7 @@ const getRawFormErrors = ( schema, data ) => {
 
 export const getFormErrors = createSelector(
 	( state ) => state.form.errors,
-	( state ) => state.form.schema,
+	( state, props ) => props.schema,
 	( state ) => state.settings,
 	( errors, schema, data ) => removeErrorDataPathRoot( errors || getRawFormErrors( schema, data ) )
 );


### PR DESCRIPTION
Follow-up from #416 

As discussed, the Redux tree shouldn't have the form schema, so I rewrote the `getFormErrors` selector so it gets the schema from the component's `props` instead of from the state.

@jeffstieler 