### PR TITLE
Multi-step form auto-advancing logic and validation

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -157,6 +157,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				'type' => 'summary',
 				'tab_title' => 'Preview',
 				'title' => 'dfhdfghdfgh',
+				'items' => array(),
 				'action_label' => 'Print',
 				'confirmation_flag' => 'confirm',
 			);

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -37,14 +37,33 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 		) );
 	}
 
-	public function update_items( $request ) {
+	private function validation_error( $fields ) {
+		return new WP_Error('validation_failed',
+			'Error!!!',
+			array(
+				'status' => 400,
+				'error' => 'validation_failure',
+				'data' => array(
+					'fields' => $fields,
+				),
+			)
+		);
+	}
 
+	public function update_items( $request ) {
 		$request_body = $request->get_body();
 		$settings = json_decode( $request_body, false, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
 
-		var_dump( $settings );
+		if ( $settings->orig_address_1 !== 'Hawk St' ) {
+			return $this->validation_error( array( 'orig_address_1' ) );
 
-		return new WP_REST_Response( array( 'success' => true ), 200 );
+		}
+
+		if ( $settings->dest_address_1 !== 'Hawk St' ) {
+			return $this->validation_error( array( 'dest_address_1' ) );
+		}
+
+		return $this->validation_error( array( 'cart', 'rate' ) );
 	}
 
 	/**

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -1,0 +1,57 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( class_exists( 'WC_REST_Connect_Shipping_Label_Controller' ) ) {
+	return;
+}
+
+class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'connect/shipping-label';
+
+	/**
+	 * Register the routes for order notes.
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '', array(
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_items' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+			),
+		) );
+	}
+
+	public function update_items( $request ) {
+
+		$request_body = $request->get_body();
+		$settings = json_decode( $request_body, false, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
+
+		var_dump( $settings );
+
+		return new WP_REST_Response( array( 'success' => true ), 200 );
+	}
+
+	/**
+	 * Validate the requester's permissions
+	 */
+	public function update_items_permissions_check( $request ) {
+		return current_user_can( 'manage_woocommerce' );
+	}
+
+}

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -25,7 +25,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 	protected $rest_base = 'connect/shipping-label';
 
 	/**
-	 * Register the routes for order notes.
+	 * Register the routes for shipping labels printing.
 	 */
 	public function register_routes() {
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '', array(
@@ -37,6 +37,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 		) );
 	}
 
+	// TODO: remove this when the real server-side validation is implemented
 	private function validation_error( $fields ) {
 		return new WP_Error('validation_failed',
 			'Error!!!',
@@ -54,6 +55,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 		$request_body = $request->get_body();
 		$settings = json_decode( $request_body, false, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
 
+		// TODO: use the real WCC server endpoint to validate
 		if ( $settings->orig_address_1 !== 'Hawk St' ) {
 			return $this->validation_error( array( 'orig_address_1' ) );
 
@@ -70,7 +72,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 	 * Validate the requester's permissions
 	 */
 	public function update_items_permissions_check( $request ) {
-		return current_user_can( 'manage_woocommerce' );
+		return current_user_can( 'edit_shop_order' );
 	}
 
 }

--- a/client/components/wcc-settings-form/index.js
+++ b/client/components/wcc-settings-form/index.js
@@ -13,6 +13,12 @@ import { translate as __ } from 'lib/mixins/i18n';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 
+const getStepFormErrors = ( allErrors, stepLayout ) => {
+	const stepFields = {};
+	stepLayout.items.forEach( group => group.items.forEach( item => stepFields[ item.key ] = true ) );
+	return allErrors.filter( elem => stepFields[ elem[0] ] );
+};
+
 const WCCSettingsForm = ( props ) => {
 	const currentStep = props.form.currentStep;
 	const currentStepLayout = props.layout[ currentStep ];
@@ -35,7 +41,15 @@ const WCCSettingsForm = ( props ) => {
 		const label = ( currentStepLayout || {} ).action_label || __( 'Next' );
 		return (
 			<FormButtonsBar>
-				<FormButton type="button" onClick={ props.formActions.nextStep }>
+				<FormButton
+					type="button"
+					disabled={ ! currentStepLayout || getStepFormErrors( props.errors, currentStepLayout ).length > 0 }
+					onClick={ () => {
+						if ( currentStepLayout.confirmation_flag ) {
+							props.settingsActions.updateSettingsField( currentStepLayout.confirmation_flag, true );
+						}
+						props.formActions.nextStep( props.schema, currentStepLayout );
+					} }>
 					{ label }
 				</FormButton>
 			</FormButtonsBar>

--- a/client/components/wcc-settings-form/index.js
+++ b/client/components/wcc-settings-form/index.js
@@ -33,11 +33,12 @@ const WCCSettingsForm = ( props ) => {
 	const renderActionButton = () => {
 		// TODO: extend <SaveForm> and use it in place of this
 		const label = ( currentStepLayout || {} ).action_label || __( 'Next' );
+		const isDisabled = ! currentStepLayout || 0 < props.stepErrors.length || props.form.isSaving;
 		return (
 			<FormButtonsBar>
 				<FormButton
 					type="button"
-					disabled={ ! currentStepLayout || 0 < props.stepErrors.length || props.form.isSaving }
+					disabled={ isDisabled }
 					onClick={ props.formActions.nextStep }>
 					{ label }
 				</FormButton>

--- a/client/components/wcc-settings-form/index.js
+++ b/client/components/wcc-settings-form/index.js
@@ -8,16 +8,10 @@ import * as FormActions from 'state/form/actions';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import * as SettingsActions from 'state/settings/actions';
 import * as PackagesActions from 'state/form/packages/actions';
-import { getFormErrors } from 'state/selectors';
+import { getFormErrors, getStepFormErrors } from 'state/selectors';
 import { translate as __ } from 'lib/mixins/i18n';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
-
-const getStepFormErrors = ( allErrors, stepLayout ) => {
-	const stepFields = {};
-	stepLayout.items.forEach( group => group.items.forEach( item => stepFields[ item.key ] = true ) );
-	return allErrors.filter( elem => stepFields[ elem[0] ] );
-};
 
 const WCCSettingsForm = ( props ) => {
 	const currentStep = props.form.currentStep;
@@ -43,13 +37,8 @@ const WCCSettingsForm = ( props ) => {
 			<FormButtonsBar>
 				<FormButton
 					type="button"
-					disabled={ ! currentStepLayout || getStepFormErrors( props.errors, currentStepLayout ).length > 0 }
-					onClick={ () => {
-						if ( currentStepLayout.confirmation_flag ) {
-							props.settingsActions.updateSettingsField( currentStepLayout.confirmation_flag, true );
-						}
-						props.formActions.nextStep( props.schema, currentStepLayout );
-					} }>
+					disabled={ ! currentStepLayout || 0 < props.stepErrors.length || props.form.isSaving }
+					onClick={ props.formActions.nextStep }>
 					{ label }
 				</FormButton>
 			</FormButtonsBar>
@@ -107,7 +96,8 @@ function mapStateToProps( state, props ) {
 	return {
 		settings: state.settings,
 		form: state.form,
-		errors: getFormErrors( state, props ),
+		errors: getFormErrors( state, props.schema ),
+		stepErrors: getStepFormErrors( state, props.schema, props.layout ),
 	};
 }
 

--- a/client/lib/save-form/index.js
+++ b/client/lib/save-form/index.js
@@ -10,7 +10,6 @@ const saveForm = ( setIsSaving, setSuccess, setError, url, nonce, formData ) => 
 	};
 
 	return fetch( url, request ).then( response => {
-		setIsSaving( false );
 		setError( null );
 		setSuccess( false );
 
@@ -34,7 +33,7 @@ const saveForm = ( setIsSaving, setSuccess, setError, url, nonce, formData ) => 
 			}
 
 			return setError( JSON.stringify( json ) );
-		} );
+		} ).then( () => setIsSaving( false ) );
 	} ).catch( ( e ) => {
 		setIsSaving( false );
 		setError( e );

--- a/client/main.js
+++ b/client/main.js
@@ -66,11 +66,7 @@ if ( module.hot ) {
 		}
 	};
 
-	module.hot.accept( 'views/shipping', () => {
-		setTimeout( render );
-	} );
-
-	module.hot.accept( 'views/shipping-label', () => {
+	module.hot.accept( [ 'views/shipping', 'views/shipping-label' ], () => {
 		setTimeout( render );
 	} );
 }

--- a/client/main.js
+++ b/client/main.js
@@ -19,7 +19,7 @@ const {
 	rootView,
 } = wcConnectData;
 
-const store = configureStore( initializeState( formSchema, formData ), thunk.withExtraArgument( { callbackURL, nonce } ) );
+const store = configureStore( initializeState( formSchema, formData ), thunk.withExtraArgument( { callbackURL, nonce, formSchema, formLayout } ) );
 
 window.addEventListener( 'beforeunload', ( event ) => {
 	if ( store.getState().form.pristine ) {

--- a/client/state/form/actions.js
+++ b/client/state/form/actions.js
@@ -1,5 +1,9 @@
 import * as SettingsActions from 'state/settings/actions';
+import * as FormActions from 'state/form/actions';
+import * as NoticeActions from 'state/notices/actions';
 import { getStepFormErrors } from 'state/selectors';
+import saveForm from 'lib/save-form';
+import isArray from 'lodash/isArray';
 
 export const SET_FORM_PROPERTY = 'SET_FORM_PROPERTY';
 export const GO_TO_STEP = 'GO_TO_STEP';
@@ -19,22 +23,59 @@ export const goToStep = ( stepIndex ) => {
 	};
 };
 
-export const nextStep = () => ( dispatch, getState, { formSchema, formLayout } ) => {
+export const nextStep = () => ( dispatch, getState, { callbackURL, nonce, formSchema, formLayout } ) => {
+	const submitForm = ( callback ) => {
+		const setIsSaving = ( value ) => {
+			dispatch( FormActions.setFormProperty( 'isSaving', value ) );
+			if ( false === value ) {
+				callback();
+			}
+		};
+		const setSuccess = ( value ) => dispatch( FormActions.setFormProperty( 'success', value ) );
+		const setError = ( value ) => dispatch( FormActions.setFormProperty( 'errors', value ) );
+
+		dispatch( FormActions.setFormProperty( 'pristine', true ) );
+		saveForm( setIsSaving, setSuccess, setError, callbackURL, nonce, getState().settings );
+	};
+
 	const tryAutoAdvance = ( isManualAction ) => {
 		const currentStep = getState().form.currentStep;
 		const currentStepLayout = formLayout[ currentStep ] || {};
+
+		if ( currentStep >= formLayout.length - 1 ) {
+			return;
+		}
 
 		if ( getStepFormErrors( getState(), formSchema, formLayout ).length ) {
 			return;
 		}
 
-		if ( isManualAction && currentStepLayout.confirmation_flag ) {
-			dispatch( SettingsActions.updateSettingsField( currentStepLayout.confirmation_flag, true ) );
+		if ( getState().form.pristine ) {
+			dispatch( goToStep( currentStep + 1 ) );
+			tryAutoAdvance( false );
+			return;
 		}
 
-		dispatch( goToStep( currentStep + 1 ) );
+		submitForm( () => {
+			if ( getState().form.errors && ! isArray( getState().form.errors ) ) {
+				dispatch( NoticeActions.errorNotice( getState().form.errors, {
+					duration: 7000,
+				} ) );
+				return;
+			}
 
-		tryAutoAdvance( false );
+			if ( getStepFormErrors( getState(), formSchema, formLayout ).length ) {
+				return;
+			}
+
+			if ( isManualAction && currentStepLayout.confirmation_flag ) {
+				dispatch( SettingsActions.updateSettingsField( currentStepLayout.confirmation_flag, true ) );
+			}
+
+			dispatch( goToStep( currentStep + 1 ) );
+
+			tryAutoAdvance( false );
+		} );
 	};
 
 	tryAutoAdvance( true );

--- a/client/state/form/actions.js
+++ b/client/state/form/actions.js
@@ -1,5 +1,7 @@
+import * as SettingsActions from 'state/settings/actions';
+import { getStepFormErrors } from 'state/selectors';
+
 export const SET_FORM_PROPERTY = 'SET_FORM_PROPERTY';
-export const NEXT_STEP = 'NEXT_STEP';
 export const GO_TO_STEP = 'GO_TO_STEP';
 
 export const setFormProperty = ( field, value ) => {
@@ -10,15 +12,30 @@ export const setFormProperty = ( field, value ) => {
 	};
 };
 
-export const nextStep = ( ) => {
-	return {
-		type: NEXT_STEP,
-	};
-};
-
 export const goToStep = ( stepIndex ) => {
 	return {
 		type: GO_TO_STEP,
 		step: stepIndex,
 	};
+};
+
+export const nextStep = () => ( dispatch, getState, { formSchema, formLayout } ) => {
+	const tryAutoAdvance = ( isManualAction ) => {
+		const currentStep = getState().form.currentStep;
+		const currentStepLayout = formLayout[ currentStep ] || {};
+
+		if ( getStepFormErrors( getState(), formSchema, formLayout ).length ) {
+			return;
+		}
+
+		if ( isManualAction && currentStepLayout.confirmation_flag ) {
+			dispatch( SettingsActions.updateSettingsField( currentStepLayout.confirmation_flag, true ) );
+		}
+
+		dispatch( goToStep( currentStep + 1 ) );
+
+		tryAutoAdvance( false );
+	};
+
+	tryAutoAdvance( true );
 };

--- a/client/state/form/reducer.js
+++ b/client/state/form/reducer.js
@@ -1,6 +1,5 @@
 import {
 	SET_FORM_PROPERTY,
-	NEXT_STEP,
 	GO_TO_STEP,
 } from './actions';
 import packages from './packages/reducer';
@@ -18,10 +17,6 @@ reducers[ SET_FORM_PROPERTY ] = ( state, action ) => {
 		newObj.pristine = true;
 	}
 	return Object.assign( {}, state, newObj );
-};
-
-reducers[ NEXT_STEP ] = ( state ) => {
-	return Object.assign( {}, state, { currentStep: state.currentStep + 1 } );
 };
 
 reducers[ GO_TO_STEP ] = ( state, action ) => {

--- a/client/state/form/shipping-label/actions.js
+++ b/client/state/form/shipping-label/actions.js
@@ -1,9 +1,12 @@
+import * as FormActions from 'state/form/actions';
+
 export const OPEN_PRINTING_FLOW = 'OPEN_PRINTING_FLOW';
 export const EXIT_PRINTING_FLOW = 'EXIT_PRINTING_FLOW';
 
-export const openPrintingFlow = () => ( {
-	type: OPEN_PRINTING_FLOW,
-} );
+export const openPrintingFlow = () => ( dispatch ) => {
+	dispatch( { type: OPEN_PRINTING_FLOW } );
+	dispatch( FormActions.nextStep() );
+};
 
 export const exitPrintingFlow = () => ( {
 	type: EXIT_PRINTING_FLOW,

--- a/client/state/form/shipping-label/actions.js
+++ b/client/state/form/shipping-label/actions.js
@@ -5,6 +5,7 @@ export const EXIT_PRINTING_FLOW = 'EXIT_PRINTING_FLOW';
 
 export const openPrintingFlow = () => ( dispatch ) => {
 	dispatch( { type: OPEN_PRINTING_FLOW } );
+	dispatch( FormActions.setFormProperty( 'pristine', false ) );
 	dispatch( FormActions.nextStep() );
 };
 

--- a/client/state/selectors.js
+++ b/client/state/selectors.js
@@ -38,7 +38,22 @@ const getRawFormErrors = ( schema, data ) => {
 
 export const getFormErrors = createSelector(
 	( state ) => state.form.errors,
-	( state, props ) => props.schema,
+	( state, schema ) => schema,
 	( state ) => state.settings,
 	( errors, schema, data ) => removeErrorDataPathRoot( errors || getRawFormErrors( schema, data ) )
+);
+
+export const getStepFormErrors = createSelector(
+	( state ) => state,
+	( state, schema ) => schema,
+	( state, schema, layout ) => layout,
+	( state, schema, layout ) => {
+		const allErrors = getFormErrors( state, schema );
+		const stepLayout = layout[ state.form.currentStep ];
+		const stepFields = {};
+		if ( stepLayout ) {
+			stepLayout.items.forEach( group => group.items.forEach( item => stepFields[ item.key ] = true ) );
+		}
+		return allErrors.filter( elem => stepFields[ elem[ 0 ] ] );
+	}
 );

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -68,6 +68,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		protected $rest_self_help_controller;
 
 		/**
+		 * @var WC_REST_Connect_Shipping_Label_Controller
+		 */
+		protected $rest_shipping_label_controller;
+
+		/**
 		 * @var WC_Connect_Service_Schemas_Validator
 		 */
 		protected $service_schemas_validator;
@@ -158,6 +163,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function set_rest_self_help_controller( WC_REST_Connect_Self_Help_Controller $rest_self_help_controller ) {
 			$this->rest_self_help_controller = $rest_self_help_controller;
+		}
+
+		public function get_rest_shipping_label_controller() {
+			return $this->rest_shipping_label_controller;
+		}
+
+		public function set_rest_shipping_label_controller( WC_REST_Connect_Shipping_Label_Controller $rest_shipping_label_controller ) {
+			$this->rest_shipping_label_controller = $rest_shipping_label_controller;
 		}
 
 		public function get_service_schemas_validator() {
@@ -290,6 +303,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_self_help_controller = new WC_REST_Connect_Self_Help_Controller( $logger );
 			$this->set_rest_self_help_controller( $rest_self_help_controller );
 			$rest_self_help_controller->register_routes();
+
+			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-label-controller.php' ) );
+			$rest_shipping_label_controller = new WC_REST_Connect_Shipping_Label_Controller( $logger );
+			$this->set_rest_shipping_label_controller( $rest_shipping_label_controller );
+			$rest_shipping_label_controller->register_routes();
 		}
 
 		/**


### PR DESCRIPTION
This PR builds on #428 , I've separated it into a new PR to ease the code review.

This PR includes logic to:
* Disable the "Next" button when the current form step has errors.
* Automatically advance the flow until a step with errors is reached.
* For auto-advance purposes, validate client-side, and then server-side only if the client-side validation succeded. Note that the server can say that there are errors, but if they are in future steps the form must auto-advance.

I've created a silly REST endpoint mock, it has these rules:
* It will fail an address if the address line 1 isn't `Hawk St`.
* It will always fail the `Packaging` step (because from that step onward, it's uncharted lands).

So you can just play with it. If you create an order with destination to `Hawk St`, you will be able to auto-advance from the `Origin address` step to the `Packaging` step.
Note that you won't be able to advance to the next step until the current step is valid, and even if it's valid for the client, a server-side validation request will be triggered and the form won't advance to the next step if the server-side validation fails (try, for example, to put `Falcon St` in the address).

@nabsul @jeffstieler @allendav 