### PR TITLE
Naming: Find 'WooCommerce Connect', replace with 'Connect for WooCommerce'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to the WooCommerce Connect 
+# Contributing to the Connect for WooCommerce 
 
-Hi! Thank you for your interest in contributing to WooCommerce Connect. We appreciate it.
+Hi! Thank you for your interest in contributing to Connect for WooCommerce. We appreciate it.
 
-Although what you see today is a plugin, the goal for  WooCommerce Connect is to be a fully integrated part of WooCommerce core. To get us from feature plugin to core, WooCommerce Connect development is now in ALPHA - this means that you should expect frequent and sometimes large changes as features are added. During ALPHA testing, we'll be fixing problems and working to launch a feature-complete BETA. Successful BETA will culminate in a PR for inclusion into a future WooCommerce release.
+Although what you see today is a plugin, the goal for  Connect for WooCommerce is to be a fully integrated part of WooCommerce core. To get us from feature plugin to core, Connect for WooCommerce development is now in ALPHA - this means that you should expect frequent and sometimes large changes as features are added. During ALPHA testing, we'll be fixing problems and working to launch a feature-complete BETA. Successful BETA will culminate in a PR for inclusion into a future WooCommerce release.
 
 **We do not recommend you use this ALPHA software on a production site.**
 
-The emphasis for initial release of WooCommerce Connect is shipping simplified. We are providing a Shipping Zones-compatible USPS shipping method and, coming soon, a Shipping Zones compatible Canada Post shipping method. Shipping Zones are [an exciting new feature of WooCommerce 2.6](https://woocommerce.wordpress.com/2016/02/10/shipping-zones-to-ship-with-2-6/).
+The emphasis for initial release of Connect for WooCommerce is shipping simplified. We are providing a Shipping Zones-compatible USPS shipping method and, coming soon, a Shipping Zones compatible Canada Post shipping method. Shipping Zones are [an exciting new feature of WooCommerce 2.6](https://woocommerce.wordpress.com/2016/02/10/shipping-zones-to-ship-with-2-6/).
 
 Our USPS shipping method fetches rates for customers' carts in real time from the USPS server. No USPS account is needed - you can use the default one if you like.
 
@@ -18,21 +18,21 @@ Open [a GitHub issue](https://github.com/Automattic/woocommerce-connect-client/i
 
 If you're filing a bug, specific steps to reproduce are helpful. Please include what you expected to see and what happened instead.
 
-## Setting up USPS shipping with the WooCommerce Connect 
+## Setting up USPS shipping with the Connect for WooCommerce 
 
 1. Install or update to [WordPress 4.5](https://wordpress.org/download/) or higher.
-2. Install and activate WooCommerce 2.6 or higher. The WooCommerce Connect will NOT work with WooCommerce 2.5 or older.  A plugin ZIP will be available soon, but for now you need to download a ZIP of the master branch or clone the WooCommerce plugin from its [repository on GitHub](https://github.com/woothemes/woocommerce).
+2. Install and activate WooCommerce 2.6 or higher. The Connect for WooCommerce will NOT work with WooCommerce 2.5 or older.  A plugin ZIP will be available soon, but for now you need to download a ZIP of the master branch or clone the WooCommerce plugin from its [repository on GitHub](https://github.com/woothemes/woocommerce).
 3. Install and activate [Jetpack 3.9.6 or higher](https://wordpress.org/plugins/jetpack/).
-4. Connect your Jetpack to WordPress.com. Although there is no specific module you need to activate, the WooCommerce Connect requires the Jetpack connection to authenticate with the WooCommerce Connect server.
+4. Connect your Jetpack to WordPress.com. Although there is no specific module you need to activate, the Connect for WooCommerce requires the Jetpack connection to authenticate with the Connect for WooCommerce server.
 5. Install and activate this feature plugin.
 6. Add at least one product with weight and dimensions.
-7. Add at least one shipping zone, and add the WooCommerce Connect USPS shipping method to it.
+7. Add at least one shipping zone, and add the Connect for WooCommerce USPS shipping method to it.
 8. Configure the USPS shipping method origin ZIP code, and select at least one service.
 9. USPS rates will automatically display during checkout once a destination address is given.
 
 ## Running PHPUnit Tests
 
-The WooCommerce Connect client tests use [WooCommerce's tests installer](https://github.com/woothemes/woocommerce/blob/master/tests/bin/install.sh) to get up and running.
+The Connect for WooCommerce client tests use [WooCommerce's tests installer](https://github.com/woothemes/woocommerce/blob/master/tests/bin/install.sh) to get up and running.
 
 In order to successfully bootstrap your testing environment, you'll need the following:
 
@@ -73,15 +73,15 @@ OK (47 tests, 105 assertions)
 
 ## We're Here To Help
 
-We encourage you to ask for help. We want your first experience with WooCommerce Connect to be a good one, so don't be shy. If you're wondering why something is the way it is, or how a decision was made, you can tag issues with [Type] Question or prefix them with “Question:”
+We encourage you to ask for help. We want your first experience with Connect for WooCommerce to be a good one, so don't be shy. If you're wondering why something is the way it is, or how a decision was made, you can tag issues with [Type] Question or prefix them with “Question:”
 
 ## License
 
-WooCommerce Connect is licensed under [GNU General Public License v2 (or later)](/LICENSE.md).
+Connect for WooCommerce is licensed under [GNU General Public License v2 (or later)](/LICENSE.md).
 
 All materials contributed should be compatible with the GPLv2. This means that if you own the material, you agree to license it under the GPLv2 license. If you are contributing code that is not your own, such as adding a component from another Open Source project, or adding an `npm` package, you need to make sure you follow these steps:
 
 1. Check that the code has a license. If you can't find one, you can try to contact the original author and get permission to use, or ask them to release under a compatible Open Source license.
 2. Check the license is compatible with [GPLv2](http://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses), note that the Apache 2.0 license is *not* compatible.
-3. Add the code source URL (e.g. a GitHub URL), the files where it's used in the WooCommerce Connect and the full license terms to [`CREDITS.md`](/CREDITS.md)
+3. Add the code source URL (e.g. a GitHub URL), the files where it's used in the Connect for WooCommerce and the full license terms to [`CREDITS.md`](/CREDITS.md)
 4. Add attribution to the code, if applicable. This line should include the copyright notice of the source, and a reference to the license contained in [`CREDITS.md`](/CREDITS.md)

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -40,7 +40,7 @@
       {
         id : "usps",
         method_description : "Obtains rates dynamically from the USPS API during cart/checkout.",
-        method_title : "USPS (WooCommerce Connect)",
+        method_title : "USPS (Connect for WooCommerce)",
         service_settings : {
           type : "object",
           required : [
@@ -121,7 +121,7 @@
       {
         id : "canada_post",
         method_description : "Obtains rates dynamically from the Canada Post API during cart/checkout.",
-        method_title : "Canada Post (WooCommerce Connect)",
+        method_title : "Canada Post (Connect for WooCommerce)",
         service_settings : {
           type : "object",
           required : [
@@ -368,8 +368,8 @@
 		{
 			"id": "connect-your-jetpack",
 			"location": "global",
-			"title": "WooCommerce Connect Rocks",
-			"message": "You should connect your Jetpack and enable WooCommerce Connect.",
+			"title": "Connect for WooCommerce Rocks",
+			"message": "You should connect your Jetpack and enable Connect for WooCommerce.",
 			"button_text": "Connect",
 			"button_action": "/wp-admin/admin.php?page=wc-settings&action=connect"
 		},
@@ -377,7 +377,7 @@
 			"id": "enable-usps-shipping",
 			"location": "shipping",
 			"title": "USPS Now Available",
-			"message": "USPS shipping is now available through WooCommerce Connect.",
+			"message": "USPS shipping is now available through Connect for WooCommerce.",
 			"button_text": "Enable USPS",
 			"button_action": "/wp-admin/admin.php?page=wc-settings&action=enable-usps"
 		}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# WooCommerce Connect
+# Connect for WooCommerce
 
-What you see today is a plugin, though the goal for  WooCommerce Connect is to be a fully integrated part of WooCommerce core. To get us from feature plugin to core, WooCommerce Connect development is now in ALPHA - this means that you should expect frequent and sometimes large changes as features are added. During ALPHA testing, we'll be fixing problems and working to launch a feature-complete BETA. Successful BETA will culminate in a PR for inclusion into a future WooCommerce release.
+What you see today is a plugin, though the goal for  Connect for WooCommerce is to be a fully integrated part of WooCommerce core. To get us from feature plugin to core, Connect for WooCommerce development is now in ALPHA - this means that you should expect frequent and sometimes large changes as features are added. During ALPHA testing, we'll be fixing problems and working to launch a feature-complete BETA. Successful BETA will culminate in a PR for inclusion into a future WooCommerce release.
 
 **We do not recommend you use this ALPHA software on a production site.**
 
-The emphasis for initial release of WooCommerce Connect is shipping simplified. We are providing a Shipping Zones-compatible USPS shipping method and, coming soon, a Shipping Zones compatible Canada Post shipping method. Shipping Zones are [an exciting new feature of WooCommerce 2.6](https://woocommerce.wordpress.com/2016/02/10/shipping-zones-to-ship-with-2-6/).
+The emphasis for initial release of Connect for WooCommerce is shipping simplified. We are providing a Shipping Zones-compatible USPS shipping method and, coming soon, a Shipping Zones compatible Canada Post shipping method. Shipping Zones are [an exciting new feature of WooCommerce 2.6](https://woocommerce.wordpress.com/2016/02/10/shipping-zones-to-ship-with-2-6/).
 
 Our USPS shipping method pulls rates for customers' carts in real time from the USPS server. No USPS account is needed - use the default one if you like.
 
@@ -41,4 +41,4 @@ We support the latest two versions of all major browsers, except  IE, where we c
 
 ## License
 
-WooCommerce Connect is licensed under [GNU General Public License v2 (or later)](./LICENSE.md).
+Connect for WooCommerce is licensed under [GNU General Public License v2 (or later)](./LICENSE.md).

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
-		 * Requests the available services for this site from the WooCommerce Connect Server
+		 * Requests the available services for this site from the Connect for WooCommerce Server
 		 *
 		 * @return array|WP_Error
 		 */
@@ -54,7 +54,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
-		 * Validates the settings for a given service with the WooCommerce Connect Server
+		 * Validates the settings for a given service with the Connect for WooCommerce Server
 		 *
 		 * @param $service_slug
 		 * @param $service_settings
@@ -65,14 +65,14 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 			// Make sure the service slug only contains underscores or letters
 			if ( 1 === preg_match( '/[^a-z_]/i', $service_slug ) ) {
-				return new WP_Error( 'invalid_service_slug', 'Invalid WooCommerce Connect service slug provided' );
+				return new WP_Error( 'invalid_service_slug', 'Invalid Connect for WooCommerce service slug provided' );
 			}
 
 			return $this->request( 'POST', "/services/{$service_slug}/settings", array( 'service_settings' => $service_settings ) );
 		}
 
 		/**
-		 * Gets shipping rates (for checkout) from the WooCommerce Connect Server
+		 * Gets shipping rates (for checkout) from the Connect for WooCommerce Server
 		 *
 		 * @param $services All settings for all services we want rates for
 		 * @param $package Package provided to WC_Shipping_Method::calculate_shipping()
@@ -143,7 +143,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
-		 * Asks the WooCommerce connect server for an array of payment methods
+		 * Asks the Connect for WooCommerce server for an array of payment methods
 		 *
 		 * @return mixed|WP_Error
 		 */
@@ -152,7 +152,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
-		 * Gets shipping rates (for labels) from the WooCommerce Connect Server
+		 * Gets shipping rates (for labels) from the Connect for WooCommerce Server
 		 *
 		 * @param array $request - array(
 		 *	'packages' => array(
@@ -222,7 +222,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			if ( 200 != $code ) {
 				return new WP_Error(
 					'wcc_server_error',
-					sprintf( 'Error: The WooCommerce Connect server returned HTTP code: %d', $code )
+					sprintf( 'Error: The Connect for WooCommerce server returned HTTP code: %d', $code )
 				);
 			}
 			return $response;
@@ -249,7 +249,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
-		 * Tests the connection to the WooCommerce Connect Server
+		 * Tests the connection to the Connect for WooCommerce Server
 		 *
 		 * @return true|WP_Error
 		 */
@@ -258,7 +258,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
-		 * Sends a request to the WooCommerce Connect Server
+		 * Sends a request to the Connect for WooCommerce Server
 		 *
 		 * @param $method
 		 * @param $path
@@ -269,17 +269,17 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 			// TODO - incorporate caching for repeated identical requests
 			if ( ! class_exists( 'Jetpack_Data' ) ) {
-				return new WP_Error( 'jetpack_data_class_not_found', 'Unable to send request to WooCommerce Connect server. Jetpack_Data was not found.' );
+				return new WP_Error( 'jetpack_data_class_not_found', 'Unable to send request to Connect for WooCommerce server. Jetpack_Data was not found.' );
 			}
 
 			if ( ! method_exists( 'Jetpack_Data', 'get_access_token' ) ) {
-				return new WP_Error( 'jetpack_data_get_access_token_not_found', 'Unable to send request to WooCommerce Connect server. Jetpack_Data does not implement get_access_token.' );
+				return new WP_Error( 'jetpack_data_get_access_token_not_found', 'Unable to send request to Connect for WooCommerce server. Jetpack_Data does not implement get_access_token.' );
 			}
 
 			if ( ! is_array( $body ) ) {
 				return new WP_Error(
 					'request_body_should_be_array',
-					'Unable to send request to WooCommerce Connect server. Body must be an array.'
+					'Unable to send request to Connect for WooCommerce server. Body must be an array.'
 				);
 			}
 
@@ -295,7 +295,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				if ( ! $body ) {
 					return new WP_Error(
 						'unable_to_json_encode_body',
-						'Unable to encode body for request to WooCommerce Connect server.'
+						'Unable to encode body for request to Connect for WooCommerce server.'
 					);
 				}
 			}
@@ -327,7 +327,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 					return new WP_Error(
 						'wcc_server_empty_response',
 						sprintf(
-							'Error: The WooCommerce Connect server returned ( %d ) and an empty response body.',
+							'Error: The Connect for WooCommerce server returned ( %d ) and an empty response body.',
 							$response_code
 						)
 					);
@@ -340,7 +340,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				return new WP_Error(
 					'wcc_server_error_response',
 					sprintf(
-						'Error: The WooCommerce Connect server returned: %s %s ( %d )',
+						'Error: The Connect for WooCommerce server returned: %s %s ( %d )',
 						$error,
 						$message,
 						$response_code
@@ -386,7 +386,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		}
 
 		/**
-		 * Generates headers for our request to the WooCommerce Connect Server
+		 * Generates headers for our request to the Connect for WooCommerce Server
 		 *
 		 * @return array|WP_Error
 		 */
@@ -409,11 +409,11 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			$token = Jetpack_Data::get_access_token( 0 );
 			$token = apply_filters( 'wc_connect_jetpack_access_token', $token );
 			if ( ! $token || empty( $token->secret ) ) {
-				return new WP_Error( 'missing_token', 'Unable to send request to WooCommerce Connect server. Jetpack Token is missing' );
+				return new WP_Error( 'missing_token', 'Unable to send request to Connect for WooCommerce server. Jetpack Token is missing' );
 			}
 
 			if ( false === strpos( $token->secret, '.' ) ) {
-				return new WP_Error( 'invalid_token', 'Unable to send request to WooCommerce Connect server. Jetpack Token is malformed.' );
+				return new WP_Error( 'invalid_token', 'Unable to send request to Connect for WooCommerce server. Jetpack Token is malformed.' );
 			}
 
 			list( $token_key, $token_secret ) = explode( '.', $token->secret );
@@ -446,7 +446,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		protected function request_signature( $token_key, $token_secret, $timestamp, $nonce, $time_diff ) {
 			$local_time = $timestamp - $time_diff;
 			if ( $local_time < time() - 600 || $local_time > time() + 300 ) {
-				return new WP_Error( 'invalid_signature', 'Unable to send request to WooCommerce Connect server. The timestamp generated for the signature is too old.' );
+				return new WP_Error( 'invalid_signature', 'Unable to send request to Connect for WooCommerce server. The timestamp generated for the signature is too old.' );
 			}
 
 			$normalized_request_string = join( "\n", array(

--- a/classes/class-wc-connect-debug-tools.php
+++ b/classes/class-wc-connect-debug-tools.php
@@ -17,9 +17,9 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
 
         function woocommerce_debug_tools( $tools ) {
             $tools['test_wcc_connection'] = array(
-                'name'    => __( 'Test your WooCommerce Connect Connection', 'woocommerce' ),
+                'name'    => __( 'Test your Connect for WooCommerce connection', 'woocommerce' ),
                 'button'  => __( 'Test Connection', 'woocommerce' ),
-                'desc'    => __( 'This will test your WooCommerce Connect Connection to ensure everything is working correctly', 'woocommerce' ),
+                'desc'    => __( 'This will test your Connect for WooCommerce connection to ensure everything is working correctly', 'woocommerce' ),
                 'callback' => array( $this, 'test_connection' ),
             );
             return $tools;
@@ -28,9 +28,9 @@ if ( ! class_exists( 'WC_Connect_Debug_Tools' ) ) {
         function test_connection() {
             $test_request = $this->api_client->auth_test();
             if ( $test_request && ! is_wp_error( $test_request ) && $test_request->authorized ) {
-                echo '<div class="updated inline"><p>' . __( 'Your site is succesfully communicating to the WooCommerce Connect API.', 'woocommerce' ) . '</p></div>';
+                echo '<div class="updated inline"><p>' . __( 'Your site is succesfully communicating to the Connect for WooCommerce API.', 'woocommerce' ) . '</p></div>';
             } else {
-                echo '<div class="error inline"><p>' . __( 'ERROR: Your site has a problem connecting to the WooCommerce Connect API. Please make sure your Jetpack connection is working.', 'woocommerce' ) . '</p></div>';
+                echo '<div class="error inline"><p>' . __( 'ERROR: Your site has a problem connecting to the Connect for WooCommerce API. Please make sure your Jetpack connection is working.', 'woocommerce' ) . '</p></div>';
             }
         }
 

--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -155,9 +155,9 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 				)
 			);
 
-			// Lastly, do the WooCommerce Connect health check
+			// Lastly, do the Connect for WooCommerce health check
 			// Check that we have schema
-			// Check that we are able to talk to the WooCommerce Connect server
+			// Check that we are able to talk to the Connect for WooCommerce server
 			$schemas = $this->service_schemas_store->get_service_schemas();
 			$last_fetch_timestamp = $this->service_schemas_store->get_last_fetch_timestamp();
 			if ( ! is_null( $last_fetch_timestamp ) ) {
@@ -212,7 +212,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 
 			$health_items[] =	(object) array(
 				'key' => 'wcc_health_items',
-				'title' => __( 'WooCommerce Connect Service Data', 'woocommerce' ),
+				'title' => __( 'Connect for WooCommerce Service Data', 'woocommerce' ),
 				'type' => 'indicators',
 				'items' => array(
 					'wcc_indicator' => $health_item
@@ -334,7 +334,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 		}
 
 		/**
-		 * Gets the last 10 lines from the WooCommerce Connect log, if it exists
+		 * Gets the last 10 lines from the Connect for WooCommerce log, if it exists
 		 */
 		protected function get_debug_log_data() {
 			$data = new stdClass;
@@ -465,7 +465,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 			if ( ! is_array( $tabs ) ) {
 				$tabs = array();
 			}
-			$tabs[ 'connect' ] = _x( 'WooCommerce Connect', 'The WooCommerce Connect brandname', 'woocommerce' );
+			$tabs[ 'connect' ] = _x( 'Connect for WooCommerce', 'The Connect for WooCommerce brandname', 'woocommerce' );
 			return $tabs;
 
 		}
@@ -648,7 +648,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 
 			$this->add_fieldset(
 				'health',
-				_x( 'Health', 'This section displays the overall health of WooCommerce Connect and the things it depends on', 'woocommerce' ),
+				_x( 'Health', 'This section displays the overall health of Connect for WooCommerce and the things it depends on', 'woocommerce' ),
 				$this->get_health_items()
 			);
 
@@ -687,7 +687,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 
 			?>
 				<h2>
-					<?php _e( 'WooCommerce Connect Status', 'woocommerce' ); ?>
+					<?php _e( 'Connect for WooCommerce Status', 'woocommerce' ); ?>
 				</h2>
 				<div class="wc-connect-admin-container" id="<?php echo esc_attr( $root_view ) ?>"></div>
 			<?php

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -137,7 +137,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		/**
-		 * Returns the service type and id for each enabled WooCommerce Connect service
+		 * Returns the service type and id for each enabled Connect for WooCommerce service
 		 *
 		 * Shipping services also include instance_id and shipping zone id
 		 *

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -35,7 +35,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			WC_Connect_Logger $logger ) {
 
 			$this->id    = 'connect';
-			$this->label = _x( 'WooCommerce Connect', 'The WooCommerce Connect brandname', 'woocommerce' );
+			$this->label = _x( 'Connect for WooCommerce', 'The Connect for WooCommerce brandname', 'woocommerce' );
 
 			$this->payment_methods_store = $payment_methods_store;
 			$this->service_settings_store = $service_settings_store;
@@ -58,7 +58,7 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			if ( ! is_array( $tabs ) ) {
 				$tabs = array();
 			}
-			$tabs[ 'connect' ] = _x( 'WooCommerce Connect', 'The WooCommerce Connect brandname', 'woocommerce' );
+			$tabs[ 'connect' ] = _x( 'Connect for WooCommerce', 'The Connect for WooCommerce brandname', 'woocommerce' );
 			return $tabs;
 		}
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -236,7 +236,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				);
 			}
 
-			// TODO: Request rates for all WooCommerce Connect powered methods in
+			// TODO: Request rates for all Connect for WooCommerce powered methods in
 			// the current shipping zone to avoid each method making an independent request
 			$services = array(
 				array(

--- a/tests/php/test_wc-connect-services-validator.php
+++ b/tests/php/test_wc-connect-services-validator.php
@@ -19,7 +19,7 @@ class WP_Test_WC_Connect_Service_Schemas_Validator extends WC_Unit_Test_Case {
 				(object) array(
 					'id' => 'usps',
 					'method_description' => 'Obtains rates dynamically from the USPS API during cart/checkout.',
-					'method_title' => 'USPS (WooCommerce Connect)',
+					'method_title' => 'USPS (Connect for WooCommerce)',
 					'form_layout' => array(),
 					'service_settings' => (object) array(
 						'type' => 'object',

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Plugin Name: WooCommerce Connect
+ * Plugin Name: Connect for WooCommerce
  * Plugin URI: http://woothemes.com/
- * Description: WooCommerce Connect: Shipping, Simplified. Powered by Jetpack, this feature plugin provides a Shipping Zones compatible USPS shipping method for your WooCommerce powered store.
+ * Description: Connect for WooCommerce: Shipping, Simplified. Powered by Jetpack, this feature plugin provides a Shipping Zones compatible USPS shipping method for your WooCommerce powered store.
  * Author: Automattic
  * Author URI: http://woothemes.com/
  * Version: 0.3


### PR DESCRIPTION
Fixes: https://github.com/Automattic/woocommerce-connect-client/issues/592 in which we update this to its rightful name!

Server change: https://github.com/Automattic/woocommerce-connect-server/pull/558