### PR TITLE
Fix shipping rates without package data

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -170,7 +170,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$form_data = compact( 'is_packed', 'packages', 'origin', 'destination' );
 
 			$form_data[ 'rates' ] = array(
-				'selected'  => $selected_rates,
+				'selected'  => (object) $selected_rates,
 			);
 
 			$form_data[ 'order_id' ] = $order->id;

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -39,7 +39,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				$name = html_entity_decode( $product->get_formatted_name() );
 
 				for ( $i = 0; $i < $item[ 'qty' ]; $i++ ) {
-					$packages[] = array(
+					$packages[ "weight_{$i}_individual" ] = array(
 						'height' => ( float ) $height,
 						'length' => ( float ) $length,
 						'weight' => ( float ) $weight,
@@ -86,19 +86,19 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return $this->get_items_as_individual_packages( $order );
 			}
 
-			foreach( $packages as $package_index => $package ) {
+			foreach( $packages as $package_id => $package ) {
 				foreach( $package[ 'items' ] as $item_index => $item ) {
 					$product = $order->get_product_from_item( $item );
 					if ( ! $product ) {
 						continue;
 					}
-					$product_data = $packages[ $package_index ][ 'items' ][ $item_index ];
+					$product_data = $packages[ $package_id ][ 'items' ][ $item_index ];
 					$product_data[ 'name' ] = $this->get_name( $product );
 					$product_data[ 'url' ] = admin_url( 'post.php?post=' . $product->id . '&action=edit' );
 					if ( isset( $product->variation_id ) ) {
 						$product_data[ 'attributes' ] = $product->get_formatted_variation_attributes( true );
 					}
-					$packages[ $package_index ][ 'items' ][ $item_index ] = $product_data;
+					$packages[ $package_id ][ 'items' ][ $item_index ] = $product_data;
 				}
 			}
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -86,23 +86,28 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				return $this->get_items_as_individual_packages( $order );
 			}
 
-			foreach( $packages as $package_id => $package ) {
+			$formatted_packages = array();
+
+			foreach( $packages as $package ) {
+				$package_id = $package[ 'id' ];
+				$formatted_packages[ $package_id ] = $package;
+
 				foreach( $package[ 'items' ] as $item_index => $item ) {
 					$product = $order->get_product_from_item( $item );
 					if ( ! $product ) {
 						continue;
 					}
-					$product_data = $packages[ $package_id ][ 'items' ][ $item_index ];
+					$product_data = $package[ 'items' ][ $item_index ];
 					$product_data[ 'name' ] = $this->get_name( $product );
 					$product_data[ 'url' ] = admin_url( 'post.php?post=' . $product->id . '&action=edit' );
 					if ( isset( $product->variation_id ) ) {
 						$product_data[ 'attributes' ] = $product->get_formatted_variation_attributes( true );
 					}
-					$packages[ $package_id ][ 'items' ][ $item_index ] = $product_data;
+					$formatted_packages[ $package_id ][ 'items' ][ $item_index ] = $product_data;
 				}
 			}
 
-			return $packages;
+			return $formatted_packages;
 		}
 
 		protected function get_selected_rates( WC_Order $order ) {

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -65,11 +65,17 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WP_REST_Controller {
 		$payload[ 'carrier' ] = 'usps';
 
 		// Exclude extraneous package fields
-		$whitelist = array_fill_keys( array( 'id', 'length', 'width', 'height', 'weight', 'template' ), true );
+		$whitelist = array_fill_keys( array( 'length', 'width', 'height', 'weight', 'template' ), true );
+		$formatted_packages = array();
 
-		foreach ( $payload[ 'packages' ] as $idx => $package ) {
-			$payload[ 'packages' ][ $idx ] = array_intersect_key( $package, $whitelist );
+		foreach ( $payload[ 'packages' ] as $package_id => $package ) {
+			$formatted_package = array_intersect_key( $package, $whitelist );
+			$formatted_package[ 'id' ] = $package_id;
+
+			$formatted_packages[] = $formatted_package;
 		}
+
+		$payload[ 'packages' ] = $formatted_packages;
 
 		$response = $this->api_client->get_label_rates( $payload );
 

--- a/client/shipping-label/index.js
+++ b/client/shipping-label/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { combineReducers } from 'redux';
 import ShippingLabelRootView from './views';
 import shippingLabel from './state/reducer';
+import isEmpty from 'lodash/isEmpty';
+import mapValues from 'lodash/mapValues';
 
 // from calypso
 import notices from 'state/notices/reducer';
@@ -48,7 +50,7 @@ export default ( { formData, labelsData, storeOptions, labelPreviewURL } ) => ( 
 						isPacked: formData.is_packed,
 					},
 					rates: {
-						values: formData.rates.selected,
+						values: isEmpty( formData.rates.selected ) ? mapValues( formData.packages, () => ( '' ) ) : formData.rates.selected,
 						available: {},
 						retrievalInProgress: false,
 					},

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -7,6 +7,7 @@ import isEqual from 'lodash/isEqual';
 import some from 'lodash/some';
 import find from 'lodash/find';
 import isEmpty from 'lodash/isEmpty';
+import map from 'lodash/map';
 import printDocument from 'lib/utils/print-document';
 import * as NoticeActions from 'state/notices/actions';
 import getFormErrors from 'shipping-label/state/selectors/errors';
@@ -284,10 +285,10 @@ export const purchaseLabel = () => ( dispatch, getState, { purchaseURL, addressN
 		const formData = {
 			origin: form.origin.selectNormalized ? form.origin.normalized : form.origin.values,
 			destination: form.destination.selectNormalized ? form.destination.normalized : form.destination.values,
-			packages: form.packages.values.map( ( pckg ) => ( {
+			packages: map( form.packages.values, ( pckg, pckgId ) => ( {
 				...omit( pckg, [ 'items', 'id' ] ),
-				service_id: form.rates.values[ pckg.id ],
-				service_name: find( form.rates.available[ pckg.id ].rates, { service_id: form.rates.values[ pckg.id ] } ).title,
+				service_id: form.rates.values[ pckgId ],
+				service_name: find( form.rates.available[ pckgId ].rates, { service_id: form.rates.values[ pckgId ] } ).title,
 				products: flatten( pckg.items.map( ( item ) => fill( new Array( item.quantity ), item.product_id ) ) ),
 			} ) ),
 			order_id: form.orderId,

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -219,10 +219,10 @@ export const submitAddressForNormalization = ( group ) => ( dispatch, getState, 
 		.catch( noop );
 };
 
-export const updatePackageWeight = ( packageIndex, value ) => {
+export const updatePackageWeight = ( packageId, value ) => {
 	return {
 		type: UPDATE_PACKAGE_WEIGHT,
-		packageIndex,
+		packageId,
 		value,
 	};
 };

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -130,11 +130,10 @@ reducers[ CONFIRM_ADDRESS_SUGGESTION ] = ( state, { group } ) => {
 	};
 };
 
-reducers[ UPDATE_PACKAGE_WEIGHT ] = ( state, { packageIndex, value } ) => {
-	const newPackages = [ ...state.form.packages.values ];
-	newPackages[ packageIndex ] = { ...newPackages[ packageIndex ],
-		weight: parseFloat( value ),
-	};
+reducers[ UPDATE_PACKAGE_WEIGHT ] = ( state, { packageId, value } ) => {
+	const newPackages = { ...state.form.packages.values };
+
+	newPackages[ packageId ].weight = parseFloat( value );
 
 	return { ...state,
 		form: { ...state.form,

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -133,7 +133,10 @@ reducers[ CONFIRM_ADDRESS_SUGGESTION ] = ( state, { group } ) => {
 reducers[ UPDATE_PACKAGE_WEIGHT ] = ( state, { packageId, value } ) => {
 	const newPackages = { ...state.form.packages.values };
 
-	newPackages[ packageId ].weight = parseFloat( value );
+	newPackages[ packageId ] = {
+		...newPackages[ packageId ],
+		weight: parseFloat( value ),
+	};
 
 	return { ...state,
 		form: { ...state.form,

--- a/client/shipping-label/state/selectors/errors.js
+++ b/client/shipping-label/state/selectors/errors.js
@@ -35,7 +35,7 @@ const getAddressErrors = ( { values, isNormalized, normalized, selectNormalized 
 	return errors;
 };
 
-const getPackagesErrors = ( values ) => values.map( ( pckg ) => {
+const getPackagesErrors = ( values ) => mapValues( values, ( pckg ) => {
 	const errors = {};
 	if ( ! pckg.weight || 'number' !== typeof pckg.weight || 0 > pckg.weight ) {
 		errors.weight = __( 'Invalid weight' );

--- a/client/shipping-label/views/purchase/steps/packages/index.js
+++ b/client/shipping-label/views/purchase/steps/packages/index.js
@@ -7,15 +7,18 @@ import { sprintf } from 'sprintf-js';
 import StepContainer from '../../step-container';
 
 const PackagesStep = ( { values, storeOptions, labelActions, errors, expanded } ) => {
-	const isValid = 0 < values[ 0 ].weight;
+	const packageIds = Object.keys( values );
+	const firstPackageId = packageIds[ 0 ];
+	const firstPackage = values[ firstPackageId ];
+	const isValid = 0 < firstPackage.weight;
 	const renderSummary = () => {
 		if ( ! isValid ) {
 			return __( 'Weight not entered' );
 		}
 		if ( 1 < values.length ) {
-			return sprintf( __( '%d packages' ), values.length );
+			return sprintf( __( '%d packages' ), packageIds.length );
 		}
-		return values[ 0 ].weight + ' ' + storeOptions.weight_unit;
+		return firstPackage.weight + ' ' + storeOptions.weight_unit;
 	};
 
 	return (
@@ -47,10 +50,10 @@ const PackagesStep = ( { values, storeOptions, labelActions, errors, expanded } 
 };
 
 PackagesStep.propTypes = {
-	values: PropTypes.array.isRequired,
+	values: PropTypes.object.isRequired,
 	labelActions: PropTypes.object.isRequired,
 	storeOptions: PropTypes.object.isRequired,
-	errors: PropTypes.array.isRequired,
+	errors: PropTypes.object.isRequired,
 };
 
 export default PackagesStep;

--- a/client/shipping-label/views/purchase/steps/packages/list.js
+++ b/client/shipping-label/views/purchase/steps/packages/list.js
@@ -3,6 +3,7 @@ import { translate as __ } from 'lib/mixins/i18n';
 import NumberField from 'components/number-field';
 import FormLegend from 'components/forms/form-legend';
 import { sprintf } from 'sprintf-js';
+import mapValues from 'lodash/mapValues';
 
 const renderPackageDimensions = ( pckg, dimensionUnit ) => {
 	return `${pckg.length} ${dimensionUnit} x ${pckg.width} ${dimensionUnit} x ${pckg.height} ${dimensionUnit}`;
@@ -23,12 +24,15 @@ const OrderPackages = ( { packages, updateWeight, dimensionUnit, weightUnit, err
 		);
 	};
 
-	const renderPackageInfo = ( pckg, pckgIndex ) => {
-		const pckgErrors = errors[ pckgIndex ] || {};
+	const numPackages = Object.keys( packages ).length;
+	let pckgIndex = 1;
+
+	const renderPackageInfo = ( pckg, pckgId ) => {
+		const pckgErrors = errors[ pckgId ] || {};
 		return (
-			<div key={ pckgIndex }>
+			<div key={ pckgId }>
 				<div className="wcc-package-package-number">
-					{ sprintf( __( 'Package %d (of %d)' ), pckgIndex + 1, packages.length ) }
+					{ sprintf( __( 'Package %d (of %d)' ), pckgIndex++, numPackages ) }
 				</div>
 
 				<div>
@@ -44,7 +48,7 @@ const OrderPackages = ( { packages, updateWeight, dimensionUnit, weightUnit, err
 					className="wcc-package-weight"
 					title={ __( 'Total Weight' ) }
 					value={ pckg.weight }
-					updateValue={ ( value ) => updateWeight( pckgIndex, value ) }
+					updateValue={ ( value ) => updateWeight( pckgId, value ) }
 					error={ pckgErrors.weight } />
 				<span className="wcc-package-weight-unit">{ weightUnit }</span>
 
@@ -58,17 +62,17 @@ const OrderPackages = ( { packages, updateWeight, dimensionUnit, weightUnit, err
 
 	return (
 		<div>
-			{ packages.map( renderPackageInfo ) }
+			{ Object.values( mapValues( packages, renderPackageInfo ) ) }
 		</div>
 	);
 };
 
 OrderPackages.propTypes = {
-	packages: PropTypes.array.isRequired,
+	packages: PropTypes.object.isRequired,
 	updateWeight: PropTypes.func.isRequired,
 	dimensionUnit: PropTypes.string.isRequired,
 	weightUnit: PropTypes.string.isRequired,
-	errors: PropTypes.array.isRequired,
+	errors: PropTypes.object.isRequired,
 };
 
 export default OrderPackages;

--- a/client/shipping-label/views/purchase/steps/rates/list.js
+++ b/client/shipping-label/views/purchase/steps/rates/list.js
@@ -4,6 +4,7 @@ import Notice from 'components/notice';
 import { translate as __ } from 'lib/mixins/i18n';
 import { sprintf } from 'sprintf-js';
 import get from 'lodash/get';
+import mapValues from 'lodash/mapValues';
 
 const renderRateNotice = ( show ) => {
 	if ( show ) {
@@ -28,16 +29,18 @@ const ShippingRates = ( {
 		errors,
 		showRateNotice,
 	} ) => {
-	const renderTitle = ( pckg, idx ) => {
-		if ( 1 === packages.length ) {
+	const renderTitle = ( pckg, index ) => {
+		if ( 1 === Object.keys( packages ).length ) {
 			return __( 'Choose rate' );
 		}
-		return sprintf( __( 'Choose rate: Package %(index)d' ), { index: idx + 1 } );
+		return sprintf( __( 'Choose rate: Package %(index)d' ), { index } );
 	};
 
-	const renderSinglePackage = ( pckg, index ) => {
-		const selectedRate = selectedRates[ pckg.id ] || '';
-		const packageRates = get( availableRates, [ pckg.id, 'rates' ], [] );
+	let packageNum = 1;
+
+	const renderSinglePackage = ( pckg, pckgId ) => {
+		const selectedRate = selectedRates[ pckgId ] || '';
+		const packageRates = get( availableRates, [ pckgId, 'rates' ], [] );
 		const valuesMap = { '': __( 'Select one...' ) };
 
 		packageRates.forEach( ( rateObject ) => {
@@ -45,14 +48,14 @@ const ShippingRates = ( {
 		} );
 
 		return (
-			<div key={ index }>
+			<div key={ packageNum }>
 				<Dropdown
-					id={ id + '_' + index }
+					id={ id + '_' + packageNum }
 					valuesMap={ valuesMap }
-					title={ renderTitle( pckg, index ) }
+					title={ renderTitle( pckg, packageNum++ ) }
 					value={ selectedRate }
-					updateValue={ ( value ) => updateRate( pckg.id, value ) }
-					error={ errors[ pckg.id ] } />
+					updateValue={ ( value ) => updateRate( pckgId, value ) }
+					error={ errors[ pckgId ] } />
 			</div>
 		);
 	};
@@ -60,7 +63,7 @@ const ShippingRates = ( {
 	return (
 		<div>
 			{ renderRateNotice( showRateNotice ) }
-			{ packages.map( renderSinglePackage ) }
+			{ Object.values( mapValues( packages, renderSinglePackage ) ) }
 		</div>
 	);
 };
@@ -69,7 +72,7 @@ ShippingRates.propTypes = {
 	id: PropTypes.string.isRequired,
 	selectedRates: PropTypes.object.isRequired,
 	availableRates: PropTypes.object.isRequired,
-	packages: PropTypes.array.isRequired,
+	packages: PropTypes.object.isRequired,
 	updateRate: PropTypes.func.isRequired,
 	dimensionUnit: PropTypes.string.isRequired,
 	weightUnit: PropTypes.string.isRequired,


### PR DESCRIPTION
This fixes an issue @kellychoffman had today testing the labels flow using a manually created order.

It also addresses the use case where an order does *not* have a rate from WCC during checkout.

To test:
* Ensure that the label flow works for orders made from the storefront
* Create a new order from the admin (or use one already existing)
* Ensure that the label flow still works for that "manual" order