### PR TITLE
Packages - fixed the outer dimensions field remaining open after dismissing the modal

### DIFF
--- a/client/packages/state/reducer.js
+++ b/client/packages/state/reducer.js
@@ -49,6 +49,7 @@ reducers[ DISMISS_MODAL ] = ( state ) => {
 	return Object.assign( {}, state, {
 		modalErrors: {},
 		showModal: false,
+		showOuterDimensions: false,
 	} );
 };
 

--- a/client/packages/state/test/reducer.js
+++ b/client/packages/state/test/reducer.js
@@ -102,6 +102,7 @@ describe( 'Packages form reducer', () => {
 		expect( state ).to.eql( {
 			modalErrors: {},
 			showModal: false,
+			showOuterDimensions: false,
 		} );
 	} );
 


### PR DESCRIPTION
During the Connectathon someone found this bug on the packages settings page:

- open the package dialog (either for edit or add new)
- show the outer dimensions field
- close the dialog by clicking the cancel button
- reopen the dialog as described in 1.
- the outer dimensions field will remain open, and there is no way to hide it

This PR fixes it.