### PR TITLE
Use the real selected payment method ID in the Purchase Label request

### DIFF
--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -66,7 +66,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WP_REST_Controller {
 				),
 				array_merge(
 					array( 'status' => 400 ),
-					$validation_result->get_error_data()
+					$result->get_error_data()
 				)
 			);
 		}

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -70,6 +70,8 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 	public function update_items( $request ) {
 		$request_body = $request->get_body();
 		$settings = json_decode( $request_body, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
+		$settings[ 'payment_method_id' ] = $this->settings_store->get_selected_payment_method_id();
+		$settings[ 'carrier' ] = 'usps';
 
 		$response = $this->api_client->send_shipping_label_request( $settings );
 

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -74,8 +74,6 @@ export const purchaseLabel = () => ( dispatch, getState, { callbackURL, nonce, s
 	const formData = {
 		origin: form.origin.values,
 		destination: form.destination.values,
-		payment_method_id: '123456789',
-		carrier: 'usps',
 		packages: form.packages.values.map( ( pckg, index ) => ( {
 			...omit( pckg, [ 'items', 'id' ] ),
 			service_id: form.rates.values[ index ],


### PR DESCRIPTION
Fixes #504

Use the real selected payment method ID in the Purchase Label request, instead of a hardcoded one.

There's no real way to test it, since the Purchase Label request doesn't actually work.

@nabsul @jeffstieler @robobot3000 @allendav 