### PR TITLE
Display the "Create Label" meta-box only for qualifying orders

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -132,6 +132,42 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return $result;
 		}
 
+		public function should_show_meta_box() {
+			global $post, $theorder;
+
+			if ( ! is_object( $post ) ) {
+				return FALSE;
+			}
+
+			if ( ! is_object( $theorder ) ) {
+				$theorder = wc_get_order( $post->ID );
+			}
+
+			if ( ! $theorder ) {
+				return FALSE;
+			}
+
+			// TODO: return TRUE if the order has already label meta-data
+
+			$base_location = wc_get_base_location();
+			if ( 'US' !== $base_location[ 'country' ] ) {
+				return FALSE;
+			}
+
+			$dest_address = $theorder->get_address( 'shipping' );
+			if ( $dest_address[ 'country' ] && 'US' !== $dest_address[ 'country' ] ) {
+				return FALSE;
+			}
+
+			foreach( $theorder->get_items() as $item ) {
+				$product = $theorder->get_product_from_item( $item );
+				if ( $product && $product->needs_shipping() ) {
+					return TRUE;
+				}
+			}
+			return FALSE;
+		}
+
 		public function meta_box( $post ) {
 			global $theorder;
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -133,47 +133,35 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		public function should_show_meta_box() {
-			global $post, $theorder;
+			$order = wc_get_order();
 
-			if ( ! is_object( $post ) ) {
-				return FALSE;
+			if ( ! $order ) {
+				return false;
 			}
 
-			if ( ! is_object( $theorder ) ) {
-				$theorder = wc_get_order( $post->ID );
-			}
-
-			if ( ! $theorder ) {
-				return FALSE;
-			}
-
-			// TODO: return TRUE if the order has already label meta-data
+			// TODO: return true if the order has already label meta-data
 
 			$base_location = wc_get_base_location();
 			if ( 'US' !== $base_location[ 'country' ] ) {
-				return FALSE;
+				return false;
 			}
 
-			$dest_address = $theorder->get_address( 'shipping' );
+			$dest_address = $order->get_address( 'shipping' );
 			if ( $dest_address[ 'country' ] && 'US' !== $dest_address[ 'country' ] ) {
-				return FALSE;
+				return false;
 			}
 
-			foreach( $theorder->get_items() as $item ) {
-				$product = $theorder->get_product_from_item( $item );
+			foreach( $order->get_items() as $item ) {
+				$product = $order->get_product_from_item( $item );
 				if ( $product && $product->needs_shipping() ) {
-					return TRUE;
+					return true;
 				}
 			}
-			return FALSE;
+			return false;
 		}
 
 		public function meta_box( $post ) {
-			global $theorder;
-
-			if ( ! is_object( $theorder ) ) {
-				$theorder = wc_get_order( $post->ID );
-			}
+			$order = wc_get_order( $post );
 
 			$debug_page_uri = esc_url( add_query_arg(
 				array(
@@ -188,7 +176,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$root_view = 'wc-connect-create-shipping-label';
 			$admin_array = array(
 				'storeOptions' => $store_options,
-				'formData'     => $this->get_form_data( $theorder ),
+				'formData'     => $this->get_form_data( $order ),
 				'callbackURL'  => get_rest_url( null, '/wc/v1/connect/shipping-label' ),
 				'nonce'        => wp_create_nonce( 'wp_rest' ),
 				'submitMethod' => 'POST',

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -262,12 +262,12 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				add_action( 'woocommerce_shipping_zone_method_added', array( $this, 'shipping_zone_method_added' ), 10, 3 );
 				add_action( 'woocommerce_shipping_zone_method_deleted', array( $this, 'shipping_zone_method_deleted' ), 10, 3 );
 				add_action( 'woocommerce_shipping_zone_method_status_toggled', array( $this, 'shipping_zone_method_status_toggled' ), 10, 4 );
-				add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 40 );
 			}
 
 			add_action( 'woocommerce_settings_saved', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_action( 'wc_connect_fetch_service_schemas', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_filter( 'woocommerce_hidden_order_itemmeta', array( $this, 'hide_wcc_meta_data' ) );
+			add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 40 );
 
 		}
 
@@ -501,8 +501,8 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function add_meta_boxes() {
 			$shipping_label = new WC_Connect_Shipping_Label( $this->service_settings_store );
-			foreach ( wc_get_order_types( 'order-meta-boxes' ) as $type ) {
-				add_meta_box( 'woocommerce-order-label', __( 'Shipping Label', 'woocommerce' ), array( $shipping_label, 'meta_box' ), $type, 'side', 'default' );
+			if ( $shipping_label->should_show_meta_box() ) {
+				add_meta_box( 'woocommerce-order-label', __( 'Shipping Label', 'woocommerce' ), array( $shipping_label, 'meta_box' ), null, 'side', 'default' );
 			}
 		}
 


### PR DESCRIPTION
Fixes #432

Hide the "Create Label" meta-box if we can't create a label for that order. The conditions are:
* The origin address (the WooCommerce "Base Location") must be in the US.
* The order shipping address must be in the US too.
* The order must contain at least one shippable product (if all the products are virtual/downloadable, a shipping label makes no sense).

To test, just create a bunch of orders and see if the "Create Label" meta-box is displayed. I've tried with an order with only downloadable products, an order for the UK, changing the WooCommerce Base Location to the UK, and in all those scenarios the meta-box must **not** appear.

@robobot3000 @allendav @nabsul @jeffstieler 