### PR TITLE
Fixed payment settings reload dialog

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -33,7 +33,9 @@ const store = createStore(
 );
 
 window.addEventListener( 'beforeunload', ( event ) => {
-	if ( ! store.getState().form || store.getState().form.pristine ) {
+	const state = store.getState();
+
+	if ( ! state.form || state.form.pristine || ( state.form.meta && state.form.meta.pristine ) ) {
 		return;
 	}
 	const text = __( 'You have unsaved changes.' );


### PR DESCRIPTION
This fixes an issue where trying to reload and navigate away from the payment settings page produces an "are you sure" dialog regardless of whether any changes have been made or not.