### PR TITLE
Change the obscure "Syntax Error <" notice to something more readable when the JSON response is malformed

### DIFF
--- a/client/account-settings/state/actions.js
+++ b/client/account-settings/state/actions.js
@@ -1,3 +1,5 @@
+import parseJson from 'lib/utils/parse-json';
+
 // SET_FORM_DATA_VALUE is used to update a form field's underlying setting, e.g. selected_payment_method_id
 export const SET_FORM_DATA_VALUE = 'SET_FORM_DATA_VALUE';
 
@@ -34,10 +36,10 @@ export const saveForm = ( onSaveSuccess, onSaveFailure ) => ( dispatch, getState
 		body: JSON.stringify( getState().form.data ),
 	};
 
-	return fetch( callbackURL, request ).then( response => {
+	return fetch( callbackURL, request ).then( ( response ) => {
 		dispatch( setFormMetaProperty( 'isSaving', false ) );
 
-		return response.json().then( json => {
+		return parseJson( response ).then( ( json ) => {
 			if ( json.success ) {
 				onSaveSuccess();
 			} else {

--- a/client/lib/save-form/index.js
+++ b/client/lib/save-form/index.js
@@ -1,5 +1,6 @@
 import isArray from 'lodash/isArray';
 import Get from 'lodash/get';
+import parseJson from 'lib/utils/parse-json';
 import { EMPTY_ERROR } from 'settings/state/selectors/errors';
 
 const saveForm = ( setIsSaving, setSuccess, setFieldsStatus, setError, url, nonce, submitMethod, formData ) => {
@@ -13,11 +14,11 @@ const saveForm = ( setIsSaving, setSuccess, setFieldsStatus, setError, url, nonc
 		body: formData ? JSON.stringify( formData ) : null,
 	};
 
-	return fetch( url, request ).then( response => {
+	return fetch( url, request ).then( ( response ) => {
 		setError( null );
 		setSuccess( false );
 
-		return response.json().then( json => {
+		return parseJson( response ).then( ( json ) => {
 			if ( json.success ) {
 				return setSuccess( true, json );
 			}

--- a/client/lib/utils/parse-json.js
+++ b/client/lib/utils/parse-json.js
@@ -1,0 +1,25 @@
+import { translate as __ } from 'lib/mixins/i18n';
+
+/**
+ * Parses a server response into a JSON object, providing a human-readable error if the
+ * JSON is invalid.
+ *
+ * @param {Response} response Response object, as obtained from a fetch call.
+ * @returns {Promise} Resolves with the parsed JSON object,
+ * or rejects with a human-readable error if the payload is not valid JSON
+ */
+export default ( response ) => {
+	if ( ! response instanceof Response ) {
+		console.error( 'Invalid Response object' );
+		return Promise.reject( __( 'Unexpected server error.' ) );
+	}
+	return response.text().then( ( text ) => {
+		try {
+			return JSON.parse( text );
+		} catch ( error ) {
+			console.error( error );
+			console.error( text );
+			throw __( 'Unexpected server error.' );
+		}
+	} );
+};

--- a/client/packages/state/actions.js
+++ b/client/packages/state/actions.js
@@ -1,3 +1,5 @@
+import parseJson from 'lib/utils/parse-json';
+
 export const ADD_PACKAGE = 'ADD_PACKAGE';
 export const REMOVE_PACKAGE = 'REMOVE_PACKAGE';
 export const EDIT_PACKAGE = 'EDIT_PACKAGE';
@@ -70,10 +72,10 @@ export const saveForm = ( onSaveSuccess, onSaveFailure ) => ( dispatch, getState
 		body: JSON.stringify( getState().form.packages ),
 	};
 
-	return fetch( callbackURL, request ).then( response => {
+	return fetch( callbackURL, request ).then( ( response ) => {
 		dispatch( setIsSaving( false ) );
 
-		return response.json().then( json => {
+		return parseJson( response ).then( ( json ) => {
 			if ( json.success ) {
 				onSaveSuccess();
 			} else {


### PR DESCRIPTION
Fixes #554 

When the result of an AJAX call fails in the PHP side, the returned error page won't be valid JSON, so the error shown to the user was the quite obscure `Syntax error: < ...`. This can happen even if PHP prints a `NOTICE` before actually printing the JSON.

I wrapped all the places where the result of an AJAX request is parsed and if it fails, show a more legible generic error (and log the whole thing in the console).

@allendav @nabsul @robobot3000 @jeffstieler 