### PR TITLE
Fixed the i18n task

### DIFF
--- a/tasks/i18n.js
+++ b/tasks/i18n.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-'use strict';
+'use strict'; /* eslint strict: 0 */
 
 /**
  * Module dependencies/
@@ -60,11 +60,7 @@ function buildWordPressString( properties ) {
  */
 function buildPhpOutput( data, arrayName ) {
 	// find matching instances of `translate()` and generate corresponding php output
-	let matches = parser.getMatches( data );
-
-	matches = uniq( matches.map( function( match ) {
-		return match.string;
-	} ) );
+	const matches = uniq( parser.getMatches( data ).map( ( match ) => match.string ) );
 
 	// prepend the matches array with this content to open the php file
 	matches.unshift( [

--- a/tasks/i18n.js
+++ b/tasks/i18n.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
+'use strict';
 
 /**
  * Module dependencies/
  */
 const fs = require( 'fs' ),
 	Xgettext = require( 'xgettext-js' ),
-	preProcessXGettextJSMatch = require( '../node_modules/wp-calypso/server/i18n/preprocess-xgettextjs-match.js' ),
+	preProcessXGettextJSMatch = require( 'i18n-calypso/cli/preprocess-xgettextjs-match.js' ),
 	uniq = require( 'lodash/uniq' );
 
 // parser object that buids a WordPress php string for every

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -1,4 +1,5 @@
-/*eslint no-process-exit: 0, no-undef: 0 */
+/*eslint no-process-exit: 0, no-undef: 0, strict: 0 */
+'use strict';
 require( 'shelljs/global' );
 const colors = require( 'colors' );
 const confirm = require( 'confirm-simple' );


### PR DESCRIPTION
Small fix. With the change on Calypso i18n structure (extracting it to a new module) the i18n task stopped working. This change fixes that.

To test, just run `npm run i18n` and check that it doesn't :boom: and it generates a valid `i18n/strings.php` file.

@robobot3000 @allendav @nabsul 