### PR TITLE
Add autoprefixer to the Webpack build

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -64,15 +64,9 @@
         @extend %form-field;
     }
 
-    @mixin placeholder {
-        &::-moz-placeholder { @content }
-        &::-webkit-input-placeholder { @content }
-        &:-ms-input-placeholder { @content }
-    }
-
     %form-field {
         box-shadow: none;
-        @include placeholder {
+        &::placeholder {
             color: lighten( $gray, 10% );
         }
     }
@@ -231,22 +225,12 @@
 
 }
 
-@-webkit-keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
-@-moz-keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
 
 #wc-connect-admin-container .form-troubles {
 	opacity: 0;
-	-webkit-animation: fadeIn ease-in 1;
-	-moz-animation: fadeIn ease-in 1;
 	animation: fadeIn ease-in 1;
-	-webkit-animation-fill-mode: forwards;
-	-moz-animation-fill-mode: forwards;
 	animation-fill-mode: forwards;
-	-webkit-animation-duration: .5s;
-	-moz-animation-duration: .5s;
 	animation-duration: .5s;
-	-webkit-animation-delay: 3s;
-	-moz-animation-delay: 3s;
 	animation-delay: 3s;
 }

--- a/client/components/shipping/packages/style.scss
+++ b/client/components/shipping/packages/style.scss
@@ -182,7 +182,7 @@
     color: $gray-dark;
     -webkit-text-fill-color: $gray-dark;
 
-    @include placeholder {
+    &::placeholder {
         color: $gray-dark;
     }
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "mocha-loader": "^0.7.1",
     "node-sass": "^3.7.0",
     "null-loader": "^0.1.1",
+    "postcss-loader": "^0.9.1",
     "react-addons-test-utils": "0.14.7",
     "redbox-react": "^1.2.2",
     "sass-loader": "^3.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require( 'webpack' );
 const path = require( 'path' );
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
+const autoprefixer = require( 'autoprefixer' );
 
 const babelSettings = {
 	presets: [
@@ -34,7 +35,7 @@ module.exports = {
 			},
 			{
 				test: /\.scss$/,
-				loader: ExtractTextPlugin.extract( 'style', 'css!sass' )
+				loader: ExtractTextPlugin.extract( 'style', 'css!postcss!sass' )
 			},
 			{
 				test: /\.html$/,
@@ -84,4 +85,7 @@ module.exports = {
 		} ),
 		new ExtractTextPlugin( '[name].css' ),
 	],
+	postcss: function () {
+		return [ autoprefixer ];
+	},
 };


### PR DESCRIPTION
Fixes #468 

We had already installed `autoprefixer` as a dependency, but for some reason it wasn't integrated into the Webpack build :)

The easiest way to test is:
* Don't forget to do `npm install` and re-start the build script.
* Go to a Canada Post settings configuration page, and remove the amount in the "Fallback Rate" field.
* If the placeholder (`Rate amount`) appears in light gray, then autoprefixer is working.
* If the placeholder appears in darker gray, then it's not working.

This is because the `::placeholder` pseudo-class is not standarized even in modern browsers, so if the vendor-prefixed versions aren't generated, the styling for that pseudo-class (make it lighter gray) is ignored.

Good:
![placeholder_good](https://cloud.githubusercontent.com/assets/1715800/17172224/f5c0f6ee-53eb-11e6-8732-e19ad59b59cd.png)

Bad:
![placeholder_bad](https://cloud.githubusercontent.com/assets/1715800/17172223/f34eaa1e-53eb-11e6-9b15-314119450fc4.png)

@allendav @jeffstieler 