### PR TITLE
Shipping labels: clean up card header, selects, and notices

### DIFF
--- a/assets/stylesheets/components/foldable-card/style.scss
+++ b/assets/stylesheets/components/foldable-card/style.scss
@@ -12,9 +12,8 @@
 }
 
 .foldable-card__header {
-	min-height: 64px;
 	width: 100%;
-	padding: 16px;
+	padding: 12px 16px;
 	box-sizing: border-box;
 	display: flex;
 	align-items: center;
@@ -39,7 +38,7 @@
 
 .foldable-card.is-compact {
 	.foldable-card__header {
-		padding: 16px;
+		padding: 12px 16px;
 		min-height: 40px;
 	}
 }
@@ -48,7 +47,6 @@
 	.foldable-card__header {
 		margin-bottom: 0px;
 		height: inherit;
-		min-height: 64px;
 	}
 }
 

--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -113,14 +113,17 @@
 	}
 
 	.validation-message {
-		padding-bottom: 16px;
-		font-size: 14px;
-		line-height: 1.6em;
+		margin: -24px -24px 24px -24px;
+
+		 .notice__icon {
+			 display: none;
+		 }
 	}
 
 	.suggestion-container {
 		display: flex;
 		align-items: flex-start;
+		margin-top: 24px;
 
 		.suggestion-title {
 			font-weight: bold;

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -295,6 +295,8 @@
 			height: auto;
 			box-shadow: none;
 			width: 100%;
+			line-height: 22px;
+			padding: 9px 32px 12px 14px;
 		}
 	}
 

--- a/client/shipping-label/views/purchase/steps/address/suggestion.js
+++ b/client/shipping-label/views/purchase/steps/address/suggestion.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import omit from 'lodash/omit';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
+import Notice from 'components/notice';
 import FormButton from 'components/forms/form-button';
 
 const RadioButton = ( props ) => {
@@ -65,7 +66,10 @@ const AddressSuggestion = ( {
 	} ) => {
 	return (
 		<div>
-			<div className="validation-message">{ __( 'We have slightly modified the entered address. If that looks correct, please use the suggested address to ensure accurate delivery.' ) }</div>
+			<Notice
+				className="validation-message"
+				status="is-warning"
+				text={ __( 'We have slightly modified the address entered. If correct, please use the suggested address to ensure accurate delivery.' ) } />
 			<div className="suggestion-container">
 				<RadioButton
 					checked={ ! selectNormalized }

--- a/client/shipping-label/views/purchase/steps/address/suggestion.js
+++ b/client/shipping-label/views/purchase/steps/address/suggestion.js
@@ -69,6 +69,7 @@ const AddressSuggestion = ( {
 			<Notice
 				className="validation-message"
 				status="is-warning"
+				showDismiss={ false }
 				text={ __( 'We have slightly modified the address entered. If correct, please use the suggested address to ensure accurate delivery.' ) } />
 			<div className="suggestion-container">
 				<RadioButton


### PR DESCRIPTION
Fixes: https://github.com/Automattic/woocommerce-connect-client/issues/599

- Suggested address: uses a notice for clarity
- Foldable card header: even out the padding, reducing overall height
- Selects: fix height so its the same size as <input>

<img width="979" alt="screen shot 2016-10-15 at 2 29 59 pm" src="https://cloud.githubusercontent.com/assets/5835847/19413251/0f3701c6-92e5-11e6-9d57-c9a12baf6c1b.png">
