### PR TITLE
[Labels] Rates selection step

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -72,7 +72,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		// TODO: Remove this when the real server-side validation is implemented for the shipping labels endpoint
-		private function validation_error( $fields, $field_options ) {
+		private function validation_error( $fields, $fields_options ) {
 			return new WP_Error( 'validation_failed',
 				__( 'One or more fields of your request are invalid.', 'woocommerce' ),
 				array(
@@ -80,7 +80,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 					'error' => 'validation_failure',
 					'data' => array(
 						'fields' => $fields,
-						'field_options' => $field_options,
+						'fieldsOptions' => $fields_options,
 					),
 				)
 			);
@@ -97,7 +97,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		public function send_shipping_label_request( $label_settings ) {
 			// TODO: use the real WCC server endpoint to validate
 			$errors = array();
-			$field_options = array();
+			$fields_options = array();
 			if ( $label_settings->orig_address_1 === 'Awk St' ) {
 				if ( ! isset( $label_settings->orig_bypass_suggestion ) || ! $label_settings->orig_bypass_suggestion ) {
 					$errors[ 'orig_address_1' ] = array(
@@ -108,6 +108,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			} else if ( $label_settings->orig_address_1 !== 'Hawk St' ) {
 				$errors[ 'orig_address_1' ] = array(
 					'value' => 'The server doesn\'t like that street!',
+					'level' => 'error',
 				);
 			}
 
@@ -121,12 +122,13 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			} else if ( $label_settings->dest_address_1 !== 'Hawk St' ) {
 				$errors[ 'dest_address_1' ] = array(
 					'value' => 'The server doesn\'t like that street!',
+					'level' => 'error',
 				);
 			}
 
-			$field_options[ 'rates' ] = array();
+			$fields_options[ 'rates' ] = array();
 			foreach ( $label_settings->cart as $index => $package ) {
-				$field_options[ 'rates' ][] = array(
+				$fields_options[ 'rates' ][] = array(
 					'pri_1day' => array(
 						'name' => 'Priority 1 Day',
 						'rate' => 1.1 + ( 0.01 * $index ),
@@ -150,7 +152,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				}
 			}
 
-			return $this->validation_error( $errors, $field_options );
+			return $this->validation_error( $errors, $fields_options );
 		}
 
 

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -76,7 +76,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			return new WP_Error( 'validation_failed',
 				__( 'One or more fields of your request are invalid.', 'woocommerce' ),
 				array(
-					'status' => 400,
+					'status' => 200,
 					'error' => 'validation_failure',
 					'data' => array(
 						'fields' => $fields,

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -72,7 +72,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		// TODO: Remove this when the real server-side validation is implemented for the shipping labels endpoint
-		private function validation_error( $fields ) {
+		private function validation_error( $fields, $field_options ) {
 			return new WP_Error( 'validation_failed',
 				__( 'One or more fields of your request are invalid.', 'woocommerce' ),
 				array(
@@ -80,6 +80,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 					'error' => 'validation_failure',
 					'data' => array(
 						'fields' => $fields,
+						'field_options' => $field_options,
 					),
 				)
 			);
@@ -95,6 +96,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 */
 		public function send_shipping_label_request( $label_settings ) {
 			// TODO: use the real WCC server endpoint to validate
+			$errors = array();
+			$field_options = array();
 			if ( $label_settings->orig_address_1 === 'Awk St' ) {
 				if ( ! isset( $label_settings->orig_bypass_suggestion ) || ! $label_settings->orig_bypass_suggestion ) {
 					$errors[ 'orig_address_1' ] = array(
@@ -121,9 +124,33 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				);
 			}
 
-			$errors[ 'rate' ] = array( 'value' => '' );
+			$field_options[ 'rates' ] = array();
+			foreach ( $label_settings->cart as $index => $package ) {
+				$field_options[ 'rates' ][] = array(
+					'pri_1day' => array(
+						'name' => 'Priority 1 Day',
+						'rate' => 1.1 + ( 0.01 * $index ),
+					),
+					'media' => array(
+						'name' => 'Media Mail',
+						'rate' => 2.2 + ( 0.01 * $index ),
+					),
+					'library' => array(
+						'name' => 'Library Mail',
+						'rate' => 3.3 + ( 0.01 * $index ),
+					),
+				);
 
-			return $this->validation_error( $errors );
+				if ( ! $label_settings->rates[ $index ] ) {
+					// If the client didn't select any rate, make it pre-select the cheapest one by default
+					$errors[ 'rates.' . $index ] = array(
+						'level' => 'overwrite',
+						'value' => 'pri_1day',
+					);
+				}
+			}
+
+			return $this->validation_error( $errors, $field_options );
 		}
 
 

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -143,7 +143,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 					),
 				);
 
-				if ( ! $label_settings->rates[ $index ] ) {
+				if ( ! isset( $label_settings->rates[ $index ] ) || ! $label_settings->rates[ $index ] ) {
 					// If the client didn't select any rate, make it pre-select the cheapest one by default
 					$errors[ 'rates.' . $index ] = array(
 						'level' => 'overwrite',

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -53,7 +53,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		protected function get_packaging_data( WC_Order $order ) {
-			$shipping_method = reset( $order->get_shipping_methods() );
+			$shipping_methods = $order->get_shipping_methods();
+			$shipping_method = reset( $shipping_methods );
 			if ( ! $shipping_method || ! isset( $shipping_method[ 'wc_connect_packages' ] ) ) {
 				return $this->get_items_as_individual_packages( $order );
 			}
@@ -74,7 +75,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		protected function get_selected_rates( WC_Order $order ) {
-			$shipping_method = reset( $order->get_shipping_methods() );
+			$shipping_methods = $order->get_shipping_methods();
+			$shipping_method = reset( $shipping_methods );
 			if ( ! $shipping_method || ! isset( $shipping_method[ 'wc_connect_packages' ] ) ) {
 				return array();
 			}

--- a/client/components/dropdown/index.js
+++ b/client/components/dropdown/index.js
@@ -24,8 +24,8 @@ const Dropdown = ( { id, layout, schema, value, updateValue, error } ) => {
 						</option>
 					);
 				} ) }
-				{ error ? <FieldError text={ error } /> : null }
 			</FormSelect>
+			{ error ? <FieldError text={ error } /> : null }
 		</FormFieldset>
 	);
 };

--- a/client/components/order-packages/index.js
+++ b/client/components/order-packages/index.js
@@ -12,7 +12,7 @@ const OrderPackages = ( { packages, updateValue, dimensionUnit, weightUnit, erro
 	);
 
 	const renderPackageDimensions = ( pckg ) => {
-		return [ pckg.length, pckg.width, pckg.height ].map( dim => dim + ' ' + dimensionUnit ).join( ' x ' );
+		return `${pckg.length} ${dimensionUnit} x ${pckg.width} ${dimensionUnit} x ${pckg.height} ${dimensionUnit}`;
 	};
 
 	const renderPackageInfo = ( pckg, pckgIndex ) => {

--- a/client/components/shipping-rates/index.js
+++ b/client/components/shipping-rates/index.js
@@ -3,9 +3,7 @@ import Dropdown from 'components/dropdown';
 
 const ShippingRates = ( { id, selectedRates, availableRates, packages, updateValue, dimensionUnit, weightUnit, currencySymbol, errors, layout } ) => {
 	const renderTitle = ( pckg ) => {
-		const dimensions = [ pckg.length, pckg.width, pckg.height ].map( dim => dim + ' ' + dimensionUnit ).join( ' x ' );
-		const weight = pckg.weight + ' ' + weightUnit;
-		return dimensions + ' ' + weight;
+		return `${pckg.length} ${dimensionUnit} x ${pckg.width} ${dimensionUnit} x ${pckg.height} ${dimensionUnit} (${pckg.weight} ${weightUnit})`;
 	};
 
 	const renderSinglePackage = ( pckg, index ) => {

--- a/client/components/shipping-rates/index.js
+++ b/client/components/shipping-rates/index.js
@@ -1,0 +1,54 @@
+import React, { PropTypes } from 'react';
+import Dropdown from 'components/dropdown';
+
+const ShippingRates = ( { selectedRates, availableRates, packages, updateValue, dimensionUnit, weightUnit, currencySymbol, errors, layout } ) => {
+	const renderTitle = ( pckg ) => {
+		const dimensions = [ pckg.length, pckg.width, pckg.height ].map( dim => dim + ' ' + dimensionUnit ).join( ' x ' );
+		const weight = pckg.weight + ' ' + weightUnit;
+		return <span>{ dimensions + ' ' + weight }</span>;
+	};
+
+	const renderSinglePackage = ( pckg, index ) => {
+		const selectedRate = selectedRates[ index ] || '';
+		const errorObject = ( errors[ index ] || {} )[ '' ];
+		const error = errorObject ? ( errorObject.value || layout.validation_hint ) : null;
+
+		const titleMap = {};
+		Object.keys( availableRates[ index ] ).forEach( ( serviceId ) => {
+			const rateObject = availableRates[ index ][ serviceId ];
+			titleMap[ serviceId ] = rateObject.name + ' (' + currencySymbol + rateObject.rate.toFixed( 2 ) + ')';
+		} );
+
+		return (
+			<li key={ index }>
+				<Dropdown
+					id={ 'rates_' + index } // TODO: remove when #469 lands
+					layout={ { titleMap: titleMap } }
+					schema={ { title: renderTitle( pckg ) } }
+					value={ selectedRate }
+					updateValue={ ( value ) => updateValue( [ index ], value ) }
+					error={ error } />
+			</li>
+		);
+	};
+
+	return (
+		<ul>
+			{ packages.map( renderSinglePackage ) }
+		</ul>
+	);
+};
+
+ShippingRates.propTypes = {
+	selectedRates: PropTypes.array.isRequired,
+	availableRates: PropTypes.array.isRequired,
+	packages: PropTypes.array.isRequired,
+	updateValue: PropTypes.func.isRequired,
+	dimensionUnit: PropTypes.string.isRequired,
+	weightUnit: PropTypes.string.isRequired,
+	currencySymbol: PropTypes.string.isRequired,
+	errors: PropTypes.object,
+	layout: PropTypes.object.isRequired,
+};
+
+export default ShippingRates;

--- a/client/components/shipping-rates/index.js
+++ b/client/components/shipping-rates/index.js
@@ -1,11 +1,11 @@
 import React, { PropTypes } from 'react';
 import Dropdown from 'components/dropdown';
 
-const ShippingRates = ( { selectedRates, availableRates, packages, updateValue, dimensionUnit, weightUnit, currencySymbol, errors, layout } ) => {
+const ShippingRates = ( { id, selectedRates, availableRates, packages, updateValue, dimensionUnit, weightUnit, currencySymbol, errors, layout } ) => {
 	const renderTitle = ( pckg ) => {
 		const dimensions = [ pckg.length, pckg.width, pckg.height ].map( dim => dim + ' ' + dimensionUnit ).join( ' x ' );
 		const weight = pckg.weight + ' ' + weightUnit;
-		return <span>{ dimensions + ' ' + weight }</span>;
+		return dimensions + ' ' + weight;
 	};
 
 	const renderSinglePackage = ( pckg, index ) => {
@@ -22,7 +22,7 @@ const ShippingRates = ( { selectedRates, availableRates, packages, updateValue, 
 		return (
 			<li key={ index }>
 				<Dropdown
-					id={ 'rates_' + index } // TODO: remove when #469 lands
+					id={ id + '_' + index }
 					layout={ { titleMap: titleMap } }
 					schema={ { title: renderTitle( pckg ) } }
 					value={ selectedRate }
@@ -40,6 +40,7 @@ const ShippingRates = ( { selectedRates, availableRates, packages, updateValue, 
 };
 
 ShippingRates.propTypes = {
+	id: PropTypes.string.isRequired,
 	selectedRates: PropTypes.array.isRequired,
 	availableRates: PropTypes.array.isRequired,
 	packages: PropTypes.array.isRequired,

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -185,6 +185,7 @@ const SettingsItem = ( {
 		case 'rates':
 			return (
 				<ShippingRates
+					id={ id }
 					selectedRates={ fieldValue }
 					availableRates={ form.fieldsOptions[ id ] }
 					packages={ form.values[ layout.packages_field ] }

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -186,7 +186,7 @@ const SettingsItem = ( {
 			return (
 				<ShippingRates
 					selectedRates={ fieldValue }
-					availableRates={ form.field_options[ id ] }
+					availableRates={ form.fieldsOptions[ id ] }
 					packages={ form.values[ layout.packages_field ] }
 					updateValue={ updateSubValue }
 					dimensionUnit={ storeOptions.dimension_unit }

--- a/client/components/wcc-settings-form/settings-item.js
+++ b/client/components/wcc-settings-form/settings-item.js
@@ -10,6 +10,7 @@ import Dropdown from 'components/dropdown';
 import CountryDropdown from 'components/country-dropdown';
 import StateDropdown from 'components/state-dropdown';
 import OrderPackages from 'components/order-packages';
+import ShippingRates from 'components/shipping-rates';
 import ShippingServiceGroups from 'components/shipping/services';
 import Packages from 'components/shipping/packages';
 
@@ -177,6 +178,21 @@ const SettingsItem = ( {
 					updateValue={ updateSubValue }
 					dimensionUnit={ storeOptions.dimension_unit }
 					weightUnit={ storeOptions.weight_unit }
+					errors={ errors }
+				/>
+			);
+
+		case 'rates':
+			return (
+				<ShippingRates
+					selectedRates={ fieldValue }
+					availableRates={ form.field_options[ id ] }
+					packages={ form.values[ layout.packages_field ] }
+					updateValue={ updateSubValue }
+					dimensionUnit={ storeOptions.dimension_unit }
+					weightUnit={ storeOptions.weight_unit }
+					currencySymbol={ storeOptions.currency_symbol }
+					layout={ layout }
 					errors={ errors }
 				/>
 			);

--- a/client/lib/save-form/index.js
+++ b/client/lib/save-form/index.js
@@ -2,7 +2,7 @@ import isArray from 'lodash/isArray';
 import Get from 'lodash/get';
 import { EMPTY_ERROR } from 'state/selectors/errors';
 
-const saveForm = ( setIsSaving, setSuccess, setFieldOptions, setError, url, nonce, submitMethod, formData ) => {
+const saveForm = ( setIsSaving, setSuccess, setFieldsOptions, setFieldsStatus, setError, url, nonce, submitMethod, formData ) => {
 	setIsSaving( true );
 	const request = {
 		method: submitMethod || 'PUT',
@@ -22,18 +22,18 @@ const saveForm = ( setIsSaving, setSuccess, setFieldOptions, setError, url, nonc
 				return setSuccess( true );
 			}
 
-			if ( Get( json, 'data.data.field_options' ) ) {
-				setFieldOptions( json.data.data.field_options );
+			if ( Get( json, 'data.data.fieldsOptions' ) ) {
+				setFieldsOptions( json.data.data.fieldsOptions );
 			}
 
 			if ( 'validation_failure' === Get( json, 'data.error' ) && Get( json, 'data.data.fields' ) ) {
-				let errors = json.data.data.fields;
+				let fieldsStatus = json.data.data.fields;
 				// Some services still give the field errors in an array, keep backwards-compatibility
-				if ( isArray( errors ) ) {
-					errors = {};
-					json.data.data.fields.forEach( ( fieldName ) => errors[ fieldName ] = EMPTY_ERROR );
+				if ( isArray( fieldsStatus ) ) {
+					fieldsStatus = {};
+					json.data.data.fields.forEach( ( fieldName ) => fieldsStatus[ fieldName ] = EMPTY_ERROR );
 				}
-				return setError( errors );
+				return setFieldsStatus( fieldsStatus );
 			}
 
 			if ( json.data.message ) {

--- a/client/lib/save-form/index.js
+++ b/client/lib/save-form/index.js
@@ -1,7 +1,8 @@
 import isArray from 'lodash/isArray';
+import Get from 'lodash/get';
 import { EMPTY_ERROR } from 'state/selectors/errors';
 
-const saveForm = ( setIsSaving, setSuccess, setError, url, nonce, submitMethod, formData ) => {
+const saveForm = ( setIsSaving, setSuccess, setFieldOptions, setError, url, nonce, submitMethod, formData ) => {
 	setIsSaving( true );
 	const request = {
 		method: submitMethod || 'PUT',
@@ -21,11 +22,11 @@ const saveForm = ( setIsSaving, setSuccess, setError, url, nonce, submitMethod, 
 				return setSuccess( true );
 			}
 
-			if ( json.data &&
-				'validation_failure' === json.data.error &&
-				json.data.data &&
-				json.data.data.fields
-			) {
+			if ( Get( json, 'data.data.field_options' ) ) {
+				setFieldOptions( json.data.data.field_options );
+			}
+
+			if ( 'validation_failure' === Get( json, 'data.error' ) && Get( json, 'data.data.fields' ) ) {
 				let errors = json.data.data.fields;
 				// Some services still give the field errors in an array, keep backwards-compatibility
 				if ( isArray( errors ) ) {

--- a/client/lib/utils/coerce-values.js
+++ b/client/lib/utils/coerce-values.js
@@ -1,5 +1,3 @@
-let coerceFormValues;
-
 /**
  * Retrieve a field's schema, handling referenced schema definitions if need be.
  *
@@ -63,7 +61,12 @@ const coerceValue = ( schema, value, definitions ) => {
 			return value ? value.toString() : '';
 
 		case 'object':
-			return coerceFormValues( schema, value, definitions );
+			const coerced = {};
+			Object.keys( value ).forEach( ( key ) => {
+				const fieldSchema = ( schema.properties || {} )[ key ];
+				coerced[ key ] = coerceValue( fieldSchema, value[ key ], definitions );
+			} );
+			return coerced;
 
 		case 'array':
 			return value.map( ( arrayItem ) => coerceValue( schema.items, arrayItem, definitions ) );
@@ -78,24 +81,10 @@ const coerceValue = ( schema, value, definitions ) => {
  *
  * @param {Object} schema - Schema containing type declarations.
  * @param {Object} values - Form values.
- * @param {Object} [definitions=null] - Optional. Schema definitions, parsed from schema if omitted.
  * @returns {Object} - Coerced values based on schema.
  */
-coerceFormValues = ( schema, values, definitions = null ) => {
-	let coerced = {};
-
-	// Pull definitions from schema if not passed explicitly.
-	if ( ( null === definitions ) && schema.definitions ) {
-		definitions = schema.definitions;
-	}
-
-	// Coerce each form value
-	Object.keys( values ).forEach( ( key ) => {
-		const fieldSchema = ( schema.properties || {} )[ key ];
-		coerced[ key ] = coerceValue( fieldSchema, values[ key ], definitions );
-	} );
-
-	return coerced;
+const coerceFormValues = ( schema, values ) => {
+	return coerceValue( { type: 'object', properties: schema.properties }, values, schema.definitions );
 };
 
 export default coerceFormValues;

--- a/client/state/form/actions.js
+++ b/client/state/form/actions.js
@@ -55,7 +55,7 @@ export const nextStep = () => ( dispatch, getState, { callbackURL, nonce, submit
 		uncheckAcceptSuggestion: () => dispatch( setFormProperty( 'acceptSuggestion', undefined ) ),
 		goToNextStep: () => dispatch( goToStep( getFormState().currentStep + 1 ) ),
 		updateField: updateField,
-		showErrorNotice: ( errors ) => dispatch( NoticeActions.errorNotice( errors, { duration: 7000 } ) ),
+		showErrorNotice: ( error ) => dispatch( NoticeActions.errorNotice( error, { duration: 7000 } ) ),
 		getFormState: getFormState,
 		submit: () => submitForm( callbackURL, nonce, submitMethod, getFormState().values, bindActionCreators( setFormProperty, dispatch ) ),
 		setConfirmationFlag: () => getCurrentStepLayout().confirmation_flag && updateField( getCurrentStepLayout().confirmation_flag, true ),

--- a/client/state/form/auto-advance.js
+++ b/client/state/form/auto-advance.js
@@ -11,10 +11,11 @@ export const submitForm = ( callbackURL, nonce, submitMethod, formValues, setFor
 			}
 		};
 		const setSuccess = ( value ) => setFormProperty( 'success', value );
+		const setFieldOptions = ( value ) => setFormProperty( 'field_options', value );
 		const setError = ( value ) => setFormProperty( 'errors', value );
 
 		setFormProperty( 'pristine', true );
-		saveForm( setIsSaving, setSuccess, setError, callbackURL, nonce, submitMethod, formValues );
+		saveForm( setIsSaving, setSuccess, setFieldOptions, setError, callbackURL, nonce, submitMethod, formValues );
 	} );
 };
 

--- a/client/state/form/auto-advance.js
+++ b/client/state/form/auto-advance.js
@@ -1,5 +1,4 @@
 import saveForm from 'lib/save-form';
-import isObject from 'lodash/isObject';
 import isEmpty from 'lodash/isEmpty';
 
 export const submitForm = ( callbackURL, nonce, submitMethod, formValues, setFormProperty ) => {
@@ -11,11 +10,12 @@ export const submitForm = ( callbackURL, nonce, submitMethod, formValues, setFor
 			}
 		};
 		const setSuccess = ( value ) => setFormProperty( 'success', value );
-		const setFieldOptions = ( value ) => setFormProperty( 'field_options', value );
-		const setError = ( value ) => setFormProperty( 'errors', value );
+		const setFieldsOptions = ( value ) => setFormProperty( 'fieldsOptions', value );
+		const setFieldsStatus = ( value ) => setFormProperty( 'fieldsStatus', value );
+		const setError = ( value ) => setFormProperty( 'error', value );
 
 		setFormProperty( 'pristine', true );
-		saveForm( setIsSaving, setSuccess, setFieldOptions, setError, callbackURL, nonce, submitMethod, formValues );
+		saveForm( setIsSaving, setSuccess, setFieldsOptions, setFieldsStatus, setError, callbackURL, nonce, submitMethod, formValues );
 	} );
 };
 
@@ -68,8 +68,8 @@ export const autoAdvanceForm = ( {
 
 		submit().then( () => {
 			uncheckAcceptSuggestion();
-			if ( getFormState().errors && ! isObject( getFormState().errors ) ) {
-				showErrorNotice( getFormState().errors );
+			if ( getFormState().error ) {
+				showErrorNotice( getFormState().error );
 				return;
 			}
 

--- a/client/state/form/reducer.js
+++ b/client/state/form/reducer.js
@@ -18,6 +18,15 @@ reducers[ SET_FORM_PROPERTY ] = ( state, action ) => {
 	newObj[ action.field ] = action.value;
 	if ( 'success' === action.field && action.value ) {
 		newObj.pristine = true;
+	} else if ( 'errors' === action.field && action.value ) {
+		Object.keys( action.value ).forEach( ( errorPath ) => {
+			const error = action.value[ errorPath ];
+			if ( 'overwrite' === error.level ) {
+				const overwriteAction = formValueActions.updateField( errorPath, error.value );
+				newObj.values = values( newObj.values || state.values || {}, overwriteAction );
+				delete action.value[ errorPath ];
+			}
+		} );
 	}
 	return Object.assign( {}, state, newObj );
 };

--- a/client/state/form/reducer.js
+++ b/client/state/form/reducer.js
@@ -18,13 +18,13 @@ reducers[ SET_FORM_PROPERTY ] = ( state, action ) => {
 	newObj[ action.field ] = action.value;
 	if ( 'success' === action.field && action.value ) {
 		newObj.pristine = true;
-	} else if ( 'errors' === action.field && action.value ) {
-		Object.keys( action.value ).forEach( ( errorPath ) => {
-			const error = action.value[ errorPath ];
-			if ( 'overwrite' === error.level ) {
-				const overwriteAction = formValueActions.updateField( errorPath, error.value );
+	} else if ( 'fieldsStatus' === action.field && action.value ) {
+		Object.keys( action.value ).forEach( ( fieldPath ) => {
+			const fieldStatus = action.value[ fieldPath ];
+			if ( 'overwrite' === fieldStatus.level ) {
+				const overwriteAction = formValueActions.updateField( fieldPath, fieldStatus.value );
 				newObj.values = values( newObj.values || state.values || {}, overwriteAction );
-				delete action.value[ errorPath ];
+				delete action.value[ fieldPath ];
 			}
 		} );
 	}
@@ -66,9 +66,8 @@ export default function form( state = {}, action ) {
 		newState.pristine = false;
 
 		// Allow client-side form validation to take over error state when inputs change
-		if ( newState.errors ) {
-			delete newState.errors;
-		}
+		delete newState.error;
+		delete newState.fieldsStatus;
 
 		newState = Object.assign( newState, {
 			values: values( state.values || {}, action ),

--- a/client/state/form/test/reducer.js
+++ b/client/state/form/test/reducer.js
@@ -49,11 +49,11 @@ describe( 'Settings reducer', () => {
 		} );
 	} );
 
-	it( 'Clears errors on settings state change', () => {
-		const initialErrorState = Object.assign( { errors: [ 'data.title' ] }, initialState );
+	it( 'Clears fields status on settings state change', () => {
+		const initialErrorState = Object.assign( { fieldsStatus: [ 'data.title' ] }, initialState );
 		const action = updateField( 'some_key', 'some value' );
 		const state = reducer( initialErrorState, action );
 
-		expect( state ).to.not.have.property( 'errors' );
+		expect( state ).to.not.have.property( 'fieldsStatus' );
 	} );
 } );

--- a/client/state/form/values/actions.js
+++ b/client/state/form/values/actions.js
@@ -29,7 +29,9 @@ export const addArrayFieldItem = ( path, item ) => ( {
 
 export const submit = ( schema, silent ) => ( dispatch, getState, { callbackURL, nonce, submitMethod } ) => {
 	silent = ( true === silent );
+
 	const setIsSaving = ( value ) => dispatch( FormActions.setFormProperty( 'isSaving', value ) );
+
 	const setSuccess = ( value ) => {
 		dispatch( FormActions.setFormProperty( 'success', value ) );
 		if ( ! silent && true === value ) {
@@ -38,9 +40,21 @@ export const submit = ( schema, silent ) => ( dispatch, getState, { callbackURL,
 			} ) );
 		}
 	};
-	const setFieldOptions = ( value ) => FormActions.setFormProperty( 'field_options', value );
+
+	const setFieldsOptions = ( value ) => FormActions.setFormProperty( 'fieldsOptions', value );
+
+	const setFieldsStatus = ( value ) => {
+		dispatch( FormActions.setFormProperty( 'fieldsStatus', value ) );
+
+		if ( ! silent ) {
+			dispatch( NoticeActions.errorNotice( __( 'There was a problem with one or more entries. Please fix the errors below and try saving again.' ), {
+				duration: 7000,
+			} ) );
+		}
+	};
+
 	const setError = ( value ) => {
-		dispatch( FormActions.setFormProperty( 'errors', value ) );
+		dispatch( FormActions.setFormProperty( 'error', value ) );
 
 		if ( ! silent ) {
 			if ( isString( value ) ) {
@@ -56,7 +70,8 @@ export const submit = ( schema, silent ) => ( dispatch, getState, { callbackURL,
 			}
 		}
 	};
+
 	const coercedValues = coerceFormValues( schema, getState().form.values );
 
-	saveForm( setIsSaving, setSuccess, setFieldOptions, setError, callbackURL, nonce, submitMethod, coercedValues );
+	saveForm( setIsSaving, setSuccess, setFieldsOptions, setFieldsStatus, setError, callbackURL, nonce, submitMethod, coercedValues );
 };

--- a/client/state/form/values/actions.js
+++ b/client/state/form/values/actions.js
@@ -38,6 +38,7 @@ export const submit = ( schema, silent ) => ( dispatch, getState, { callbackURL,
 			} ) );
 		}
 	};
+	const setFieldOptions = ( value ) => FormActions.setFormProperty( 'field_options', value );
 	const setError = ( value ) => {
 		dispatch( FormActions.setFormProperty( 'errors', value ) );
 
@@ -57,5 +58,5 @@ export const submit = ( schema, silent ) => ( dispatch, getState, { callbackURL,
 	};
 	const coercedValues = coerceFormValues( schema, getState().form.values );
 
-	saveForm( setIsSaving, setSuccess, setError, callbackURL, nonce, submitMethod, coercedValues );
+	saveForm( setIsSaving, setSuccess, setFieldOptions, setError, callbackURL, nonce, submitMethod, coercedValues );
 };

--- a/client/state/form/values/reducer.js
+++ b/client/state/form/values/reducer.js
@@ -21,7 +21,7 @@ reducers[ REMOVE_FIELD ] = ( state, action ) => {
 
 reducers[ ADD_ARRAY_FIELD_ITEM ] = ( state, action ) => {
 	return objectPath.push( state, action.path, action.item );
-}
+};
 
 reducers[ SAVE_PACKAGE ] = ( state, action ) => {
 	const {

--- a/client/state/selectors/errors.js
+++ b/client/state/selectors/errors.js
@@ -4,7 +4,9 @@ import validator from 'is-my-json-valid';
 import ObjectPath from 'objectpath';
 import coerceFormValues from 'lib/utils/coerce-values';
 
-export const EMPTY_ERROR = {};
+export const EMPTY_ERROR = {
+	level: 'error',
+};
 Object.freeze( EMPTY_ERROR );
 
 /*
@@ -77,10 +79,10 @@ const getRawFormErrors = ( schema, data ) => {
 };
 
 export const getFormErrors = createSelector(
-	( state ) => state.form.errors,
+	( state ) => state.form.fieldsStatus,
 	( state, schema ) => schema,
 	( state ) => state.form.values,
-	( errors, schema, data ) => parseErrorsList( errors || getRawFormErrors( schema, data ) )
+	( fieldsStatus, schema, data ) => parseErrorsList( fieldsStatus || getRawFormErrors( schema, data ) )
 );
 
 export const getStepFormErrors = createSelector(

--- a/vendor/class-wp-rest-controller.php
+++ b/vendor/class-wp-rest-controller.php
@@ -311,13 +311,13 @@ abstract class WP_REST_Controller {
 
 		$additional_fields = $this->get_additional_fields();
 
-		foreach ( $additional_fields as $field_name => $field_options ) {
+		foreach ( $additional_fields as $field_name => $fields_options ) {
 
-			if ( ! $field_options['get_callback'] ) {
+			if ( ! $fields_options['get_callback'] ) {
 				continue;
 			}
 
-			$object[ $field_name ] = call_user_func( $field_options['get_callback'], $object, $field_name, $request, $this->get_object_type() );
+			$object[ $field_name ] = call_user_func( $fields_options['get_callback'], $object, $field_name, $request, $this->get_object_type() );
 		}
 
 		return $object;
@@ -333,9 +333,9 @@ abstract class WP_REST_Controller {
 
 		$additional_fields = $this->get_additional_fields();
 
-		foreach ( $additional_fields as $field_name => $field_options ) {
+		foreach ( $additional_fields as $field_name => $fields_options ) {
 
-			if ( ! $field_options['update_callback'] ) {
+			if ( ! $fields_options['update_callback'] ) {
 				continue;
 			}
 
@@ -344,7 +344,7 @@ abstract class WP_REST_Controller {
 				continue;
 			}
 
-			call_user_func( $field_options['update_callback'], $request[ $field_name ], $object, $field_name, $request, $this->get_object_type() );
+			call_user_func( $fields_options['update_callback'], $request[ $field_name ], $object, $field_name, $request, $this->get_object_type() );
 		}
 	}
 
@@ -367,12 +367,12 @@ abstract class WP_REST_Controller {
 
 		$additional_fields = $this->get_additional_fields( $object_type );
 
-		foreach ( $additional_fields as $field_name => $field_options ) {
-			if ( ! $field_options['schema'] ) {
+		foreach ( $additional_fields as $field_name => $fields_options ) {
+			if ( ! $fields_options['schema'] ) {
 				continue;
 			}
 
-			$schema['properties'][ $field_name ] = $field_options['schema'];
+			$schema['properties'][ $field_name ] = $fields_options['schema'];
 		}
 
 		return $schema;


### PR DESCRIPTION
Fixes #452 

As usual, crude UI and everything mocked in the server, but only 1 more step to go!

For the UI of that step, I did a simple loop over all the packages in the order, and for each one, show the package dimensions (as a way for the merchant to remember which package is the rate referring to) and a `<select>` with all available rates for each package (with the price alongside).

Since this step required a more "dynamic" communication between client and server, I've added 2 small things:
* Apart from returning `errors`, the server can now return an array of `field_options`. This assoc array will have the structure `"field.path" => "arbitrary data"`. That can be used to feed the client with dynamic options for a field (because the `formLayout` is immutable).
* There is a new kind of `error`. You have the plain error, the `suggestion` (used by returning an error with `"level" => "suggestion"`), and now, `overwrite` (used by returning an error with the structure `"level" => "overwrite", "value" => "newFieldValue"`). The form value for that field will be overwritten with the value provided by the server, and then the error will be discarded. This allows the server to not only return the possible rates, but to also `pre-select` a rate for the user (normally the cheapest one), so the client can even skip that step. This "feeding the client with form values" will come useful in the Packaging step for the Free Shipping case.

If you don't understand something, please point it out so I can add documentation.

@jeffstieler @allendav 