### PR TITLE
Changed source maps method and added console logging to the JS unit tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,6 +10,9 @@ module.exports = function( config ) {
 		preprocessors: {
 			'client/**/test/*.js': [ 'webpack', 'sourcemap' ]
 		},
+		client: {
+			captureConsole: true
+		},
 		reporters: [ 'mocha', 'coverage' ],
 		coverageReporter: {
 			dir: 'coverage/',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
 		filename: '[name].js',
 		publicPath: 'http://localhost:8085/',
 	},
-	devtool: '#eval-source-map',
+	devtool: '#inline-source-map',
 	module: {
 		loaders: [
 			{


### PR DESCRIPTION
Fixes #518 and #517 

To check if it works:
Webpack source maps change:
* Add a breakpoint to mapped JS source in a browser
* Verify that it is being hit

Console logging
* add `console.log` or any other console statement to a unit test
* run `npm-test` from terminal
* verify that the message has been logged to the terminal