### PR TITLE
[Labels] Address form

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -82,6 +82,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				array(
 					'key' => 'country',
 					'validation_hint' => 'This field is required.',
+					'type' => 'dropdown',
+					'titleMap' => WC()->countries->get_countries(),
 				),
 			);
 			$address_summary = '{first_name} {last_name}\\n{address_1} {address_2}\\n{city}, {postcode} {state}, {country}';
@@ -201,7 +203,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				'country' => array(
 					'type' => 'string',
 					'title' => 'Country',
-					'minLength' => 1,
+					'enum' => array_keys( WC()->countries->get_countries() ),
+					'default' => 'US',
 				),
 			);
 			$required_address_fields = array( 'first_name', 'address_1', 'city', 'state', 'postcode', 'country' );

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -53,19 +53,14 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 		protected function get_states_map() {
 			$result = array();
-			foreach( WC()->countries->get_states() as $country => $states ) {
-				$result[ $country ] = array();
-				foreach ( $states as $code => $name ) {
-					$result[ $country ][ $code ] = html_entity_decode( $name );
-				}
-			}
-			return $result;
-		}
-
-		protected function get_countries() {
-			$result = array();
 			foreach( WC()->countries->get_countries() as $code => $name ) {
-				$result[ $code ] = html_entity_decode( $name );
+				$result[ $code ] = array( 'name' => html_entity_decode( $name ) );
+			}
+			foreach( WC()->countries->get_states() as $country => $states ) {
+				$result[ $country ][ 'states' ] = array();
+				foreach ( $states as $code => $name ) {
+					$result[ $country ][ 'states' ][ $code ] = html_entity_decode( $name );
+				}
 			}
 			return $result;
 		}
@@ -95,7 +90,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				array(
 					'key' => 'state',
 					'type' => 'state',
-					'dataset' => $this->get_states_map(),
 					'validation_hint' => __( 'Required.', 'woocommerce' ),
 				),
 				array(
@@ -105,8 +99,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				array(
 					'key' => 'country',
 					'validation_hint' => __( 'Required.', 'woocommerce' ),
-					'type' => 'dropdown',
-					'titleMap' => $this->get_countries(),
+					'type' => 'country',
 				),
 			);
 			$address_summary = '{name}\\n{address_1} {address_2}\\n{city}, {postcode} {state}, {country}';

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -73,7 +73,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				),
 				array(
 					'key' => 'state',
-					'validation_hint' => 'This field is required.',
+					'type' => 'state',
+					'dataset' => WC()->countries->get_states(),
 				),
 				array(
 					'key' => 'postcode',
@@ -93,6 +94,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			foreach( $address_fields as $index => $_ ) {
 				$orig_address_fields[ $index ][ 'key' ] = 'orig_' . $address_fields[ $index ][ 'key' ];
 				$dest_address_fields[ $index ][ 'key' ] = 'dest_' . $address_fields[ $index ][ 'key' ];
+				if ( 'state' === $address_fields[ $index ][ 'key' ] ) {
+					$orig_address_fields[ $index ][ 'country_field' ] = 'orig_country';
+					$dest_address_fields[ $index ][ 'country_field' ] = 'dest_country';
+				}
 			}
 
 			$layout[] = array(
@@ -193,7 +198,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				'state' => array(
 					'type' => 'string',
 					'title' => 'State',
-					'minLength' => 1,
 				),
 				'postcode' => array(
 					'type' => 'string',
@@ -207,7 +211,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					'default' => 'US',
 				),
 			);
-			$required_address_fields = array( 'first_name', 'address_1', 'city', 'state', 'postcode', 'country' );
+			$required_address_fields = array( 'first_name', 'address_1', 'city', 'postcode', 'country' );
 
 			foreach( $address_fields as $key => $value ) {
 				$properties[ 'orig_' . $key ] = $value;

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -119,7 +119,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				'type' => 'step',
 				'tab_title' => __( 'Origin', 'woocommerce' ),
 				'title' => __( 'Generate shipping label: Origin address', 'woocommerce' ),
-				'description' => __( 'Confirm the address of the recipient is correct to ensure the package will get to the correct destination', 'woocommerce' ),
+				'description' => __( 'Confirm the address you are shipping from is correct to ensure the package will get to the correct destination', 'woocommerce' ),
 				'items' => $orig_address_fields,
 				'bypass_suggestion_flag' => 'orig_bypass_suggestion',
 				'summary' => str_replace( '{', '{orig_', $address_summary ),
@@ -302,8 +302,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				admin_url( 'admin.php' )
 			) );
 
+			$store_options = $this->settings_store->get_shared_settings();
+			$store_options[ 'countriesData' ] = $this->get_states_map();
 			$admin_array = array(
-				'storeOptions' => $this->settings_store->get_shared_settings(),
+				'storeOptions' => $store_options,
 				'formSchema'   => $this->get_form_schema(),
 				'formLayout'   => $this->get_form_layout(),
 				'formData'     => $this->get_form_data( $theorder ),

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -46,6 +46,25 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return $formData;
 		}
 
+		protected function get_states_map() {
+			$result = array();
+			foreach( WC()->countries->get_states() as $country => $states ) {
+				$result[ $country ] = array();
+				foreach ( $states as $code => $name ) {
+					$result[ $country ][ $code ] = html_entity_decode( $name );
+				}
+			}
+			return $result;
+		}
+
+		protected function get_countries() {
+			$result = array();
+			foreach( WC()->countries->get_countries() as $code => $name ) {
+				$result[ $code ] = html_entity_decode( $name );
+			}
+			return $result;
+		}
+
 		protected function get_form_layout() {
 			$layout = array();
 
@@ -74,7 +93,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				array(
 					'key' => 'state',
 					'type' => 'state',
-					'dataset' => WC()->countries->get_states(),
+					'dataset' => $this->get_states_map(),
 				),
 				array(
 					'key' => 'postcode',
@@ -84,7 +103,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					'key' => 'country',
 					'validation_hint' => 'This field is required.',
 					'type' => 'dropdown',
-					'titleMap' => WC()->countries->get_countries(),
+					'titleMap' => $this->get_countries(),
 				),
 			);
 			$address_summary = '{first_name} {last_name}\\n{address_1} {address_2}\\n{city}, {postcode} {state}, {country}';

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -11,7 +11,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		protected function get_form_data( WC_Order $order ) {
-			$formData = array();
+			$form_data = array();
 			$contents = array();
 
 			foreach( $order->get_items() as $item ) {
@@ -36,14 +36,19 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					'width' => $width
 				);
 			}
-			$formData[ 'cart' ] = $contents;
+			$form_data[ 'cart' ] = $contents;
 
-			foreach( $order->get_address( 'shipping' ) as $key => $value ) {
-				$formData[ 'orig_' . $key ] = '';
-				$formData[ 'dest_' . $key ] = $value;
-			}
+			$dest_address = $order->get_address( 'shipping' );
+			$form_data[ 'dest_name' ] = trim( $dest_address[ 'first_name' ] . ' ' . $dest_address[ 'last_name' ] );
+			$form_data[ 'dest_company' ] = $dest_address[ 'company' ];
+			$form_data[ 'dest_address_1' ] = $dest_address[ 'address_1' ];
+			$form_data[ 'dest_address_2' ] = $dest_address[ 'address_2' ];
+			$form_data[ 'dest_city' ] = $dest_address[ 'city' ];
+			$form_data[ 'dest_state' ] = $dest_address[ 'state' ];
+			$form_data[ 'dest_postcode' ] = $dest_address[ 'postcode' ];
+			$form_data[ 'dest_country' ] = $dest_address[ 'country' ];
 
-			return $formData;
+			return $form_data;
 		}
 
 		protected function get_states_map() {
@@ -70,43 +75,41 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			$address_fields = array(
 				array(
-					'key' => 'first_name',
-					'validation_hint' => 'This field is required.',
-				),
-				array(
-					'key' => 'last_name',
+					'key' => 'name',
+					'validation_hint' => __( 'Required.', 'woocommerce' ),
 				),
 				array(
 					'key' => 'company',
 				),
 				array(
 					'key' => 'address_1',
-					'validation_hint' => 'This field is required.',
+					'validation_hint' => __( 'Required.', 'woocommerce' ),
 				),
 				array(
 					'key' => 'address_2',
 				),
 				array(
 					'key' => 'city',
-					'validation_hint' => 'This field is required.',
+					'validation_hint' => __( 'Required.', 'woocommerce' ),
 				),
 				array(
 					'key' => 'state',
 					'type' => 'state',
 					'dataset' => $this->get_states_map(),
+					'validation_hint' => __( 'Required.', 'woocommerce' ),
 				),
 				array(
 					'key' => 'postcode',
-					'validation_hint' => 'This field is required.',
+					'validation_hint' => __( 'Required.', 'woocommerce' ),
 				),
 				array(
 					'key' => 'country',
-					'validation_hint' => 'This field is required.',
+					'validation_hint' => __( 'Required.', 'woocommerce' ),
 					'type' => 'dropdown',
 					'titleMap' => $this->get_countries(),
 				),
 			);
-			$address_summary = '{first_name} {last_name}\\n{address_1} {address_2}\\n{city}, {postcode} {state}, {country}';
+			$address_summary = '{name}\\n{address_1} {address_2}\\n{city}, {postcode} {state}, {country}';
 
 			$orig_address_fields = $address_fields;
 			$dest_address_fields = $address_fields;
@@ -121,30 +124,30 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			$layout[] = array(
 				'type' => 'step',
-				'tab_title' => 'Origin',
-				'title' => 'Generate shipping label: Address verification (origin)',
-				'description' => 'asdfghjkjhgfdsaASDFGHJJHGFDSA',
+				'tab_title' => __( 'Origin', 'woocommerce' ),
+				'title' => __( 'Generate shipping label: Origin address', 'woocommerce' ),
+				'description' => __( 'Confirm the address of the recipient is correct to ensure the package will get to the correct destination', 'woocommerce' ),
 				'items' => $orig_address_fields,
 				'bypass_suggestion_flag' => 'orig_bypass_suggestion',
 				'summary' => str_replace( '{', '{orig_', $address_summary ),
-				'sugggestion_hint' => 'vnkdjfitysncgkgse,jhxccvnaluerghsldjfvbzdj',
+				'sugggestion_hint' => __( 'To ensure accurate delivery, we have slightly modified the address you entered. Select the address you wish to use before continuing to the next step.', 'woocommerce' ),
 			);
 
 			$layout[] = array(
 				'type' => 'step',
-				'tab_title' => 'Destination',
-				'title' => 'Generate shipping label: Address verification',
-				'description' => 'asdfghjkjhgfdsaASDFGHJJHGFDSA',
+				'tab_title' =>  __( 'Destination', 'woocommerce' ),
+				'title' => __( 'Generate shipping label: Address verification', 'woocommerce' ),
+				'description' => __( 'Confirm the address of the recipient is correct to ensure the package will get to the correct destination', 'woocommerce' ),
 				'items' => $dest_address_fields,
 				'bypass_suggestion_flag' => 'dest_bypass_suggestion',
 				'summary' => str_replace( '{', '{dest_', $address_summary ),
-				'sugggestion_hint' => 'qwertyuiopqwertyuiopqwerty uiopqwertyuiopqwertyuiop',
+				'sugggestion_hint' => __( 'To ensure accurate delivery, we have slightly modified the address you entered. Select the address you wish to use before continuing to the next step.', 'woocommerce' ),
 			);
 
 			$layout[] = array(
 				'type' => 'step',
-				'tab_title' => 'Packages',
-				'title' => 'Shopping cart contents',
+				'tab_title' => __( 'Packages', 'woocommerce' ),
+				'title' => 'TODO: Not implemented yet',
 				'items' => array(
 					array(
 						'key' => 'cart',
@@ -156,8 +159,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			$layout[] = array(
 				'type' => 'step',
-				'tab_title' => 'Rates',
-				'title' => 'Select a shipping service',
+				'tab_title' => __( 'Rates', 'woocommerce' ),
+				'title' => 'TODO: Not implemented yet',
 				'items' => array(
 					array(
 						'key' => 'rate',
@@ -165,6 +168,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 						'titleMap' => array(
 							'media' => 'Media Mail ($1.00)',
 							'pri_1' => 'Priority 1-day ($9.99)',
+							'todo' => 'TODO: These are NOT real rates',
 						),
 					),
 				),
@@ -173,10 +177,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			$layout[] = array(
 				'type' => 'summary',
-				'tab_title' => 'Preview',
-				'title' => 'dfhdfghdfgh',
+				'tab_title' => __( 'Buy & Print', 'woocommerce' ),
+				'title' => 'TODO: Not implemented yet',
 				'items' => array(),
-				'action_label' => 'Print',
+				'action_label' => __( 'Print', 'woocommerce' ),
 				'confirmation_flag' => 'confirm',
 			);
 
@@ -187,50 +191,45 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$properties = array();
 
 			$address_fields = array(
-				'first_name' => array(
+				'name' => array(
 					'type' => 'string',
-					'title' => 'First name',
+					'title' => __( 'Name', 'woocommerce' ),
 					'minLength' => 1,
-				),
-				'last_name' => array(
-					'type' => 'string',
-					'title' => 'Last name',
 				),
 				'company' => array(
 					'type' => 'string',
-					'title' => 'Company',
+					'title' => __( 'Company', 'woocommerce' ),
 				),
 				'address_1' => array(
 					'type' => 'string',
-					'title' => 'Address',
+					'title' => __( 'Street address', 'woocommerce' ),
 					'minLength' => 1,
 				),
 				'address_2' => array(
-					'type' => 'string',
-					'title' => 'Address line 2',
+					'type' => 'string'
 				),
 				'city' => array(
 					'type' => 'string',
-					'title' => 'City',
+					'title' => __( 'City', 'woocommerce' ),
 					'minLength' => 1,
 				),
 				'state' => array(
 					'type' => 'string',
-					'title' => 'State',
+					'title' => __( 'State', 'woocommerce' ),
 				),
 				'postcode' => array(
 					'type' => 'string',
-					'title' => 'Postal code',
+					'title' => __( 'Postal code', 'woocommerce' ),
 					'minLength' => 1,
 				),
 				'country' => array(
 					'type' => 'string',
-					'title' => 'Country',
+					'title' => __( 'Country', 'woocommerce' ),
 					'enum' => array_keys( WC()->countries->get_countries() ),
 					'default' => 'US',
 				),
 			);
-			$required_address_fields = array( 'first_name', 'address_1', 'city', 'postcode', 'country' );
+			$required_address_fields = array( 'name', 'address_1', 'city', 'postcode', 'country' );
 
 			foreach( $address_fields as $key => $value ) {
 				$properties[ 'orig_' . $key ] = $value;
@@ -250,42 +249,42 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				'properties' => array(
 					'height' => array(
 						'type' => 'number',
-						'title' => 'Height',
+						'title' => __( 'Height', 'woocommerce' ),
 					),
 					'product_id' => array(
 						'type' => 'string',
-						'title' => 'Product ID',
+						'title' => __( 'Product ID', 'woocommerce' ),
 					),
 					'length' => array(
 						'type' => 'number',
-						'title' => 'Length',
+						'title' => __( 'Length', 'woocommerce' ),
 					),
 					'quantity' => array(
 						'type' => 'number',
-						'title' => 'Quantity',
+						'title' => __( 'Quantity', 'woocommerce' ),
 					),
 					'weight' => array(
 						'type' => 'number',
-						'title' => 'Weight',
+						'title' => __( 'Weight', 'woocommerce' ),
 					),
 					'width' => array(
 						'type' => 'number',
-						'title' => 'Width',
+						'title' => __( 'Width', 'woocommerce' ),
 					),
 				),
 			);
 
 			$properties[ 'cart' ] = array(
 				'type' => 'array',
-				'title' => 'Items to send',
+				'title' => __( 'Items to send', 'woocommerce' ),
 				'items' => $itemDefinition,
 			);
 			$required_fields[] = 'cart';
 
 			$properties[ 'rate' ] = array(
 				'type' => 'string',
-				'title' => 'Shipping rate',
-				'enum' => array( 'pri_1', 'media' ),
+				'title' => __( 'Shipping rate', 'woocommerce' ),
+				'enum' => array( 'pri_1', 'media', 'todo' ),
 			);
 			$required_fields[] = 'rate';
 

--- a/client/components/country-dropdown/index.js
+++ b/client/components/country-dropdown/index.js
@@ -1,0 +1,30 @@
+import React, { PropTypes } from 'react';
+import Dropdown from 'components/dropdown';
+
+const CountryDropdown = ( props ) => {
+	const titleMap = {};
+	Object.keys( props.countriesData ).forEach( ( countryCode ) => {
+		titleMap[ countryCode ] = props.countriesData[ countryCode ].name;
+	} );
+	return (
+		<Dropdown
+			{ ...props }
+			layout={ { titleMap } }
+			/>
+	);
+};
+
+CountryDropdown.propTypes = {
+	id: PropTypes.string.isRequired,
+	countriesData: PropTypes.object.isRequired,
+	layout: PropTypes.object.isRequired,
+	schema: PropTypes.object.isRequired,
+	value: PropTypes.string.isRequired,
+	updateValue: PropTypes.func.isRequired,
+	error: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.bool,
+	] ),
+};
+
+export default CountryDropdown;

--- a/client/components/dropdown/index.js
+++ b/client/components/dropdown/index.js
@@ -1,0 +1,45 @@
+import React, { PropTypes } from 'react';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormSelect from 'components/forms/form-select';
+import FormLegend from 'components/forms/form-legend';
+import FormInputValidation from 'components/forms/form-input-validation';
+
+const renderFieldError = ( validationHint ) => {
+	return (
+		<FormInputValidation isError text={ validationHint } />
+	);
+};
+
+const Dropdown = ( { id, layout, schema, value, setValue, error } ) => {
+	return (
+		<FormFieldset>
+			<FormLegend>{ schema.title }</FormLegend>
+			<FormSelect
+				id={ id }
+				name={ id }
+				value={ value }
+				onChange={ ( event ) => setValue( event.target.value ) }
+				isError={ error } >
+				{ Object.keys( layout.titleMap ).map( key => {
+					return (
+						<option
+							key={ key }
+							value={ key }>
+							{ layout.titleMap[ key ] }
+						</option>
+					);
+				} ) }
+				{ error ? renderFieldError( error ) : null }
+			</FormSelect>
+		</FormFieldset>
+	);
+};
+
+Dropdown.propTypes = {
+	layout: PropTypes.object.isRequired,
+	schema: PropTypes.object.isRequired,
+	value: PropTypes.string.isRequired,
+	setValue: PropTypes.func.isRequired,
+};
+
+export default Dropdown;

--- a/client/components/dropdown/index.js
+++ b/client/components/dropdown/index.js
@@ -10,7 +10,7 @@ const renderFieldError = ( validationHint ) => {
 	);
 };
 
-const Dropdown = ( { id, layout, schema, value, setValue, error } ) => {
+const Dropdown = ( { id, layout, schema, value, updateValue, error } ) => {
 	return (
 		<FormFieldset>
 			<FormLegend>{ schema.title }</FormLegend>
@@ -18,7 +18,7 @@ const Dropdown = ( { id, layout, schema, value, setValue, error } ) => {
 				id={ id }
 				name={ id }
 				value={ value }
-				onChange={ ( event ) => setValue( event.target.value ) }
+				onChange={ ( event ) => updateValue( event.target.value ) }
 				isError={ error } >
 				{ Object.keys( layout.titleMap ).map( key => {
 					return (
@@ -36,10 +36,15 @@ const Dropdown = ( { id, layout, schema, value, setValue, error } ) => {
 };
 
 Dropdown.propTypes = {
+	id: PropTypes.string.isRequired,
 	layout: PropTypes.object.isRequired,
 	schema: PropTypes.object.isRequired,
 	value: PropTypes.string.isRequired,
-	setValue: PropTypes.func.isRequired,
+	updateValue: PropTypes.func.isRequired,
+	error: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.bool,
+	] ),
 };
 
 export default Dropdown;

--- a/client/components/dropdown/index.js
+++ b/client/components/dropdown/index.js
@@ -12,7 +12,7 @@ const renderFieldError = ( validationHint ) => {
 
 const Dropdown = ( { id, layout, schema, value, updateValue, error } ) => {
 	return (
-		<FormFieldset>
+		<FormFieldset id={ id + '_container' }>
 			<FormLegend>{ schema.title }</FormLegend>
 			<FormSelect
 				id={ id }

--- a/client/components/indicators/index.js
+++ b/client/components/indicators/index.js
@@ -47,9 +47,9 @@ const renderSubTitle = ( subtitle ) => {
 	);
 };
 
-const Indicators = ( { schema, indicators } ) => {
+const Indicators = ( { id, schema, indicators } ) => {
 	return (
-		<FormFieldset>
+		<FormFieldset id={ id + '_container' }>
 			<FormLegend>{ schema.title }{ renderSubTitle( schema.subtitle ) }</FormLegend>
 			{ indicators.map( indicator => (
 				<Indicator
@@ -65,6 +65,7 @@ const Indicators = ( { schema, indicators } ) => {
 };
 
 Indicators.propTypes = {
+	id: PropTypes.string.isRequired,
 	schema: PropTypes.object.isRequired,
 	indicators: PropTypes.array.isRequired,
 };

--- a/client/components/number-field/index.js
+++ b/client/components/number-field/index.js
@@ -21,7 +21,7 @@ const renderFieldError = ( validationHint ) => {
 
 const NumberField = ( { id, schema, value, placeholder, updateValue, error } ) => {
 	return (
-		<FormFieldset>
+		<FormFieldset id={ id + '_container' }>
 			<FormLabel htmlFor={ id }>{ schema.title }</FormLabel>
 			<NumberInput
 				id={ id }

--- a/client/components/number-field/index.js
+++ b/client/components/number-field/index.js
@@ -40,7 +40,7 @@ NumberField.propTypes = {
 	id: PropTypes.string.isRequired,
 	schema: PropTypes.shape( {
 		type: PropTypes.string.valueOf( 'number' ),
-		title: PropTypes.string.isRequired,
+		title: PropTypes.string,
 		description: PropTypes.string,
 		default: PropTypes.string,
 	} ).isRequired,

--- a/client/components/radio-buttons/index.js
+++ b/client/components/radio-buttons/index.js
@@ -13,9 +13,9 @@ const RadioButton = ( { value, currentValue, setValue, description } ) => {
 	);
 };
 
-const RadioButtons = ( { layout, schema, value, setValue } ) => {
+const RadioButtons = ( { id, layout, schema, value, setValue } ) => {
 	return (
-		<FormFieldset>
+		<FormFieldset id={ id + '_container' }>
 			<FormLegend>{ schema.title }</FormLegend>
 			{ Object.keys( layout.titleMap ).map( key => {
 				return (
@@ -33,6 +33,7 @@ const RadioButtons = ( { layout, schema, value, setValue } ) => {
 };
 
 RadioButtons.propTypes = {
+	id: PropTypes.string.isRequired,
 	layout: PropTypes.object.isRequired,
 	schema: PropTypes.object.isRequired,
 	value: PropTypes.string.isRequired,

--- a/client/components/state-dropdown/index.js
+++ b/client/components/state-dropdown/index.js
@@ -1,11 +1,12 @@
 import React, { PropTypes } from 'react';
 import Dropdown from 'components/dropdown';
 import TextField from 'components/text-field';
+import { translate as __ } from 'lib/mixins/i18n';
 
 const StateDropdown = ( props ) => {
 	const statesMap = props.layout.dataset[ props.countryCode ];
 
-	if ( ! statesMap || ! Object.keys( statesMap ).length ) {
+	if ( ! statesMap ) { // We don't have a list of states for this country
 		return (
 			<TextField
 				{ ...props }
@@ -15,10 +16,14 @@ const StateDropdown = ( props ) => {
 		);
 	}
 
+	if ( ! Object.keys( statesMap ).length ) { // This country has no states
+		return null;
+	}
+
 	return (
 		<Dropdown
 			{ ...props }
-			layout={ { titleMap: statesMap } }
+			layout={ { titleMap: { '': __( 'Select one...' ), ...statesMap } } }
 			/>
 	);
 };

--- a/client/components/state-dropdown/index.js
+++ b/client/components/state-dropdown/index.js
@@ -1,0 +1,38 @@
+import React, { PropTypes } from 'react';
+import Dropdown from 'components/dropdown';
+import TextField from 'components/text-field';
+
+const StateDropdown = ( props ) => {
+	const statesMap = props.layout.dataset[ props.countryCode ];
+
+	if ( ! statesMap || ! Object.keys( statesMap ).length ) {
+		return (
+			<TextField
+				{ ...props }
+				placeholder={ props.layout.placeholder }
+				required={ false }
+			/>
+		);
+	}
+
+	return (
+		<Dropdown
+			{ ...props }
+			layout={ { titleMap: statesMap } }
+			/>
+	);
+};
+
+StateDropdown.propTypes = {
+	id: PropTypes.string.isRequired,
+	layout: PropTypes.object.isRequired,
+	schema: PropTypes.object.isRequired,
+	value: PropTypes.string.isRequired,
+	updateValue: PropTypes.func.isRequired,
+	error: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.bool,
+	] ),
+};
+
+export default StateDropdown;

--- a/client/components/state-dropdown/index.js
+++ b/client/components/state-dropdown/index.js
@@ -4,7 +4,7 @@ import TextField from 'components/text-field';
 import { translate as __ } from 'lib/mixins/i18n';
 
 const StateDropdown = ( props ) => {
-	const statesMap = props.layout.dataset[ props.countryCode ];
+	const statesMap = ( props.countriesData[ props.countryCode ] || {} ).states;
 
 	if ( ! statesMap ) { // We don't have a list of states for this country
 		return (
@@ -30,6 +30,7 @@ const StateDropdown = ( props ) => {
 
 StateDropdown.propTypes = {
 	id: PropTypes.string.isRequired,
+	countriesData: PropTypes.object.isRequired,
 	layout: PropTypes.object.isRequired,
 	schema: PropTypes.object.isRequired,
 	value: PropTypes.string.isRequired,

--- a/client/components/text-area/index.js
+++ b/client/components/text-area/index.js
@@ -23,7 +23,7 @@ const TextArea = ( { id, schema, value, placeholder, layout, updateValue, error 
 	const readOnly = 'undefined' === typeof layout.readonly ? false : layout.readonly;
 
 	return (
-		<FormFieldset>
+		<FormFieldset id={ id + '_container' }>
 			<FormLabel htmlFor={ id }>{ schema.title }</FormLabel>
 			<FormTextarea
 				id={ id }

--- a/client/components/text-area/index.js
+++ b/client/components/text-area/index.js
@@ -44,7 +44,7 @@ TextArea.propTypes = {
 	layout: PropTypes.object.isRequired,
 	schema: PropTypes.shape( {
 		type: PropTypes.string.valueOf( 'string' ),
-		title: PropTypes.string.isRequired,
+		title: PropTypes.string,
 		description: PropTypes.string,
 		default: PropTypes.string,
 	} ).isRequired,

--- a/client/components/text-field/index.js
+++ b/client/components/text-field/index.js
@@ -41,7 +41,7 @@ TextField.propTypes = {
 	id: PropTypes.string.isRequired,
 	schema: PropTypes.shape( {
 		type: PropTypes.string.valueOf( 'string' ),
-		title: PropTypes.string.isRequired,
+		title: PropTypes.string,
 		description: PropTypes.string,
 		default: PropTypes.string,
 	} ).isRequired,

--- a/client/components/text-field/index.js
+++ b/client/components/text-field/index.js
@@ -22,7 +22,7 @@ const TextField = ( { id, schema, value, placeholder, updateValue, error } ) => 
 	const handleChangeEvent = event => updateValue( event.target.value );
 
 	return (
-		<FormFieldset>
+		<FormFieldset id={ id + '_container' }>
 			<FormLabel htmlFor={ id }>{ schema.title }</FormLabel>
 			<FormTextInput
 				id={ id }

--- a/client/components/text/index.js
+++ b/client/components/text/index.js
@@ -25,7 +25,7 @@ const renderText = ( text ) => {
 
 const Text = ( { id, layout, value } ) => {
 	return (
-		<FormFieldset>
+		<FormFieldset id={ id + '_container' }>
 			{ renderTitle( layout.title ) }
 			<p id={ id } className={ layout.class } >
 				{ renderText( value ) }

--- a/client/components/toggle/index.js
+++ b/client/components/toggle/index.js
@@ -45,7 +45,7 @@ Toggle.propTypes = {
 	id: PropTypes.string.isRequired,
 	schema: PropTypes.shape( {
 		type: PropTypes.string.valueOf( 'string' ),
-		title: PropTypes.string.isRequired,
+		title: PropTypes.string,
 		trueText: PropTypes.string,
 		falseText: PropTypes.string,
 		saveOnToggle: PropTypes.bool,

--- a/client/components/toggle/index.js
+++ b/client/components/toggle/index.js
@@ -26,7 +26,7 @@ const Toggle = ( { id, schema, checked, placeholder, saveForm, updateValue } ) =
 	};
 
 	return (
-		<FormFieldset>
+		<FormFieldset id={ id + '_container' }>
 			<FormLabel htmlFor={ id }>{ schema.title }</FormLabel>
 			<FormToggle
 				id={ id }

--- a/client/components/wcc-settings-form/settings-group.js
+++ b/client/components/wcc-settings-form/settings-group.js
@@ -56,6 +56,15 @@ const SettingsGroup = ( props ) => {
 				</CompactCard>
 			);
 
+		case 'step':
+			return (
+				<div className="settings-group-default">
+					<FormSectionHeading>{ group.title }</FormSectionHeading>
+					{ group.description ? <p>{ group.description }</p> : null }
+					{ group.items.map( renderSettingsItem ) }
+				</div>
+			);
+
 		case 'actions':
 			const buttons = group.items.map( ( button ) => {
 				let onClick = noop;

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -7,6 +7,7 @@ import NumberField from 'components/number-field';
 import TextField from 'components/text-field';
 import Toggle from 'components/toggle';
 import RadioButtons from 'components/radio-buttons';
+import Dropdown from 'components/dropdown';
 import ShippingServiceGroups from 'components/shipping/services';
 import Packages from 'components/shipping/packages';
 
@@ -38,6 +39,18 @@ const SettingsItem = ( {
 		case 'radios':
 			return (
 				<RadioButtons
+					layout={ layout }
+					schema={ fieldSchema }
+					value={ fieldValue }
+					setValue={ updateValue }
+					error={ fieldError }
+				/>
+			);
+
+		case 'dropdown':
+			return (
+				<Dropdown
+					id={ id }
 					layout={ layout }
 					schema={ fieldSchema }
 					value={ fieldValue }

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -22,7 +22,6 @@ const SettingsItem = ( {
 	packagesActions,
 	errors,
 	saveForm,
-	countriesData,
 } ) => {
 	const id = layout.key ? layout.key : layout;
 	const updateValue = ( value ) => formValueActions.updateField( id, value );
@@ -72,7 +71,7 @@ const SettingsItem = ( {
 					value={ fieldValue }
 					updateValue={ updateValue }
 					error={ fieldError }
-					countriesData={ countriesData }
+					countriesData={ storeOptions.countriesData }
 				/>
 			);
 
@@ -86,7 +85,7 @@ const SettingsItem = ( {
 					updateValue={ updateValue }
 					error={ fieldError }
 					countryCode={ form.values[ layout.country_field ] }
-					countriesData={ countriesData }
+					countriesData={ storeOptions.countriesData }
 				/>
 			);
 

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -69,7 +69,7 @@ const SettingsItem = ( {
 					value={ fieldValue }
 					updateValue={ updateValue }
 					error={ fieldError }
-					countryCode={ settings[ layout.country_field ] }
+					countryCode={ form.values[ layout.country_field ] }
 				/>
 			);
 

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -8,6 +8,7 @@ import TextField from 'components/text-field';
 import Toggle from 'components/toggle';
 import RadioButtons from 'components/radio-buttons';
 import Dropdown from 'components/dropdown';
+import CountryDropdown from 'components/country-dropdown';
 import StateDropdown from 'components/state-dropdown';
 import ShippingServiceGroups from 'components/shipping/services';
 import Packages from 'components/shipping/packages';
@@ -21,6 +22,7 @@ const SettingsItem = ( {
 	packagesActions,
 	errors,
 	saveForm,
+	countriesData,
 } ) => {
 	const id = layout.key ? layout.key : layout;
 	const updateValue = ( value ) => formValueActions.updateField( id, value );
@@ -61,6 +63,19 @@ const SettingsItem = ( {
 				/>
 			);
 
+		case 'country':
+			return (
+				<CountryDropdown
+					id={ id }
+					layout={ layout }
+					schema={ fieldSchema }
+					value={ fieldValue }
+					updateValue={ updateValue }
+					error={ fieldError }
+					countriesData={ countriesData }
+				/>
+			);
+
 		case 'state':
 			return (
 				<StateDropdown
@@ -71,6 +86,7 @@ const SettingsItem = ( {
 					updateValue={ updateValue }
 					error={ fieldError }
 					countryCode={ form.values[ layout.country_field ] }
+					countriesData={ countriesData }
 				/>
 			);
 
@@ -188,6 +204,7 @@ SettingsItem.propTypes = {
 	packagesActions: PropTypes.object.isRequired,
 	errors: PropTypes.array,
 	saveForm: PropTypes.func,
+	countriesData: PropTypes.object,
 };
 
 export default SettingsItem;

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -40,6 +40,7 @@ const SettingsItem = ( {
 		case 'radios':
 			return (
 				<RadioButtons
+					id={ id }
 					layout={ layout }
 					schema={ fieldSchema }
 					value={ fieldValue }
@@ -107,6 +108,7 @@ const SettingsItem = ( {
 		case 'indicators':
 			return (
 				<Indicators
+					id={ id }
 					schema={ schema.properties[ id ] }
 					indicators={ Object.values( fieldValue ) }
 				/>

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -8,6 +8,7 @@ import TextField from 'components/text-field';
 import Toggle from 'components/toggle';
 import RadioButtons from 'components/radio-buttons';
 import Dropdown from 'components/dropdown';
+import StateDropdown from 'components/state-dropdown';
 import ShippingServiceGroups from 'components/shipping/services';
 import Packages from 'components/shipping/packages';
 
@@ -54,8 +55,21 @@ const SettingsItem = ( {
 					layout={ layout }
 					schema={ fieldSchema }
 					value={ fieldValue }
-					setValue={ updateValue }
+					updateValue={ updateValue }
 					error={ fieldError }
+				/>
+			);
+
+		case 'state':
+			return (
+				<StateDropdown
+					id={ id }
+					layout={ layout }
+					schema={ fieldSchema }
+					value={ fieldValue }
+					updateValue={ updateValue }
+					error={ fieldError }
+					countryCode={ settings[ layout.country_field ] }
 				/>
 			);
 

--- a/client/main.js
+++ b/client/main.js
@@ -18,7 +18,6 @@ const {
 	nonce,
 	submitMethod,
 	rootView,
-	countriesData,
 } = wcConnectData;
 
 const thunkArgs = { callbackURL, nonce, submitMethod, formSchema, formLayout };
@@ -43,7 +42,6 @@ let render = () => {
 				storeOptions={ storeOptions }
 				schema={ formSchema }
 				layout={ formLayout }
-				countriesData={ countriesData }
 			/>
 		</Provider>,
 		rootEl

--- a/client/main.js
+++ b/client/main.js
@@ -18,6 +18,7 @@ const {
 	nonce,
 	submitMethod,
 	rootView,
+	countriesData,
 } = wcConnectData;
 
 const thunkArgs = { callbackURL, nonce, submitMethod, formSchema, formLayout };
@@ -42,6 +43,7 @@ let render = () => {
 				storeOptions={ storeOptions }
 				schema={ formSchema }
 				layout={ formLayout }
+				countriesData={ countriesData }
 			/>
 		</Provider>,
 		rootEl

--- a/client/views/shipping/index.js
+++ b/client/views/shipping/index.js
@@ -1,12 +1,10 @@
 import React, { PropTypes } from 'react';
 import WCCSettingsForm from 'components/wcc-settings-form';
 
-const Settings = ( { storeOptions, schema, layout } ) => {
+const Settings = ( props ) => {
 	return (
 		<WCCSettingsForm
-			storeOptions={ storeOptions }
-			schema={ schema }
-			layout={ layout }
+			{ ...props }
 		/>
 	);
 };


### PR DESCRIPTION
Fixes #435

See #442 
This PR has the exact same code that #442, but the destination branch is `master`. Apparently you can't change the destination branch of an existing PR, so there you go, new one.

In this PR:
* Put the real, localized strings of the Address steps
* Implemented the country and state selectors
* Got the address form(s) ready for design

To test this, just go to a pending WooCommerce order with a physical product and click the "Create Label" button.

We have 3 different cases for the State selector:
* There are countries with States, and WooCommerce has a list of them. Example: US, Spain
* Some countries have states (or an equivalent concept) but WoCommerce doesn't have a list of them. In that case, a text field is displayed instead of a dropdown. Example: UK
* Some countries doesn't have states. In that case, we hide the entire field. Example: Sri Lanka

Screenshot:
![address](https://cloud.githubusercontent.com/assets/1715800/16520427/eca1e2ee-3f87-11e6-84c3-59678eb621cf.png)

@nabsul @jeffstieler @allendav 