### PR TITLE
Remove .catch(noop) to make errors in Promises be logged in the console

### DIFF
--- a/classes/class-wc-rest-connect-account-settings-controller.php
+++ b/classes/class-wc-rest-connect-account-settings-controller.php
@@ -34,9 +34,15 @@ class WC_REST_Connect_Account_Settings_Controller extends WP_REST_Controller {
 	 */
 	protected $settings_store;
 
-	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store ) {
+	/**
+	 * @var WC_Connect_Logger
+	 */
+	protected $logger;
+
+	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store, WC_Connect_Logger $logger ) {
 		$this->api_client = $api_client;
 		$this->settings_store = $settings_store;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -59,7 +65,7 @@ class WC_REST_Connect_Account_Settings_Controller extends WP_REST_Controller {
 		$result = $this->settings_store->update_account_settings( $settings );
 
 		if ( is_wp_error( $result ) ) {
-			return new WP_Error( 'save_failed',
+			$error = new WP_Error( 'save_failed',
 				sprintf(
 					__( 'Unable to update settings. %s', 'woocommerce' ),
 					$result->get_error_message()
@@ -69,6 +75,8 @@ class WC_REST_Connect_Account_Settings_Controller extends WP_REST_Controller {
 					$result->get_error_data()
 				)
 			);
+			$this->logger->log( $error, __CLASS__ );
+			return $error;
 		}
 
 		return new WP_REST_Response( array( 'success' => true ), 200 );

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -65,6 +65,14 @@ class WC_REST_Connect_Address_Normalization_Controller extends WP_REST_Controlle
 		);
 		$response = $this->api_client->send_address_normalization_request( $body );
 
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				$response->get_error_code(),
+				$response->get_error_message(),
+				array( 'message' => $response->get_error_message() )
+			);
+		}
+
 		if ( isset( $response->error ) ) {
 			return new WP_Error(
 				$response->error->code,

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -34,9 +34,15 @@ class WC_REST_Connect_Address_Normalization_Controller extends WP_REST_Controlle
 	 */
 	protected $settings_store;
 
-	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store ) {
+	/**
+	 * @var WC_Connect_Logger
+	 */
+	protected $logger;
+
+	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store, WC_Connect_Logger $logger ) {
 		$this->api_client = $api_client;
 		$this->settings_store = $settings_store;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -66,19 +72,23 @@ class WC_REST_Connect_Address_Normalization_Controller extends WP_REST_Controlle
 		$response = $this->api_client->send_address_normalization_request( $body );
 
 		if ( is_wp_error( $response ) ) {
-			return new WP_Error(
+			$error = new WP_Error(
 				$response->get_error_code(),
 				$response->get_error_message(),
 				array( 'message' => $response->get_error_message() )
 			);
+			$this->logger->log( $error, __CLASS__ );
+			return $error;
 		}
 
 		if ( isset( $response->error ) ) {
-			return new WP_Error(
+			$error = new WP_Error(
 				$response->error->code,
 				$response->error->message,
 				array( 'message' => $response->error->message )
 			);
+			$this->logger->log( $error, __CLASS__ );
+			return $error;
 		}
 
 		$response->normalized->name = $name;

--- a/classes/class-wc-rest-connect-packages-controller.php
+++ b/classes/class-wc-rest-connect-packages-controller.php
@@ -29,8 +29,14 @@ class WC_REST_Connect_Packages_Controller extends WP_REST_Controller {
 	 */
 	protected $service_settings_store;
 
-	public function __construct( WC_Connect_Service_Settings_Store $service_settings_store ) {
+	/**
+	 * @var WC_Connect_Logger
+	 */
+	protected $logger;
+
+	public function __construct( WC_Connect_Service_Settings_Store $service_settings_store, WC_Connect_Logger $logger ) {
 		$this->service_settings_store = $service_settings_store;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -50,7 +56,7 @@ class WC_REST_Connect_Packages_Controller extends WP_REST_Controller {
 		$request_body = $request->get_body();
 		$packages = json_decode( $request_body, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
 
-		$result = $this->service_settings_store->update_packages( $packages );
+		$this->service_settings_store->update_packages( $packages );
 
 		return new WP_REST_Response( array( 'success' => true ), 200 );
 	}

--- a/classes/class-wc-rest-connect-self-help-controller.php
+++ b/classes/class-wc-rest-connect-self-help-controller.php
@@ -57,10 +57,12 @@ class WC_REST_Connect_Self_Help_Controller extends WP_REST_Controller {
 		$settings = json_decode( $request_body, false, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
 
 		if ( empty( $settings ) || ! is_object( $settings ) || ! property_exists( $settings, 'wcc_debug_on' ) ) {
-			return new WP_Error( 'bad_form_data',
+			$error = new WP_Error( 'bad_form_data',
 				__( 'Unable to update settings. The form data could not be read.', 'woocommerce' ),
 				array( 'status' => 400 )
 			);
+			$this->logger->log( $error, __CLASS__ );
+			return $error;
 		}
 
 		error_log( "WCC DEBUG ON = {$settings->wcc_debug_on}" );

--- a/classes/class-wc-rest-connect-shipping-label-image-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-image-controller.php
@@ -29,8 +29,14 @@ class WC_REST_Connect_Shipping_Label_Image_Controller extends WP_REST_Controller
 	 */
 	protected $api_client;
 
-	public function __construct( WC_Connect_API_Client $api_client ) {
+	/**
+	 * @var WC_Connect_Logger
+	 */
+	protected $logger;
+
+	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Logger $logger ) {
 		$this->api_client = $api_client;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -50,6 +56,7 @@ class WC_REST_Connect_Shipping_Label_Image_Controller extends WP_REST_Controller
 		$raw_response = $this->api_client->get_label_image( $request[ 'label_id' ] );
 
 		if ( is_wp_error( $raw_response ) ) {
+			$this->logger->log( $raw_response, __CLASS__ );
 			return $raw_response;
 		}
 

--- a/classes/class-wc-rest-connect-shipping-label-refund-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-refund-controller.php
@@ -34,9 +34,15 @@ class WC_REST_Connect_Shipping_Label_Refund_Controller extends WP_REST_Controlle
 	 */
 	protected $settings_store;
 
-	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store ) {
+	/**
+	 * @var WC_Connect_Logger
+	 */
+	protected $logger;
+
+	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store, WC_Connect_Logger $logger ) {
 		$this->api_client = $api_client;
 		$this->settings_store = $settings_store;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -62,11 +68,13 @@ class WC_REST_Connect_Shipping_Label_Refund_Controller extends WP_REST_Controlle
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return new WP_Error(
+			$error = new WP_Error(
 				$response->get_error_code(),
 				$response->get_error_message(),
 				array( 'message' => $response->get_error_message() )
 			);
+			$this->logger->log( $error, __CLASS__ );
+			return $error;
 		}
 
 		$this->settings_store->update_label_order_meta_data( $request[ 'order_id' ], $response->label );

--- a/classes/class-wc-rest-connect-shipping-label-status-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-status-controller.php
@@ -34,9 +34,15 @@ class WC_REST_Connect_Shipping_Label_Status_Controller extends WP_REST_Controlle
 	 */
 	protected $settings_store;
 
-	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store ) {
+	/**
+	 * @var WC_Connect_Logger
+	 */
+	protected $logger;
+
+	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store, WC_Connect_Logger $logger ) {
 		$this->api_client = $api_client;
 		$this->settings_store = $settings_store;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -56,11 +62,13 @@ class WC_REST_Connect_Shipping_Label_Status_Controller extends WP_REST_Controlle
 		$response = $this->api_client->get_label_status( $request[ 'label_id' ] );
 
 		if ( is_wp_error( $response ) ) {
-			return new WP_Error(
+			$error = new WP_Error(
 				$response->get_error_code(),
 				$response->get_error_message(),
 				array( 'message' => $response->get_error_message() )
 			);
+			$this->logger->log( $error, __CLASS__ );
+			return $error;
 		}
 
 		$this->settings_store->update_label_order_meta_data( $request[ 'order_id' ], $response->label );

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -34,9 +34,15 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WP_REST_Controller {
 	 */
 	protected $settings_store;
 
-	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store ) {
+	/**
+	 * @var WC_Connect_Logger
+	 */
+	protected $logger;
+
+	public function __construct( WC_Connect_API_Client $api_client, WC_Connect_Service_Settings_Store $settings_store, WC_Connect_Logger $logger ) {
 		$this->api_client = $api_client;
 		$this->settings_store = $settings_store;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -55,7 +61,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WP_REST_Controller {
 	/**
 	 *
 	 * @param WP_REST_Request $request - See WC_Connect_API_Client::get_label_rates()
-	 * @return array
+	 * @return array|WP_Error
 	 */
 	public function update_items( $request ) {
 		$request_body = $request->get_body();
@@ -80,7 +86,13 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WP_REST_Controller {
 		$response = $this->api_client->get_label_rates( $payload );
 
 		if ( is_wp_error( $response ) ) {
-			return $response;
+			$error = new WP_Error(
+				$response->get_error_code(),
+				$response->get_error_message(),
+				array( 'message' => $response->get_error_message() )
+			);
+			$this->logger->log( $error, __CLASS__ );
+			return $error;
 		}
 
 		return array(

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -103,8 +103,7 @@ const getLabelRates = ( dispatch, getState, handleResponse, { getRatesURL, nonce
 	} = formState;
 
 	return getRates( dispatch, origin.values, destination.values, packages.values, getRatesURL, nonce )
-		.then( handleResponse )
-		.catch( noop );
+		.then( handleResponse );
 };
 
 export const openPrintingFlow = () => ( dispatch, getState, { storeOptions, addressNormalizationURL, getRatesURL, nonce } ) => {
@@ -216,8 +215,7 @@ export const submitAddressForNormalization = ( group ) => ( dispatch, getState, 
 		return;
 	}
 	normalizeAddress( dispatch, getState().shippingLabel.form[ group ].values, group, addressNormalizationURL, nonce )
-		.then( handleNormalizeResponse )
-		.catch( noop );
+		.then( handleNormalizeResponse );
 };
 
 export const updatePackageWeight = ( packageId, value ) => {
@@ -295,7 +293,7 @@ export const purchaseLabel = () => ( dispatch, getState, { purchaseURL, addressN
 		};
 
 		saveForm( setIsSaving, setSuccess, noop, setError, purchaseURL, nonce, 'POST', formData );
-	} ).catch( noop );
+	} );
 };
 
 export const openRefundDialog = ( labelId ) => {

--- a/client/shipping-label/state/normalize-address.js
+++ b/client/shipping-label/state/normalize-address.js
@@ -7,7 +7,7 @@ import {
 
 export default ( dispatch, address, type, addressNormalizationURL, nonce ) => {
 	dispatch( { type: ADDRESS_NORMALIZATION_IN_PROGRESS, group: type } );
-	return new Promise( ( resolve, reject ) => {
+	return new Promise( ( resolve ) => {
 		let error = null;
 		let response = null;
 		const setError = ( err ) => error = err;
@@ -25,10 +25,9 @@ export default ( dispatch, address, type, addressNormalizationURL, nonce ) => {
 					error,
 				} );
 				if ( error ) {
-					setTimeout( () => reject( error ), 0 );
-				} else {
-					setTimeout( resolve, 0 );
+					console.error( error );
 				}
+				setTimeout( () => resolve( ! error ), 0 );
 			}
 		};
 		saveForm( setIsSaving, setSuccess, noop, setError, addressNormalizationURL, nonce, 'POST', { address, type } );

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -407,17 +407,17 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			}
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-packages-controller.php' ) );
-			$rest_packages_controller = new WC_REST_Connect_Packages_Controller( $settings_store );
+			$rest_packages_controller = new WC_REST_Connect_Packages_Controller( $settings_store, $logger );
 			$this->set_rest_packages_controller( $rest_packages_controller );
 			$rest_packages_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-account-settings-controller.php' ) );
-			$rest_account_settings_controller = new WC_REST_Connect_Account_Settings_Controller( $this->api_client, $settings_store );
+			$rest_account_settings_controller = new WC_REST_Connect_Account_Settings_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_account_settings_controller( $rest_account_settings_controller );
 			$rest_account_settings_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-services-controller.php' ) );
-			$rest_services_controller = new WC_REST_Connect_Services_Controller( $schemas_store, $settings_store );
+			$rest_services_controller = new WC_REST_Connect_Services_Controller( $schemas_store, $settings_store, $logger );
 			$this->set_rest_services_controller( $rest_services_controller );
 			$rest_services_controller->register_routes();
 
@@ -427,32 +427,32 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$rest_self_help_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-label-controller.php' ) );
-			$rest_shipping_label_controller = new WC_REST_Connect_Shipping_Label_Controller( $this->api_client, $settings_store );
+			$rest_shipping_label_controller = new WC_REST_Connect_Shipping_Label_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_shipping_label_controller( $rest_shipping_label_controller );
 			$rest_shipping_label_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-label-status-controller.php' ) );
-			$rest_shipping_label_status_controller = new WC_REST_Connect_Shipping_Label_Status_Controller( $this->api_client, $settings_store );
+			$rest_shipping_label_status_controller = new WC_REST_Connect_Shipping_Label_Status_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_shipping_label_status_controller( $rest_shipping_label_status_controller );
 			$rest_shipping_label_status_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-label-refund-controller.php' ) );
-			$rest_shipping_label_refund_controller = new WC_REST_Connect_Shipping_Label_Refund_Controller( $this->api_client, $settings_store );
+			$rest_shipping_label_refund_controller = new WC_REST_Connect_Shipping_Label_Refund_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_shipping_label_refund_controller( $rest_shipping_label_refund_controller );
 			$rest_shipping_label_refund_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-label-image-controller.php' ) );
-			$rest_shipping_label_image_controller = new WC_REST_Connect_Shipping_Label_Image_Controller( $this->api_client );
+			$rest_shipping_label_image_controller = new WC_REST_Connect_Shipping_Label_Image_Controller( $this->api_client, $logger );
 			$this->set_rest_shipping_label_image_controller( $rest_shipping_label_image_controller );
 			$rest_shipping_label_image_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-shipping-rates-controller.php' ) );
-			$rest_shipping_rates_controller = new WC_REST_Connect_Shipping_Rates_Controller( $this->api_client, $settings_store );
+			$rest_shipping_rates_controller = new WC_REST_Connect_Shipping_Rates_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_shipping_rates_controller( $rest_shipping_rates_controller );
 			$rest_shipping_rates_controller->register_routes();
 
 			require_once( plugin_basename( 'classes/class-wc-rest-connect-address-normalization-controller.php' ) );
-			$rest_address_normalization_controller = new WC_REST_Connect_Address_Normalization_Controller( $this->api_client, $settings_store );
+			$rest_address_normalization_controller = new WC_REST_Connect_Address_Normalization_Controller( $this->api_client, $settings_store, $logger );
 			$this->set_rest_address_normalization_controller( $rest_address_normalization_controller );
 			$rest_address_normalization_controller->register_routes();
 		}


### PR DESCRIPTION
Fixes #556

The default behaviour (in Chrome) when a Promise is rejected and there is no `.catch` handler is to log the error in the console. So by removing the `.catch(noop)` the errors will be logged.

@allendav @nabsul @robobot3000 @jeffstieler 