### PR TITLE
Package Settings - Assuming empty string if the value is undefined

### DIFF
--- a/client/settings/views/packages/add-package.js
+++ b/client/settings/views/packages/add-package.js
@@ -121,7 +121,7 @@ const AddPackageDialog = ( props ) => {
 					id="name"
 					name="name"
 					placeholder={ __( 'The customer will see this during checkout' ) }
-					value={ name }
+					value={ name || '' }
 					onChange={ updateTextField }
 					isError={ modalErrors.name }
 				/>
@@ -132,7 +132,7 @@ const AddPackageDialog = ( props ) => {
 				<FormTextInput
 					name="inner_dimensions"
 					placeholder={ exampleDimensions }
-					value={ inner_dimensions }
+					value={ inner_dimensions || '' }
 					className={ fieldClassName }
 					onChange={ updateTextField }
 					disabled={ ! is_user_defined }
@@ -147,7 +147,7 @@ const AddPackageDialog = ( props ) => {
 						<FormTextInput
 							name="outer_dimensions"
 							placeholder={ exampleDimensions }
-							value={ outer_dimensions }
+							value={ outer_dimensions || '' }
 							className={ fieldClassName }
 							onChange={ updateTextField }
 							disabled={ ! is_user_defined }
@@ -164,7 +164,7 @@ const AddPackageDialog = ( props ) => {
 						id="box_weight"
 						name="box_weight"
 						placeholder={ __( 'Weight of box' ) }
-						value={ box_weight }
+						value={ box_weight || '' }
 						className={ fieldClassName }
 						onChange={ updateTextField }
 						disabled={ ! is_user_defined }
@@ -178,7 +178,7 @@ const AddPackageDialog = ( props ) => {
 						id="max_weight"
 						name="max_weight"
 						placeholder={ __( 'Max weight' ) }
-						value={ max_weight }
+						value={ max_weight || '' }
 						className={ fieldClassName }
 						onChange={ updateTextField }
 						disabled={ ! is_user_defined }


### PR DESCRIPTION
Fixes #484 

It's a bit of a tricky one and depends on the React/Redux practices. The React warning was caused by setting the `value` field to `undefined` on the form elements and then allowing the user to edit them. Now the setting to undefined/null happens all across the code in places such as reducer or preset packages. Rather than initialize default values there and set, for example, box weight to an empty string on the model, I assumed it's better to do it in the rendering step.

I'm happy to change it if necessary.