### PR TITLE
Fixed rendering of the service settings pages

### DIFF
--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -382,13 +382,13 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$path = $instance ? "/wc/v1/connect/services/{$id}/{$instance}" : "/wc/v1/connect/services/{$id}";
 
 			$admin_array = array(
-				'storeOptions' => $settings_store->get_shared_settings(),
+				'storeOptions' => $settings_store->get_store_options(),
 				'formSchema'   => $service_schema->service_settings,
 				'formLayout'   => $service_schema->form_layout,
 				'formData'     => $settings_store->get_service_settings( $id, $instance ),
 				'callbackURL'  => get_rest_url( null, $path ),
 				'nonce'        => wp_create_nonce( 'wp_rest' ),
-				'rootView'     => 'wc-connect-settings',
+				'rootView'     => 'wc-connect-service-settings',
 			);
 
 			wp_localize_script( 'wc_connect_admin', 'wcConnectData', $admin_array );


### PR DESCRIPTION
Fixes #526 

Updated a changed function name and `rootView` in `woocommerce-connect-client.php` when rendering the service settings pages.

To verify:
* check that the service settings page renders correctly