### PR TITLE
Make sure all Calypso components with an "isError" prop are invoked with an actual boolean

### DIFF
--- a/client/components/dropdown/index.js
+++ b/client/components/dropdown/index.js
@@ -16,7 +16,7 @@ const Dropdown = ( { id, valuesMap, title, description, value, updateValue, erro
 				value={ value }
 				onChange={ ( event ) => updateValue( event.target.value ) }
 				disabled={ Boolean( disabled ) }
-				isError={ error } >
+				isError={ Boolean( error ) } >
 				{ Object.keys( valuesMap ).map( key => {
 					return (
 						<option

--- a/client/components/number-field/index.js
+++ b/client/components/number-field/index.js
@@ -17,7 +17,7 @@ const NumberField = ( { id, title, description, value, placeholder, updateValue,
 				placeholder={ placeholder }
 				value={ value }
 				onChange={ ( event ) => updateValue( parseNumber( event.target.value ) ) }
-				isError={ error }
+				isError={ Boolean( error ) }
 			/>
 			{ error ? <FieldError text={ error } /> : <FieldDescription text={ description } /> }
 		</FormFieldset>

--- a/client/components/text-area/index.js
+++ b/client/components/text-area/index.js
@@ -19,7 +19,7 @@ const TextArea = ( { id, readonly, title, description, value, placeholder, updat
 				readOnly={ readonly }
 				value={ value }
 				onChange={ handleChangeEvent }
-				isError={ error }
+				isError={ Boolean( error ) }
 			/>
 			{ error ? <FieldError text={ error } /> : <FieldDescription text={ description } /> }
 		</FormFieldset>

--- a/client/components/text-field/index.js
+++ b/client/components/text-field/index.js
@@ -18,7 +18,7 @@ const TextField = ( { id, title, description, value, placeholder, updateValue, e
 				placeholder={ placeholder }
 				value={ value }
 				onChange={ handleChangeEvent }
-				isError={ error }
+				isError={ Boolean( error ) }
 			/>
 			{ error ? <FieldError text={ error } /> : <FieldDescription text={ description } /> }
 		</FormFieldset>

--- a/client/packages/views/modal-errors.js
+++ b/client/packages/views/modal-errors.js
@@ -48,11 +48,9 @@ const preProcessPackageData = ( data, boxNames ) => {
 	return omitBy( result, ( value ) => null === value );
 };
 
-const getErrors = ( packageData, boxNames, schema ) => {
+export default ( packageData, boxNames, schema ) => {
 	const validate = memoizedValidator( schema );
 	const data = preProcessPackageData( packageData, boxNames );
 	validate( data );
 	return processErrors( validate.errors );
 };
-
-module.exports = getErrors;


### PR DESCRIPTION
This fixes a warning that appeared in development. Calypso's `<FormTextInput>` requires a boolean `isError` prop, and we were passing whatever, trusting the Javascript "true-ish" and "false-ish" values.

This `propType` enforcement was implemented recently, so this started emitting the warning when we updated our `wp-calypso` dependency.

To test, go to the Purchase Label Dialog, delete some required field (for example, `City`), and check that the console doesn't emit an error.

@allendav @nabsul @robobot3000 @jeffstieler 