### PR TITLE
Wrapped package texts in translate function

### DIFF
--- a/client/settings/views/packages/add-package-presets.js
+++ b/client/settings/views/packages/add-package-presets.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import SelectOptGroups from 'components/forms/select-opt-groups';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
+import { translate as __ } from 'lib/mixins/i18n';
 
 const defaultPackages = {
 	label: 'Custom box',
@@ -76,7 +77,7 @@ const AddPackagePresets = ( { selectedPreset, setSelectedPreset, presets, setMod
 
 	return (
 		<FormFieldset>
-			<FormLabel htmlFor="package_type">Type of package</FormLabel>
+			<FormLabel htmlFor="package_type">{ __( 'Type of package' ) }</FormLabel>
 			<SelectOptGroups
 				id="package_type"
 				defaultValue={ selectedPreset }

--- a/client/settings/views/packages/packages-list-item.js
+++ b/client/settings/views/packages/packages-list-item.js
@@ -3,6 +3,7 @@ import Gridicon from 'components/gridicon';
 import Button from 'components/button';
 import classNames from 'classnames';
 import trim from 'lodash/trim';
+import { translate as __ } from 'lib/mixins/i18n';
 
 const renderIcon = ( isLetter, isError, onClick ) => {
 	let icon;
@@ -41,7 +42,7 @@ const PackagesListItem = ( {
 					{
 						data.name && '' !== trim( data.name )
 						? data.name
-						: <span className="package-no-name">Untitled</span>
+						: <span className="package-no-name">{ __( 'Untitled' ) }</span>
 					}
 				</a>
 			</div>

--- a/client/settings/views/packages/packages-list.js
+++ b/client/settings/views/packages/packages-list.js
@@ -3,6 +3,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import PackagesListItem from './packages-list-item';
 import Gridicon from 'components/gridicon';
+import { translate as __ } from 'lib/mixins/i18n';
 
 const noPackages = () => {
 	return (
@@ -10,7 +11,7 @@ const noPackages = () => {
 			<div className="package-list-empty-icon">
 				<Gridicon icon="info" size={ 18 } />
 			</div>
-			<div className="packages-list-empty-description">Your packages will display here once they are added.</div>
+			<div className="packages-list-empty-description">{ __( 'Your packages will display here once they are added.' ) }</div>
 		</div>
 	);
 };
@@ -51,9 +52,9 @@ const PackagesList = ( {
 	return (
 		<FormFieldset className="wcc-shipping-packages-list">
 			<div className="wcc-shipping-packages-list-header">
-				<FormLegend className="package-type">Type</FormLegend>
-				<FormLegend className="package-name">Name</FormLegend>
-				<FormLegend className="package-dimensions">Dimensions (L x W x H)</FormLegend>
+				<FormLegend className="package-type">{ __( 'Type' ) }</FormLegend>
+				<FormLegend className="package-name">{ __( 'Name' ) }</FormLegend>
+				<FormLegend className="package-dimensions">{ __( 'Dimensions (L x W x H)' ) }</FormLegend>
 			</div>
 			{ 0 === packages.length
 				? noPackages()


### PR DESCRIPTION
Fixes #492 

I ran this regex: `^.+>[^><_=\{\}]+<.+$` in the client folder to find other potential offenders