### PR TITLE
Store the merchant address so it's prefilled the next times the label printing dialog is opened

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -43,11 +43,19 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		public function get_origin_address() {
-			return get_option( 'woocommerce_connect_origin_address', array() );
+			$wc_address_fields = array();
+			$wc_address_fields[ 'company' ] = get_bloginfo( 'name' );
+			$wc_address_fields[ 'name' ] = wp_get_current_user()->display_name;
+			$base_location = wc_get_base_location();
+			$wc_address_fields[ 'country' ] = $base_location[ 'country' ];
+			$wc_address_fields[ 'state' ] = $base_location[ 'state' ];
+
+			$stored_address_fields = get_option( 'wc_connect_origin_address', array() );
+			return array_merge( $wc_address_fields, $stored_address_fields );
 		}
 
 		public function update_origin_address( $address ) {
-			return update_option( 'woocommerce_connect_origin_address', $address );
+			return update_option( 'wc_connect_origin_address', $address );
 		}
 
 		protected function sort_services( $a, $b ) {

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -42,6 +42,14 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			);
 		}
 
+		public function get_origin_address() {
+			return get_option( 'woocommerce_connect_origin_address', array() );
+		}
+
+		public function update_origin_address( $address ) {
+			return update_option( 'woocommerce_connect_origin_address', $address );
+		}
+
 		protected function sort_services( $a, $b ) {
 
 			if ( $a->zone_order === $b->zone_order ) {

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -39,7 +39,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$form_data[ 'cart' ] = $contents;
 
 			foreach( $this->settings_store->get_origin_address() as $key => $value ) {
-				$formData[ 'orig_' . $key ] = $value;
+				$form_data[ 'orig_' . $key ] = $value;
 			}
 
 			$dest_address = $order->get_address( 'shipping' );

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -38,6 +38,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			}
 			$form_data[ 'cart' ] = $contents;
 
+			foreach( $this->settings_store->get_origin_address() as $key => $value ) {
+				$formData[ 'orig_' . $key ] = $value;
+			}
+
 			$dest_address = $order->get_address( 'shipping' );
 			$form_data[ 'dest_name' ] = trim( $dest_address[ 'first_name' ] . ' ' . $dest_address[ 'last_name' ] );
 			$form_data[ 'dest_company' ] = $dest_address[ 'company' ];

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -73,7 +73,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 
 		$response = $this->api_client->send_shipping_label_request( $settings );
 
-		if ( true /* TODO: Trigger this only when the label was correctly purchased */ ) {
+		if ( true /* TODO: Trigger this only if the origin address correctly validates */ ) {
 			$this->store_origin_address( $settings );
 		}
 

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -305,7 +305,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_self_help_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-label-controller.php' ) );
-			$rest_shipping_label_controller = new WC_REST_Connect_Shipping_Label_Controller( $this->api_client );
+			$rest_shipping_label_controller = new WC_REST_Connect_Shipping_Label_Controller( $this->api_client, $settings_store );
 			$this->set_rest_shipping_label_controller( $rest_shipping_label_controller );
 			$rest_shipping_label_controller->register_routes();
 		}


### PR DESCRIPTION
Fixes #434 

See #450 
This PR has the exact same code that #450, but the destination branch is `master`. Apparently you can't change the destination branch of an existing PR, so there you go, new one.

To test it:
* Open the label printing dialog.
* Input a complete origin address.
* Click the "Next" button.
* Reload the page and open the label printing dialog again.

The second time you open the label printing dialog, the Origin step should be pre-filled, and if it's "valid" for the server (remember, only `Hawk St` addresses are acceptable for now) it will auto-skip the step entirely.

Ideally, the merchant address should only be "remembered" if it was used to actually purchase a label, but since the integration between the merchant host and the WCC server isn't implemented yet, that's not possible.

@jeffstieler @nabsul @allendav 