### PR TITLE
Improved the performance of form validation by caching the validator.

### DIFF
--- a/client/components/shipping/packages/modal-errors.js
+++ b/client/components/shipping/packages/modal-errors.js
@@ -3,6 +3,9 @@ import trim from 'lodash/trim';
 import omitBy from 'lodash/omitBy';
 import reduce from 'lodash/reduce';
 import validator from 'is-my-json-valid';
+import memoize from 'lodash/memoize';
+
+const memoizedValidator = memoize( ( schema ) => validator( schema, { greedy: true } ) );
 
 const processErrors = ( errors ) => {
 	return reduce( errors, ( result, value ) => {
@@ -46,7 +49,7 @@ const preProcessPackageData = ( data, boxNames ) => {
 };
 
 const getErrors = ( packageData, boxNames, schema ) => {
-	const validate = validator( schema, { greedy: true } );
+	const validate = memoizedValidator( schema );
 	const data = preProcessPackageData( packageData, boxNames );
 	validate( data );
 	return processErrors( validate.errors );

--- a/client/state/selectors.js
+++ b/client/state/selectors.js
@@ -1,9 +1,12 @@
 import { createSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import isArray from 'lodash/isArray';
+import memoize from 'lodash/memoize';
 import validator from 'is-my-json-valid';
 import ObjectPath from 'objectpath';
 import coerceFormValues from 'lib/utils/coerce-values';
+
+const memoizedValidator = memoize( ( schema ) => validator( schema, { greedy: true } ) );
 
 /*
  * Errors from `is-my-json-valid` are paths to fields, all using `data` as the root.
@@ -27,7 +30,7 @@ const removeErrorDataPathRoot = ( errantFields ) => {
 };
 
 const getRawFormErrors = ( schema, data ) => {
-	const validate = validator( schema, { greedy: true } );
+	const validate = memoizedValidator( schema );
 	const coerced = coerceFormValues( schema, data );
 	const success = validate( coerced );
 


### PR DESCRIPTION
This makes each form validation to take about 1ms. Before, in my machine,
it took between 10 and 15ms.

Fixes #443 

Turns out, the **mayor** lag I was noticing was caused by React validating PropTypes, and so it doesn't happen in release builds. Still, trying to fix it I run across this optimisation (caching the `is-my-json-valid` validator).

@jeffstieler @allendav @nabsul 