### PR TITLE
Fix handling of label refund response.

### DIFF
--- a/classes/class-wc-rest-connect-shipping-label-refund-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-refund-controller.php
@@ -75,11 +75,17 @@ class WC_REST_Connect_Shipping_Label_Refund_Controller extends WP_REST_Controlle
 			return $response;
 		}
 
-		$this->settings_store->update_label_order_meta_data( $request[ 'order_id' ], $response->label );
+		// TODO: use $response->refund->amount ?
+		$label_refund = (object) array(
+			'label_id'      => (int) $response->label->id,
+			'refunded_time' => time() * 1000,
+		);
+
+		$this->settings_store->update_label_order_meta_data( $request[ 'order_id' ], $label_refund );
 
 		return array(
 			'success' => true,
-			'label' => $response->label,
+			'label'   => $label_refund,
 		);
 	}
 


### PR DESCRIPTION
The settings store label metadata update is reused, and expects `label_id` as a property. This should be temporary as we rework the handler to use all response data.