### PR TITLE
Add REST controller for retrieving shipping rates from Connect.

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -72,7 +72,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
-		 * Gets the shipping rates from the WooCommerce Connect Server
+		 * Gets shipping rates (for checkout) from the WooCommerce Connect Server
 		 *
 		 * @param $services All settings for all services we want rates for
 		 * @param $package Package provided to WC_Shipping_Method::calculate_shipping()
@@ -144,6 +144,49 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 */
 		public function get_payment_methods() {
 			return $this->request( 'POST', '/payment/methods' );
+		}
+
+		/**
+		 * Gets shipping rates (for labels) from the WooCommerce Connect Server
+		 *
+		 * @param array $request - array(
+		 *	'packages' => array(
+		 *		array(
+		 * 			'id' => 'box_1',
+		 *			'height' => 10,
+		 *			'length' => 10,
+		 *			'width' => 10,
+		 *			'weight' => 10,
+		 *		),
+		 *		array(
+		 *			'id' => 'box_2',
+		 *			'template' => 'medium_flat_box_top',
+		 *			'weight' => 5,
+		 *		),
+		 *		...
+		 * 	),
+		 *	'carrier' => 'usps',
+		 *	'origin' => array(
+		 *		'address' => '132 Hawthorne St',
+		 *		'address_2' => '',
+		 *		'city' => 'San Francisco',
+		 *		'state' => 'CA',
+		 *		'postcode' => '94107',
+		 *		'country' => 'US',
+		 *	),
+		 *	'destination' => array(
+		 *		'address' => '1550 Snow Creek Dr',
+		 *		'address_2' => '',
+		 *		'city' => 'Park City',
+		 *		'state' => 'UT',
+		 *		'postcode' => '84060',
+		 *		'country' => 'US',
+		 *	),
+		 * )
+		 * @return object|WP_Error
+		 */
+		public function get_label_rates( $request ) {
+			return $this->request( 'POST', '/shipping/label/rates', $request );
 		}
 
 		/**

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -277,18 +277,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 				foreach ( (array) $instance->rates as $rate_idx => $rate ) {
 					$rate_to_add = array(
-						'id'       => sprintf( '%s:%d:%d', $instance->id, $instance->instance, $rate_idx ),
-						'label'    => wp_kses(
-							html_entity_decode( $rate->title ),
-							array(
-								'sup' => array(),
-								'del' => array(),
-								'small' => array(),
-								'em' => array(),
-								'i' => array(),
-								'strong' => array(),
-							)
-						),
+						'id'       => self::format_rate_id( $instance->id, $instance->instance, $rate_idx ),
+						'label'    => self::format_rate_title( $rate->title ),
 						'cost'     => $rate->rate,
 						'calc_tax' => 'per_item',
 						'meta_data' => array( 'wc_connect_packages' => json_encode( $rate->packages ) ),
@@ -345,6 +335,26 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 					</span>
 				</div>
 			<?php
+		}
+
+		public static function format_rate_id( $method_id, $instance, $rate_idx ) {
+			return sprintf( '%s:%d:%d', $method_id, $instance, $rate_idx );
+		}
+
+		public static function format_rate_title( $rate_title ) {
+			$formatted_title = wp_kses(
+				html_entity_decode( $rate_title ),
+				array(
+					'sup' => array(),
+					'del' => array(),
+					'small' => array(),
+					'em' => array(),
+					'i' => array(),
+					'strong' => array(),
+				)
+			);
+
+			return $formatted_title;
 		}
 
 	}

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -1,0 +1,126 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( class_exists( 'WC_REST_Connect_Shipping_Rates_Controller' ) ) {
+	return;
+}
+
+class WC_REST_Connect_Shipping_Rates_Controller extends WP_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'connect/shipping-rates';
+
+	/**
+	 * @var WC_Connect_API_Client
+	 */
+	protected $api_client;
+
+	/**
+	 * @var WC_Connect_Service_Settings_Store
+	 */
+	protected $settings_store;
+
+	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store ) {
+		$this->api_client = $api_client;
+		$this->settings_store = $settings_store;
+	}
+
+	/**
+	 * Register the routes for shipping labels printing.
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'update_items' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+			),
+		) );
+	}
+
+	/**
+	 * Expected in request body:
+	 * array(
+	 *	'instance' => 30,
+	 *	'contents' => array(
+	 *		array(
+	 * 			'data' => array(
+	 *				'id' => 1,
+	 *				'variation_id' => 2,
+	 *			),
+	 *			'quantity' => 1,
+	 *		),
+	 * 	),
+	 *	'destination' => array(
+	 *		'address' => '1550 Snow Creek Dr',
+	 *		'address_2' => '',
+	 *		'city' => 'Park City',
+	 *		'state' => 'UT',
+	 *		'postcode' => '84060',
+	 *		'country' => 'US',
+	 *	),
+	 * )
+	 *
+	 * @param WP_REST_Request $request
+	 * @return array
+	 */
+	public function update_items( $request ) {
+		$request_body = $request->get_body();
+		$settings     = json_decode( $request_body, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
+
+		// Get shipping method instance id
+		$instance_id  = absint( $settings[ 'instance' ] );
+
+		// WC_Shipping_Method::calculate_rates() expects 'data' to be an object
+		foreach ( $settings[ 'contents' ] as $i => $content ) {
+			$settings[ 'contents' ][ $i ][ 'data' ] = (object) $settings[ 'contents' ][ $i ][ 'data' ];
+		}
+
+		// Instantiate Connect Shipping Method and get rates
+		$connect_shipping_method = new WC_Connect_Shipping_Method( $instance_id );
+		$rates = $connect_shipping_method->get_rates_for_package( $settings );
+
+		$processed_rates = array();
+
+		// Add `service_id` to rates for selection purposes
+		foreach ( $rates as $rate ) {
+			$rate_meta = $rate->get_meta_data();
+			$rate_packages = json_decode( $rate_meta[ 'wc_connect_packages' ], true );
+
+			$processed_rates[] = array(
+				'id'         => $rate->id,
+				'label'      => $rate->label,
+				'cost'       => $rate->cost,
+				'method_id'  => $rate->method_id,
+				'service_id' => $rate_packages[ 0 ][ 'service_id' ],
+			);
+		}
+
+		return array(
+			'success' => true,
+			'rates'   => $processed_rates,
+		);
+	}
+
+	/**
+	 * Validate the requester's permissions
+	 */
+	public function update_items_permissions_check( $request ) {
+		return current_user_can( 'manage_woocommerce' );
+	}
+
+}

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -63,6 +63,10 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WP_REST_Controller {
 
 		$response = $this->api_client->get_label_rates( $payload );
 
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
 		return array(
 			'success' => true,
 			'rates'   => $response,

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -113,26 +113,18 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WP_REST_Controller {
 		$processed_rates = array();
 
 		// Add `service_id` to rates for selection purposes
-		// TODO: refactor this, it's copy-pasta from WC_Connect_Shipping_Method::calculate_shipping()
 		foreach ( (array) $response->rates as $instance ) {
 			if ( ! property_exists( $instance, 'rates' ) ) {
 				continue;
 			}
 
 			foreach ( (array) $instance->rates as $rate_idx => $rate ) {
+				$rate_id    = WC_Connect_Shipping_Method::format_rate_id( $instance->id, $instance->instance, $rate_idx );
+				$rate_label = WC_Connect_Shipping_Method::format_rate_title( $rate->title );
+
 				$processed_rates[] = array(
-					'id'         => sprintf( '%s:%d:%d', $instance->id, $instance->instance, $rate_idx ),
-					'label'      => wp_kses(
-						html_entity_decode( $rate->title ),
-						array(
-							'sup' => array(),
-							'del' => array(),
-							'small' => array(),
-							'em' => array(),
-							'i' => array(),
-							'strong' => array(),
-						)
-					),
+					'id'         => $rate_id,
+					'label'      => $rate_label,
 					'cost'       => $rate->rate,
 					'method_id'  => 'usps',
 					'service_id' => $rate->packages[ 0 ]->service_id,

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -83,6 +83,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		protected $rest_shipping_label_controller;
 
 		/**
+		 * @var WC_REST_Connect_Shipping_Rates_Controller
+		 */
+		protected $rest_shipping_rates_controller;
+
+		/**
 		 * @var WC_Connect_Service_Schemas_Validator
 		 */
 		protected $service_schemas_validator;
@@ -202,6 +207,10 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 		public function set_rest_shipping_label_controller( WC_REST_Connect_Shipping_Label_Controller $rest_shipping_label_controller ) {
 			$this->rest_shipping_label_controller = $rest_shipping_label_controller;
+		}
+
+		public function set_rest_shipping_rates_controller( WC_REST_Connect_Shipping_Rates_Controller $rest_shipping_rates_controller ) {
+			$this->rest_shipping_rates_controller = $rest_shipping_rates_controller;
 		}
 
 		public function get_service_schemas_validator() {
@@ -358,6 +367,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_shipping_label_controller = new WC_REST_Connect_Shipping_Label_Controller( $this->api_client, $settings_store );
 			$this->set_rest_shipping_label_controller( $rest_shipping_label_controller );
 			$rest_shipping_label_controller->register_routes();
+
+			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-rates-controller.php' ) );
+			$rest_shipping_rates_controller = new WC_REST_Connect_Shipping_Rates_Controller( $this->api_client, $settings_store );
+			$this->set_rest_shipping_rates_controller( $rest_shipping_rates_controller );
+			$rest_shipping_rates_controller->register_routes();
 		}
 
 		/**


### PR DESCRIPTION
Fixes #513.

To test:
* Use a REST client to make a `POST` request to `/wc-api/v1/connect/shipping-rates`
* Sample data below

```javascript
{
    "origin": {
        "address": "2100 Park Ave",
        "address_2": "Unit 684212",
        "country": "US",
        "city": "Park City",
        "postcode": "84068",
        "state": "UT"
    },
    "destination": {
        "address": "1003 1st St",
        "address_2": "",
        "country": "US",
        "city": "Snohomish",
        "postcode": "98290",
        "state": "WA"
    },
    "carrier": "usps",
    "packages": [
        {
            "id": "box_1",
            "template": "medium_flat_box_top",
            "weight": 5
        },
        {
            "id": "box_2",
            "weight": 3,
            "length": 10,
            "width": 10,
            "height": 10
        }
    ]
}
```