### PR TITLE
The destination country for a manual order defaults to the country of origin instead of being blank

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -172,6 +172,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			$selected_rates  = $this->get_selected_rates( $order );
 			$destination     = $this->get_destination_address( $order );
 
+			if ( ! $destination[ 'country' ] ) {
+				$destination[ 'country' ] = $origin[ 'country' ];
+			}
+
 			$form_data = compact( 'is_packed', 'packages', 'origin', 'destination' );
 
 			$form_data[ 'rates' ] = array(


### PR DESCRIPTION
With some recent refactor, when you create an order from scratch, the destination address is completely empty. That means even the country, which defaults to the first one alphabetically (Aland Islands), and the country selector is disabled. Since we don't support shipping to wherever that is, this is a bug :)

To test:
* Create an empty order with a shippable item.
* Go to the Print Label Dialog.
* Notice that the (disabled) destination country selector has `United States (US)` selected.

@nabsul @allendav @jeffstieler @robobot3000 