### PR TITLE
Label tracking code comes back in its own property now, not “provider label id”.

### DIFF
--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -102,7 +102,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 			$labels_data[] = $label_data->label;
 			$labels_order_meta[] = array(
 				'label_id' => $label_data->label->label_id,
-				'provider_label_id' => $label_data->label->provider_label_id,
+				'tracking' => $label_data->label->tracking,
 				'refundable_amount' => $label_data->label->refundable_amount,
 				'created' => $label_data->label->created,
 				'carrier_id' => $settings[ 'carrier' ],

--- a/client/shipping-label/views/tracking-link.js
+++ b/client/shipping-label/views/tracking-link.js
@@ -6,19 +6,19 @@ const TRACKING_URL_MAP = {
 	usps: 'https://tools.usps.com/go/TrackConfirmAction.action?tLabels=%s',
 };
 
-const TrackingLink = ( { provider_label_id, carrier_id } ) => {
-	if ( ! provider_label_id ) {
+const TrackingLink = ( { tracking, carrier_id } ) => {
+	if ( ! tracking ) {
 		return <span>{ __( 'N/A' ) }</span>;
 	}
 	const url = TRACKING_URL_MAP[ carrier_id ];
 	if ( ! url ) {
-		return <span>{ provider_label_id }</span>;
+		return <span>{ tracking }</span>;
 	}
-	return <a target="_blank" href={ sprintf( url, provider_label_id ) }>{ provider_label_id }</a>;
+	return <a target="_blank" href={ sprintf( url, tracking ) }>{ tracking }</a>;
 };
 
 TrackingLink.propTypes = {
-	provider_label_id: PropTypes.string,
+	tracking: PropTypes.string,
 	carrier_id: PropTypes.string,
 };
 


### PR DESCRIPTION
To test:
* Purchase a label via Edit Order screen, or go to an order that already has a label
* Verify that the tracking code still appears and is linked