### PR TITLE
Changed the message appearing when settings/labels fail to load

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -164,7 +164,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			wp_enqueue_style( 'wc_connect_admin' );
 
 			?>
-			<div class="wc-connect-admin-container" id="<?php echo esc_attr( $root_view ) ?>"><span class="form-troubles" style="opacity: 0"><?php printf( __( 'Settings not loading? Visit the WooCommerce Connect <a href="%s">debug page</a> to get some troubleshooting steps.', 'woocommerce' ), $debug_page_uri ); ?></span></div>
+			<div class="wc-connect-admin-container" id="<?php echo esc_attr( $root_view ) ?>"><span class="form-troubles" style="opacity: 0"><?php printf( __( 'Shipping labels not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce' ), $debug_page_uri ); ?></span></div>
 			<?php
 		}
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -337,7 +337,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 					<span class="form-troubles" style="opacity: 0">
 						<?php printf(
 							wp_kses(
-								__( 'Settings not loading? Visit the WooCommerce Connect <a href="%s">debug page</a> to get some troubleshooting steps.', 'woocommerce' ),
+								__( 'Settings not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'woocommerce' ),
 								array( 'a' => array( 'href' => array() ) )
 							),
 							$debug_page_uri


### PR DESCRIPTION
Fix for #478 

When labels fail to load the copy should read: "Shipping labels not loading? Visit the status page for troubleshooting steps."

When settings fail to load: "Settings not loading? Visit the status page for some troubleshooting steps."

CC @kellychoffman 