### PR TITLE
Added an error to the "address" field if USPS couldn't validate an address

### DIFF
--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -121,7 +121,7 @@
 			}
 
 			.highlight {
-				background-color: $blue-light;
+				background-color: lighten( $blue-light, 15 );
 			}
 		}
 

--- a/client/shipping-label/state/selectors/errors.js
+++ b/client/shipping-label/state/selectors/errors.js
@@ -7,7 +7,7 @@ const getAddressErrors = ( { values, isNormalized, normalized, selectNormalized 
 		// If the address is normalized but the server didn't return a normalized address, then it's
 		// invalid and must register as an error
 		return {
-			address: __( 'This address was not recognized' ),
+			address: __( 'This address is not recognized. Please try another.' ),
 		};
 	}
 	const { postcode, state, country } = ( isNormalized && selectNormalized ) ? normalized : values;

--- a/client/shipping-label/state/selectors/errors.js
+++ b/client/shipping-label/state/selectors/errors.js
@@ -5,8 +5,10 @@ import isEmpty from 'lodash/isEmpty';
 const getAddressErrors = ( { values, isNormalized, normalized, selectNormalized }, countriesData ) => {
 	if ( isNormalized && ! normalized ) {
 		// If the address is normalized but the server didn't return a normalized address, then it's
-		// invalid and must register as an error, but no concrete field is erroneous, so return a truthy value
-		return true;
+		// invalid and must register as an error
+		return {
+			address: __( 'This address was not recognized' ),
+		};
 	}
 	const { postcode, state, country } = ( isNormalized && selectNormalized ) ? normalized : values;
 	const requiredFields = [ 'name', 'address', 'city', 'postcode', 'country' ];


### PR DESCRIPTION
Fixes #530

To test, just input an address with all the required fields, but a totally fake street name.

After you try to validate the address, the step should be marked as "Error", and the `Address` field should have an error that says "This address was not recognized".

@kellychoffman @allendav @nabsul @jeffstieler 