### PR TITLE
Fix “select all” checkbox in service groups.

### DIFF
--- a/client/components/shipping/services/group.js
+++ b/client/components/shipping/services/group.js
@@ -20,7 +20,7 @@ const summaryLabel = ( services ) => {
 
 const updateAll = ( event, updateValue, services ) => {
 	services.forEach( ( service ) => {
-		updateValue( service.id + '.enabled', event.target.checked );
+		updateValue( [ service.id, 'enabled' ], event.target.checked );
 	} )
 };
 


### PR DESCRIPTION
State value paths should be arrays, not strings.

Fixes #441.