### PR TITLE
[Labels] Packaging step

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,7 +91,6 @@ module.exports = {
 		'react/jsx-no-undef': 2,
 		'react/jsx-no-duplicate-props': 1,
 		'react/react-in-jsx-scope': 2,
-		'react/no-danger': 2,
 		'react/no-did-mount-set-state': 1,
 		'react/no-did-update-set-state': 1,
 		'react/jsx-no-bind': [ 1, { 'allowArrowFunctions': true } ],

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -121,7 +121,6 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				);
 			}
 
-			$errors[ 'cart' ] = array( 'value' => '' );
 			$errors[ 'rate' ] = array( 'value' => '' );
 
 			return $this->validation_error( $errors );

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -166,7 +166,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 					$contents[] = array(
 						'height' => $height,
-						'product_id' => $values['data']->id,
+						'product_id' => isset( $values['data']->variation_id ) ? $values['data']->variation_id : $values['data']->id,
 						'length' => $length,
 						'quantity' => $values['quantity'],
 						'weight' => $weight,

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -38,7 +38,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 						'items' => array(
 							array(
 								'height' => $height,
-								'product_id' => $item['product_id'],
+								'product_id' => $item[ 'product_id' ],
 								'length' => $length,
 								'quantity' => 1,
 								'weight' => $weight,

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -14,7 +14,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$packages = array();
 			foreach( $order->get_items() as $item ) {
 				$product = $order->get_product_from_item( $item );
-				if ( ! $product ) {
+				if ( ! $product || ! $product->needs_shipping() ) {
 					continue;
 				}
 				$height = 0;
@@ -53,12 +53,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		protected function get_packaging_data( WC_Order $order ) {
-			$shipping_methods = $order->get_shipping_methods();
-			if ( empty( $shipping_methods ) || ! isset( $shipping_methods[ 0 ][ 'wc_connect_packages' ] ) ) {
+			$shipping_method = reset( $order->get_shipping_methods() );
+			if ( ! $shipping_method || ! isset( $shipping_method[ 'wc_connect_packages' ] ) ) {
 				return $this->get_individual_packages( $order );
 			}
 
-			$packages = json_decode( $shipping_methods[ 0 ][ 'wc_connect_packages' ], true );
+			$packages = json_decode( $shipping_method[ 'wc_connect_packages' ], true );
 
 			foreach( $packages as $package_index => $package ) {
 				foreach( $package[ 'items' ] as $item_index => $item ) {

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -10,7 +10,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$this->settings_store = $settings_store;
 		}
 
-		protected function get_individual_packages( $order ) {
+		protected function get_items_as_individual_packages( $order ) {
 			$packages = array();
 			foreach( $order->get_items() as $item ) {
 				$product = $order->get_product_from_item( $item );
@@ -55,7 +55,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		protected function get_packaging_data( WC_Order $order ) {
 			$shipping_method = reset( $order->get_shipping_methods() );
 			if ( ! $shipping_method || ! isset( $shipping_method[ 'wc_connect_packages' ] ) ) {
-				return $this->get_individual_packages( $order );
+				return $this->get_items_as_individual_packages( $order );
 			}
 
 			$packages = json_decode( $shipping_method[ 'wc_connect_packages' ], true );

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -38,7 +38,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 						'items' => array(
 							array(
 								'height' => $height,
-								'product_id' => $item['product_id'], // TODO: Make this work with product variations
+								'product_id' => $item['product_id'],
 								'length' => $length,
 								'quantity' => 1,
 								'weight' => $weight,
@@ -62,7 +62,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			foreach( $packages as $package_index => $package ) {
 				foreach( $package[ 'items' ] as $item_index => $item ) {
-					// TODO: Make this work with product variations (make the WCC server handle and return 'variation_id' as well as 'product_id')
 					$product = $order->get_product_from_item( $item );
 					if ( ! $product ) {
 						continue;

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -27,7 +27,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					$length = $product->get_length();
 					$width  = $product->get_width();
 				}
-				$name = $product->get_formatted_name();
+				$name = html_entity_decode( $product->get_formatted_name() );
 
 				for ( $i = 0; $i < $item[ 'qty' ]; $i++ ) {
 					$packages[] = array(
@@ -67,7 +67,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					if ( ! $product ) {
 						continue;
 					}
-					$packages[ $package_index ][ 'items' ][ $item_index ][ 'name' ] = $product->get_formatted_name();
+					$packages[ $package_index ][ 'items' ][ $item_index ][ 'name' ] = html_entity_decode( $product->get_formatted_name() );
 				}
 			}
 
@@ -287,7 +287,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			$itemDefinition = array(
 				'type' => 'object',
-				'required' => array(),
+				'required' => array( 'height', 'product_id', 'name', 'length', 'quantity', 'weight', 'width' ),
 				'properties' => array(
 					'height' => array(
 						'type' => 'number',
@@ -296,6 +296,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					'product_id' => array(
 						'type' => 'string',
 						'title' => __( 'Product ID', 'woocommerce' ),
+					),
+					'name' => array(
+						'type' => 'string',
+						'title' => __( 'Product Name', 'woocommerce' ),
 					),
 					'length' => array(
 						'type' => 'number',
@@ -316,10 +320,38 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				),
 			);
 
+			$packageDefinition = array(
+				'type' => 'object',
+				'required' => array( 'height', 'length', 'weight', 'width', 'items' ),
+				'properties' => array(
+					'height' => array(
+						'type' => 'number',
+						'title' => __( 'Height', 'woocommerce' ),
+					),
+					'length' => array(
+						'type' => 'number',
+						'title' => __( 'Length', 'woocommerce' ),
+					),
+					'weight' => array(
+						'type' => 'number',
+						'title' => __( 'Weight', 'woocommerce' ),
+					),
+					'width' => array(
+						'type' => 'number',
+						'title' => __( 'Width', 'woocommerce' ),
+					),
+					'items' => array(
+						'type' => 'array',
+						'title' => __( 'Items', 'woocommerce' ),
+						'items' => $itemDefinition,
+					),
+				),
+			);
+
 			$properties[ 'cart' ] = array(
 				'type' => 'array',
-				'title' => __( 'Items to send', 'woocommerce' ),
-				'items' => $itemDefinition,
+				'title' => __( 'Packages to send', 'woocommerce' ),
+				'items' => $packageDefinition,
 			);
 			$required_fields[] = 'cart';
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -290,7 +290,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 							)
 						),
 						'cost'     => $rate->rate,
-						'calc_tax' => 'per_item'
+						'calc_tax' => 'per_item',
+						'meta_data' => array( 'wc_connect_packages' => json_encode( $rate->packages ) ),
 					);
 
 					$this->add_rate( $rate_to_add );

--- a/client/components/indicators/index.js
+++ b/client/components/indicators/index.js
@@ -10,15 +10,12 @@ const renderLastUpdated = ( lastUpdated ) => {
 		return null;
 	}
 
-	/* for dangerouslySetInnerHTML we need to pause linting for a narrow scope */
-	/* eslint-disable */
 	return (
 		<div className="form-setting-explanation indicator__last-updated">
-			<span dangerouslySetInnerHTML={ { __html: sanitize( lastUpdated, { ADD_ATTR: ['target'] } ) } } >
+			<span dangerouslySetInnerHTML={ { __html: sanitize( lastUpdated, { ADD_ATTR: [ 'target' ] } ) } } >
 			</span>
 		</div>
 	);
-	/* eslint-enable */
 };
 
 const Indicator = ( { icon, className, message, lastUpdated } ) => {

--- a/client/components/order-packages/index.js
+++ b/client/components/order-packages/index.js
@@ -12,7 +12,7 @@ const OrderPackages = ( { packages, updateValue, dimensionUnit, weightUnit, erro
 	);
 
 	const renderPackageDimensions = ( pckg ) => {
-		return [ pckg.length, pckg.width, pckg.height ].map( dim => dim + dimensionUnit ).join( ' x ' );
+		return [ pckg.length, pckg.width, pckg.height ].map( dim => dim + ' ' + dimensionUnit ).join( ' x ' );
 	};
 
 	const renderPackageInfo = ( pckg, pckgIndex ) => {

--- a/client/components/order-packages/index.js
+++ b/client/components/order-packages/index.js
@@ -3,7 +3,7 @@ import NumberInput from 'components/number-field/number-input';
 import Gridicon from 'components/gridicon';
 import { sanitize } from 'dompurify';
 
-const ShoppingCart = ( { packages, updateValue, dimensionUnit, weightUnit, errors } ) => {
+const OrderPackages = ( { packages, updateValue, dimensionUnit, weightUnit, errors } ) => {
 	const renderItemInfo = ( item, itemIndex ) => (
 		<li key={ itemIndex }>
 			<span dangerouslySetInnerHTML={ { __html: sanitize( item.name ) } } />
@@ -43,7 +43,7 @@ const ShoppingCart = ( { packages, updateValue, dimensionUnit, weightUnit, error
 	);
 };
 
-ShoppingCart.propTypes = {
+OrderPackages.propTypes = {
 	packages: PropTypes.array.isRequired,
 	updateValue: PropTypes.func.isRequired,
 	dimensionUnit: PropTypes.string.isRequired,
@@ -51,4 +51,4 @@ ShoppingCart.propTypes = {
 	errors: PropTypes.object,
 };
 
-export default ShoppingCart;
+export default OrderPackages;

--- a/client/components/shopping-cart/index.js
+++ b/client/components/shopping-cart/index.js
@@ -1,11 +1,12 @@
 import React, { PropTypes } from 'react';
 import NumberInput from 'components/number-field/number-input';
 import Gridicon from 'components/gridicon';
+import { sanitize } from 'dompurify';
 
 const ShoppingCart = ( { packages, updateValue, dimensionUnit, weightUnit, errors } ) => {
 	const renderItemInfo = ( item, itemIndex ) => (
 		<li key={ itemIndex }>
-			{ item.name }
+			<span dangerouslySetInnerHTML={ { __html: sanitize( item.name ) } } />
 			{ 1 < item.quantity ? ' (x' + item.quantity + ')' : null }
 		</li>
 	);

--- a/client/components/shopping-cart/index.js
+++ b/client/components/shopping-cart/index.js
@@ -3,27 +3,41 @@ import NumberInput from 'components/number-field/number-input';
 import Gridicon from 'components/gridicon';
 
 const ShoppingCart = ( { packages, updateValue, dimensionUnit, weightUnit, errors } ) => {
+	const renderItemInfo = ( item, itemIndex ) => (
+		<li key={ itemIndex }>
+			{ item.name }
+			{ 1 < item.quantity ? ' (x' + item.quantity + ')' : null }
+		</li>
+	);
+
+	const renderPackageDimensions = ( pckg ) => {
+		return [ pckg.length, pckg.width, pckg.height ].map( dim => dim + dimensionUnit ).join( ' x ' );
+	};
+
+	const renderPackageInfo = ( pckg, pckgIndex ) => {
+		const pckgErrors = errors[ pckgIndex ] || {};
+		return (
+			<li key={ pckgIndex }>
+				{ renderPackageDimensions( pckg ) }
+
+				{ pckgErrors.weight ? <Gridicon icon="notice" /> : null }
+				<NumberInput
+					value={ pckg.weight }
+					onChange={ ( event ) => updateValue( [ pckgIndex, 'weight' ], event.target.value ) }
+					isError={ Boolean( pckgErrors.weight ) }
+					style={ { width: 60, marginLeft: 16 } }
+				/> { weightUnit }
+
+				<ul>
+					{ pckg.items.map( renderItemInfo ) }
+				</ul>
+			</li>
+		);
+	};
+
 	return (
 		<ul>
-			{ packages.map( ( pckg, pckgIndex ) => (
-				<li key={ pckgIndex }>
-					{ [ pckg.length, pckg.width, pckg.height ].map( dim => dim + dimensionUnit ).join( ' x ' ) }
-					{ errors[ pckgIndex ] && errors[ pckgIndex ][ 'weight' ] ? <Gridicon icon="notice" /> : null }
-					<NumberInput
-						value={ pckg.weight }
-						onChange={ ( event ) => updateValue( [ pckgIndex, 'weight' ], event.target.value ) }
-						isError={ errors[ pckgIndex ] && errors[ pckgIndex ][ 'weight' ] }
-					/> { weightUnit }
-					<ul>
-						{ pckg.items.map( ( item, itemIndex ) => (
-							<li key={ itemIndex }>
-								{ item.name }
-								{ 1 < item.quantity ? ' (x' + item.quantity + ')' : null }
-							</li>
-						) ) }
-					</ul>
-				</li>
-			) ) }
+			{ packages.map( renderPackageInfo ) }
 		</ul>
 	);
 };

--- a/client/components/shopping-cart/index.js
+++ b/client/components/shopping-cart/index.js
@@ -1,0 +1,39 @@
+import React, { PropTypes } from 'react';
+import NumberInput from 'components/number-field/number-input';
+import Gridicon from 'components/gridicon';
+
+const ShoppingCart = ( { packages, updateValue, dimensionUnit, weightUnit, errors } ) => {
+	return (
+		<ul>
+			{ packages.map( ( pckg, pckgIndex ) => (
+				<li key={ pckgIndex }>
+					{ [ pckg.length, pckg.width, pckg.height ].map( dim => dim + dimensionUnit ).join( ' x ' ) }
+					{ errors[ pckgIndex ] && errors[ pckgIndex ][ 'weight' ] ? <Gridicon icon="notice" /> : null }
+					<NumberInput
+						value={ pckg.weight }
+						onChange={ ( event ) => updateValue( [ pckgIndex, 'weight' ], event.target.value ) }
+						isError={ errors[ pckgIndex ] && errors[ pckgIndex ][ 'weight' ] }
+					/> { weightUnit }
+					<ul>
+						{ pckg.items.map( ( item, itemIndex ) => (
+							<li key={ itemIndex }>
+								{ item.name }
+								{ 1 < item.quantity ? ' (x' + item.quantity + ')' : null }
+							</li>
+						) ) }
+					</ul>
+				</li>
+			) ) }
+		</ul>
+	);
+};
+
+ShoppingCart.propTypes = {
+	packages: PropTypes.array.isRequired,
+	updateValue: PropTypes.func.isRequired,
+	dimensionUnit: PropTypes.string.isRequired,
+	weightUnit: PropTypes.string.isRequired,
+	errors: PropTypes.object,
+};
+
+export default ShoppingCart;

--- a/client/components/state-dropdown/index.js
+++ b/client/components/state-dropdown/index.js
@@ -11,7 +11,6 @@ const StateDropdown = ( props ) => {
 			<TextField
 				{ ...props }
 				placeholder={ props.layout.placeholder }
-				required={ false }
 			/>
 		);
 	}

--- a/client/components/text/index.js
+++ b/client/components/text/index.js
@@ -14,14 +14,11 @@ const renderTitle = ( title ) => {
 };
 
 const renderText = ( text ) => {
-	/* for dangerouslySetInnerHTML we need to pause linting for a narrow scope */
-	/* eslint-disable */
 	return (
-		<span dangerouslySetInnerHTML={ { __html: sanitize( text, { ADD_ATTR: ['target'] } ) } }>
+		<span dangerouslySetInnerHTML={ { __html: sanitize( text, { ADD_ATTR: [ 'target' ] } ) } }>
 		</span>
 	);
-	/* eslint-enable */
-}
+};
 
 const Text = ( { id, layout, value } ) => {
 	return (

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -27,7 +27,6 @@ const SettingsItem = ( {
 	const updateSubValue = ( key, val ) => formValueActions.updateField( [ id ].concat( key ), val );
 	const removeArrayItem = ( idx ) => formValueActions.removeField( [ id ].concat( idx ) );
 	const savePackage = ( packageData ) => packagesActions.savePackage( id, packageData );
-	const fieldRequired = ( -1 !== schema.required.indexOf( id ) );
 	const fieldValue = form.values[ id ];
 	const fieldSchema = schema.properties[ id ];
 	const fieldType = layout.type || fieldSchema.type || '';
@@ -141,7 +140,6 @@ const SettingsItem = ( {
 					id={ id }
 					layout={ layout }
 					placeholder={ layout.placeholder }
-					required={ fieldRequired }
 					schema={ fieldSchema }
 					updateValue={ updateValue }
 					value={ fieldValue }
@@ -167,7 +165,6 @@ const SettingsItem = ( {
 					value={ fieldValue }
 					placeholder={ layout.placeholder }
 					updateValue={ updateValue }
-					required={ fieldRequired }
 					error={ fieldError }
 				/>
 			);
@@ -180,7 +177,6 @@ const SettingsItem = ( {
 					value={ fieldValue }
 					placeholder={ layout.placeholder }
 					updateValue={ updateValue }
-					required={ fieldRequired }
 					error={ fieldError }
 				/>
 			);

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -9,6 +9,7 @@ import RadioButtons from 'components/radio-buttons';
 import Dropdown from 'components/dropdown';
 import CountryDropdown from 'components/country-dropdown';
 import StateDropdown from 'components/state-dropdown';
+import ShoppingCart from 'components/shopping-cart';
 import ShippingServiceGroups from 'components/shipping/services';
 import Packages from 'components/shipping/packages';
 
@@ -166,6 +167,17 @@ const SettingsItem = ( {
 					placeholder={ layout.placeholder }
 					updateValue={ updateValue }
 					error={ fieldError }
+				/>
+			);
+
+		case 'cart':
+			return (
+				<ShoppingCart
+					packages={ fieldValue }
+					updateValue={ updateSubValue }
+					dimensionUnit={ storeOptions.dimension_unit }
+					weightUnit={ storeOptions.weight_unit }
+					errors={ errors }
 				/>
 			);
 

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -9,7 +9,7 @@ import RadioButtons from 'components/radio-buttons';
 import Dropdown from 'components/dropdown';
 import CountryDropdown from 'components/country-dropdown';
 import StateDropdown from 'components/state-dropdown';
-import ShoppingCart from 'components/shopping-cart';
+import OrderPackages from 'components/order-packages';
 import ShippingServiceGroups from 'components/shipping/services';
 import Packages from 'components/shipping/packages';
 
@@ -172,7 +172,7 @@ const SettingsItem = ( {
 
 		case 'cart':
 			return (
-				<ShoppingCart
+				<OrderPackages
 					packages={ fieldValue }
 					updateValue={ updateSubValue }
 					dimensionUnit={ storeOptions.dimension_unit }

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -250,8 +250,6 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			$schemas_store = $this->get_service_schemas_store();
 			$schemas = $schemas_store->get_service_schemas();
-			$settings_store = $this->get_service_settings_store();
-			$rest_services_controller = $this->get_rest_services_controller();
 
 			if ( $schemas ) {
 				add_filter( 'woocommerce_shipping_methods', array( $this, 'woocommerce_shipping_methods' ) );
@@ -269,6 +267,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			add_action( 'woocommerce_settings_saved', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_action( 'wc_connect_fetch_service_schemas', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
+			add_filter( 'woocommerce_hidden_order_itemmeta', array( $this, 'hide_wcc_meta_data' ) );
 
 		}
 
@@ -504,6 +503,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			foreach ( wc_get_order_types( 'order-meta-boxes' ) as $type ) {
 				add_meta_box( 'woocommerce-order-label', __( 'Shipping Label', 'woocommerce' ), array( $shipping_label, 'meta_box' ), $type, 'side', 'default' );
 			}
+		}
+
+		public function hide_wcc_meta_data( $hidden_keys ) {
+			$hidden_keys[] = 'wc_connect_packages';
+			return $hidden_keys;
 		}
 
 	}


### PR DESCRIPTION
Fixes #445 

Things to consider:
* The UI is very crude. I just made a few loops with plain `<ul>` and `<li>` tags.
* Since everything you see in the Packaging step is already valid, that step is skipped by default. So after the address steps you will appear in a (not implemented) Rates step. You can go back clicking the "Packages" link at the top. If we decide that the last step will have a summary of everything, I think this behaviour is fine. Anyway, we can change our minds later.
* If there is no information in the order `meta` about packaging (for example, if the user selected Free Shipping, or the order was placed using the code in the current `master` branch), then all the items will be packed individually (not a perfect fallback, but a fallback).
* All the relevant information per-package is visible (dimensions, weight), but only the weight is editable.
* In each package, it's displayed a list of the products that will go in that package.
* It works flawlessly with product variations! (Of course, y'all should try to challenge this fact).

@jeffstieler @allendav 