### PR TITLE
Generate preview and printing label PDFs in the client

### DIFF
--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -86,7 +86,7 @@
 		justify-content:center;
 		align-items:center;
 
-		img {
+		iframe {
 			max-height: 100%;
 		}
 	}

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -103,6 +103,14 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			return array_merge( $wc_address_fields, $stored_address_fields );
 		}
 
+		public function get_preferred_paper_size() {
+			return get_option( 'wc_connect_paper_size', '' );
+		}
+
+		public function set_preferred_paper_size( $size ) {
+			return update_option( 'wc_connect_paper_size', $size );
+		}
+
 		public function update_label_order_meta_data( $order_id, $new_label_data ) {
 			$raw_labels_data = get_post_meta( ( int ) $order_id, 'wc_connect_labels', true );
 			$labels_data = json_decode( $raw_labels_data, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -180,6 +180,8 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			$form_data[ 'order_id' ] = $order->id;
 
+			$form_data[ 'paper_size' ] = $this->settings_store->get_preferred_paper_size();
+
 			return $form_data;
 		}
 

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -63,6 +63,9 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 		$settings = json_decode( $request_body, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
 		$order_id = $settings[ 'order_id' ];
 
+		$this->settings_store->set_preferred_paper_size( $settings[ 'paper_size' ] );
+		unset( $settings[ 'paper_size' ] );
+
 		$settings[ 'payment_method_id' ] = $this->settings_store->get_selected_payment_method_id();
 		$settings[ 'carrier' ] = 'usps';
 		$settings[ 'label_size' ] = 'default';

--- a/client/lib/pdf-label-generator/index.js
+++ b/client/lib/pdf-label-generator/index.js
@@ -1,10 +1,29 @@
 import { translate as __ } from 'lib/mixins/i18n';
+import blobStream from 'blob-stream';
+import PDF from 'pdfkit';
+import _ from 'lodash';
 
 const PDF_DENSITY = 72; // dots per inch
+
+const MARGIN = 0.5 * PDF_DENSITY;
+
+const FONT_SIZE = 24;
+
+const PARAGRAPH_MARGIN = 12;
 
 const LABEL_SIZE = {
 	width: 4 * PDF_DENSITY,
 	height: 6 * PDF_DENSITY,
+};
+
+const LABEL_SIZE_WITH_CAPTION = {
+	width: LABEL_SIZE.width,
+	height: LABEL_SIZE.height + FONT_SIZE + PARAGRAPH_MARGIN,
+};
+
+const LABEL_SIZE_WITH_CAPTION_AND_MARGIN = {
+	width: LABEL_SIZE_WITH_CAPTION.width + MARGIN * 2,
+	height: LABEL_SIZE_WITH_CAPTION.height + MARGIN * 2,
 };
 
 // Dimensions from https://github.com/devongovett/pdfkit/blob/master/lib/page.coffee#L72
@@ -27,11 +46,104 @@ export const PAPER_SIZES = {
 	},
 };
 
-export default ( paperSize, labels ) => {
-	return new Promise( ( resolve ) => {
-		const text = `Rendering ${labels.length} labels in ${paperSize} paper`;
-		const blob = new Blob( [ `<p>${text}</p>` ], { type: 'text/html' } );
-		const url = URL.createObjectURL( blob );
-		setTimeout( () => resolve( url ), 1000 );
+// TODO: If we implement batched purchase & printing, make this an LRU cache
+const IMAGES_CACHE = {};
+
+const fetchImage = ( url, nonce ) => {
+	if ( IMAGES_CACHE[ url ] ) {
+		return Promise.resolve( { url, buffer: IMAGES_CACHE[ url ] } );
+	}
+	return fetch( url, {
+		credentials: 'same-origin',
+		headers: {
+			'X-WP-Nonce': nonce,
+		},
+	} )
+	.then( ( response ) => {
+		if ( 200 !== response.status ) {
+			throw new Error( response.statusText );
+		}
+		return response.arrayBuffer();
+	} )
+	.then( ( buffer ) => {
+		IMAGES_CACHE[ url ] = buffer;
+		return { url, buffer };
 	} );
+};
+
+const fits2LabelsInPage = ( dimensions ) => {
+	return dimensions[ 0 ] >= LABEL_SIZE_WITH_CAPTION_AND_MARGIN.height &&
+		dimensions[ 1 ] >= LABEL_SIZE_WITH_CAPTION_AND_MARGIN.width * 2;
+};
+
+const fitsCaption = ( dimensions ) => {
+	return dimensions[ 0 ] >= LABEL_SIZE_WITH_CAPTION_AND_MARGIN.width &&
+		dimensions[ 1 ] >= LABEL_SIZE_WITH_CAPTION_AND_MARGIN.height;
+};
+
+const renderPDF = ( paperSize, labels ) => {
+	const dimensions = PAPER_SIZES[ paperSize ].dimensions;
+	const doc = new PDF( {
+		size: dimensions,
+		margin: 0,
+	} );
+	doc.fontSize( FONT_SIZE );
+	const stream = doc.pipe( blobStream() );
+
+	const renderLabel = ( caption, imageBuffer, pageDimensions, offset ) => {
+		const labelSize = caption ? LABEL_SIZE_WITH_CAPTION : LABEL_SIZE;
+		const labelX = ( pageDimensions[ 0 ] - labelSize.width ) / 2 - offset[ 0 ];
+		let labelY = ( pageDimensions[ 1 ] - labelSize.height ) / 2 - offset[ 1 ];
+		if ( caption ) {
+			doc.text( caption, labelX, labelY, { width: LABEL_SIZE.width, align: 'center' } );
+			labelY += FONT_SIZE + PARAGRAPH_MARGIN;
+		}
+		doc.image( imageBuffer, labelX, labelY, { fit: PAPER_SIZES.label.dimensions } );
+	};
+
+	const renderSingleLabelInPage = ( { caption, imageBuffer }, index ) => {
+		if ( 0 !== index ) {
+			doc.addPage();
+		}
+		renderLabel( caption, imageBuffer, dimensions, [ 0, 0 ] );
+	};
+
+	if ( 1 < labels.length && fits2LabelsInPage( dimensions ) ) {
+		labels.forEach( ( { caption, imageBuffer }, index ) => {
+			const even = 0 === index % 2;
+			if ( even ) {
+				if ( 0 !== index ) {
+					doc.addPage();
+				}
+				doc.rotate( 90, { origin: [ dimensions[ 0 ] / 2, dimensions[ 1 ] / 2 ] } );
+			}
+			const pageDimensions = [ dimensions[ 1 ] / 2, dimensions[ 0 ] ];
+			const offset = [ ( dimensions[ 1 ] - dimensions[ 0 ] ) / 2, ( dimensions[ 0 ] - dimensions[ 1 ] ) / 2 ];
+			if ( ! even ) {
+				offset[ 0 ] -= pageDimensions[ 0 ];
+			}
+			renderLabel( caption, imageBuffer, pageDimensions, offset );
+		} );
+	} else if ( fitsCaption( dimensions ) ) {
+		labels.forEach( renderSingleLabelInPage );
+	} else {
+		labels.map( ( { imageBuffer } ) => ( { imageBuffer } ) ).forEach( renderSingleLabelInPage );
+	}
+
+	doc.end();
+	return new Promise( ( resolve ) => {
+		stream.on( 'finish', function() {
+			resolve( stream.toBlobURL( 'application/pdf' ) );
+		} );
+	} );
+};
+
+export default ( paperSize, labels, nonce ) => {
+	const downloadTasks = _.uniq( _.map( labels, 'imageURL' ) ).map( ( url ) => fetchImage( url, nonce ) );
+	return Promise.all( downloadTasks )
+		.then( ( results ) => _.keyBy( results, 'url' ) )
+		.then( ( images ) => {
+			labels.forEach( ( label ) => label.imageBuffer = images[ label.imageURL ].buffer );
+			return renderPDF( paperSize, labels );
+		} );
 };

--- a/client/lib/pdf-label-generator/index.js
+++ b/client/lib/pdf-label-generator/index.js
@@ -7,12 +7,24 @@ const LABEL_SIZE = {
 	height: 6 * PDF_DENSITY,
 };
 
-// Measures from https://github.com/devongovett/pdfkit/blob/master/lib/page.coffee#L72
+// Dimensions from https://github.com/devongovett/pdfkit/blob/master/lib/page.coffee#L72
 export const PAPER_SIZES = {
-	[ __( 'A4' ) ]: [ 595.28, 841.89 ],
-	[ __( 'Letter' ) ]: [ 612.00, 792.00 ],
-	[ __( 'Legal' ) ]: [ 612.00, 1008.00 ],
-	[ __( 'Label (4"x6")' ) ]: [ LABEL_SIZE.width, LABEL_SIZE.height ],
+	a4: {
+		name: __( 'A4' ),
+		dimensions: [ 595.28, 841.89 ],
+	},
+	letter: {
+		name: __( 'Letter' ),
+		dimensions: [ 612.00, 792.00 ],
+	},
+	legal: {
+		name: __( 'Legal' ),
+		dimensions: [ 612.00, 1008.00 ],
+	},
+	label: {
+		name: __( 'Label (4"x6")' ),
+		dimensions: [ LABEL_SIZE.width, LABEL_SIZE.height ],
+	},
 };
 
 export default ( paperSize, labels ) => {

--- a/client/lib/pdf-label-generator/index.js
+++ b/client/lib/pdf-label-generator/index.js
@@ -1,0 +1,25 @@
+import { translate as __ } from 'lib/mixins/i18n';
+
+const PDF_DENSITY = 72; // dots per inch
+
+const LABEL_SIZE = {
+	width: 4 * PDF_DENSITY,
+	height: 6 * PDF_DENSITY,
+};
+
+// Measures from https://github.com/devongovett/pdfkit/blob/master/lib/page.coffee#L72
+export const PAPER_SIZES = {
+	[ __( 'A4' ) ]: [ 595.28, 841.89 ],
+	[ __( 'Letter' ) ]: [ 612.00, 792.00 ],
+	[ __( 'Legal' ) ]: [ 612.00, 1008.00 ],
+	[ __( 'Label (4"x6")' ) ]: [ LABEL_SIZE.width, LABEL_SIZE.height ],
+};
+
+export default ( paperSize, labels ) => {
+	return new Promise( ( resolve ) => {
+		const text = `Rendering ${labels.length} labels in ${paperSize} paper`;
+		const blob = new Blob( [ `<p>${text}</p>` ], { type: 'text/html' } );
+		const url = URL.createObjectURL( blob );
+		setTimeout( () => resolve( url ), 1000 );
+	} );
+};

--- a/client/lib/utils/print-document.js
+++ b/client/lib/utils/print-document.js
@@ -9,29 +9,35 @@ let iframe = null;
  * @returns {Promise} Promise that resolves when the document is loaded, and rejected if there's an error fetching it
  */
 export default ( url, nonce ) => {
-	const request = {
-		credentials: 'same-origin',
-		headers: {
-			'X-WP-Nonce': nonce,
-		},
-	};
-	return fetch( url, request )
-		.then( ( response ) => {
-			if ( 200 !== response.status ) {
-				throw new Error( response.statusText );
-			}
-			return response.blob().then( ( blob ) => URL.createObjectURL( blob ) );
-		} )
-		.then( ( dataUrl ) => {
-			if ( iframe ) {
-				document.body.removeChild( iframe );
-			}
-			iframe = document.createElement( 'iframe' );
-			iframe.src = dataUrl;
-			iframe.style.display = 'none';
-			iframe.onload = () => {
-				iframe.contentWindow.print();
-			};
-			document.body.appendChild( iframe );
-		} );
+	let downloadTask;
+
+	if ( url.startsWith( 'blob:' ) ) {
+		downloadTask = Promise.resolve( url );
+	} else {
+		const request = {
+			credentials: 'same-origin',
+			headers: {
+				'X-WP-Nonce': nonce,
+			},
+		};
+		downloadTask = fetch( url, request )
+			.then( ( response ) => {
+				if ( 200 !== response.status ) {
+					throw new Error( response.statusText );
+				}
+				return response.blob().then( ( blob ) => URL.createObjectURL( blob ) );
+			} );
+	}
+	return downloadTask.then( ( dataUrl ) => {
+		if ( iframe ) {
+			document.body.removeChild( iframe );
+		}
+		iframe = document.createElement( 'iframe' );
+		iframe.src = dataUrl;
+		iframe.style.display = 'none';
+		iframe.onload = () => {
+			iframe.contentWindow.print();
+		};
+		document.body.appendChild( iframe );
+	} );
 };

--- a/client/shipping-label/index.js
+++ b/client/shipping-label/index.js
@@ -8,7 +8,7 @@ import mapValues from 'lodash/mapValues';
 // from calypso
 import notices from 'state/notices/reducer';
 
-export default ( { formData, labelsData, storeOptions, labelPreviewURL } ) => ( {
+export default ( { formData, labelsData, storeOptions } ) => ( {
 	getReducer() {
 		return combineReducers( {
 			shippingLabel,
@@ -55,7 +55,7 @@ export default ( { formData, labelsData, storeOptions, labelPreviewURL } ) => ( 
 						retrievalInProgress: false,
 					},
 					preview: {
-						labelPreviewURL,
+						paperSize: '', // TODO: remember this setting in the merchant host
 					},
 				},
 			},

--- a/client/shipping-label/index.js
+++ b/client/shipping-label/index.js
@@ -55,7 +55,7 @@ export default ( { formData, labelsData, storeOptions } ) => ( {
 						retrievalInProgress: false,
 					},
 					preview: {
-						paperSize: '', // TODO: remember this setting in the merchant host
+						paperSize: formData.paper_size,
 					},
 				},
 			},

--- a/client/shipping-label/index.js
+++ b/client/shipping-label/index.js
@@ -27,6 +27,7 @@ export default ( { formData, labelsData, storeOptions } ) => ( {
 		return {
 			shippingLabel: {
 				labels: labelsData || [],
+				paperSize: formData.paper_size,
 				form: labelsData ? {} : {
 					orderId: formData.order_id,
 					origin: {
@@ -54,9 +55,7 @@ export default ( { formData, labelsData, storeOptions } ) => ( {
 						available: {},
 						retrievalInProgress: false,
 					},
-					preview: {
-						paperSize: formData.paper_size,
-					},
+					preview: {},
 				},
 			},
 		};

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -261,13 +261,14 @@ export const updateRate = ( packageId, value ) => {
 };
 
 const refreshPreview = ( dispatch, getState, { labelPreviewURL, nonce } ) => {
-	const form = getState().shippingLabel.form;
+	const state = getState().shippingLabel;
+	const { form, paperSize } = state;
 	let pckgIndex = 1;
 	const labels = _.map( form.packages.values, () => ( {
 		caption: sprintf( __( 'Package %d (of %d)' ), pckgIndex++, Object.keys( form.packages.values ).length ).toUpperCase(),
 		imageURL: labelPreviewURL,
 	} ) );
-	generatePDF( form.preview.paperSize, labels, nonce ).then( ( url ) => dispatch( { type: UPDATE_PREVIEW, url } ) );
+	generatePDF( paperSize, labels, nonce ).then( ( url ) => dispatch( { type: UPDATE_PREVIEW, url } ) );
 };
 
 export const updatePaperSize = ( value ) => ( dispatch, getState, context ) => {
@@ -297,8 +298,13 @@ export const purchaseLabel = () => ( dispatch, getState, { purchaseURL, addressN
 				console.error( error );
 				dispatch( NoticeActions.errorNotice( error.toString() ) );
 			} else {
-				// TODO: Figure out how to print multiple labels
-				printDocument( sprintf( labelImageURL, response[ 0 ].label_id ), nonce )
+				let pckgIndex = 1;
+				const labels = response.map( ( label ) => ( {
+					caption: sprintf( __( 'Package %d (of %d)' ), pckgIndex++, response.length ).toUpperCase(),
+					imageURL: sprintf( labelImageURL, label.label_id ),
+				} ) );
+				generatePDF( getState().shippingLabel.paperSize, labels, nonce )
+					.then( printDocument )
 					.then( () => dispatch( exitPrintingFlow() ) )
 					.catch( ( err ) => {
 						console.error( err );
@@ -321,7 +327,9 @@ export const purchaseLabel = () => ( dispatch, getState, { purchaseURL, addressN
 		if ( ! every( normalizationResults ) ) {
 			return;
 		}
-		form = getState().shippingLabel.form;
+		const state = getState().shippingLabel;
+		const { paperSize } = state;
+		form = state.form;
 		const formData = {
 			origin: form.origin.selectNormalized ? form.origin.normalized : form.origin.values,
 			destination: form.destination.selectNormalized ? form.destination.normalized : form.destination.values,
@@ -332,7 +340,7 @@ export const purchaseLabel = () => ( dispatch, getState, { purchaseURL, addressN
 				products: flatten( pckg.items.map( ( item ) => fill( new Array( item.quantity ), item.product_id ) ) ),
 			} ) ),
 			order_id: form.orderId,
-			paper_size: form.preview.paperSize,
+			paper_size: paperSize,
 		};
 
 		saveForm( setIsSaving, setSuccess, noop, setError, purchaseURL, nonce, 'POST', formData );
@@ -414,7 +422,9 @@ export const closeReprintDialog = () => {
 export const confirmReprint = () => ( dispatch, getState, { labelImageURL, nonce } ) => {
 	dispatch( { type: CONFIRM_REPRINT } );
 	const labelId = getState().shippingLabel.reprintDialog.labelId;
-	printDocument( sprintf( labelImageURL, labelId ), nonce )
+	const imageURL = sprintf( labelImageURL, labelId );
+	generatePDF( getState().shippingLabel.paperSize, [ { imageURL } ], nonce )
+		.then( printDocument )
 		.then( () => dispatch( closeReprintDialog() ) )
 		.catch( ( error ) => dispatch( NoticeActions.errorNotice( error.toString() ) ) );
 };

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -260,14 +260,14 @@ export const updateRate = ( packageId, value ) => {
 	};
 };
 
-const refreshPreview = ( dispatch, getState, { labelPreviewURL } ) => {
+const refreshPreview = ( dispatch, getState, { labelPreviewURL, nonce } ) => {
 	const form = getState().shippingLabel.form;
 	let pckgIndex = 1;
 	const labels = _.map( form.packages.values, () => ( {
-		text: sprintf( __( 'Package %d (of %d)' ), pckgIndex++, Object.keys( form.packages.values ).length ).toUpperCase(),
+		caption: sprintf( __( 'Package %d (of %d)' ), pckgIndex++, Object.keys( form.packages.values ).length ).toUpperCase(),
 		imageURL: labelPreviewURL,
 	} ) );
-	generatePDF( form.preview.paperSize, labels ).then( ( url ) => dispatch( { type: UPDATE_PREVIEW, url } ) );
+	generatePDF( form.preview.paperSize, labels, nonce ).then( ( url ) => dispatch( { type: UPDATE_PREVIEW, url } ) );
 };
 
 export const updatePaperSize = ( value ) => ( dispatch, getState, context ) => {

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -260,23 +260,23 @@ export const updateRate = ( packageId, value ) => {
 	};
 };
 
-export const updatePaperSize = ( value ) => ( dispatch, getState, { labelPreviewURL } ) => {
+const refreshPreview = ( dispatch, getState, { labelPreviewURL } ) => {
 	const form = getState().shippingLabel.form;
-	if ( form.preview.paperSize === value ) {
-		return;
-	}
-
-	dispatch( {
-		type: UPDATE_PAPER_SIZE,
-		value,
-	} );
-
 	let pckgIndex = 1;
 	const labels = _.map( form.packages.values, () => ( {
 		text: sprintf( __( 'Package %d (of %d)' ), pckgIndex++, Object.keys( form.packages.values ).length ).toUpperCase(),
 		imageURL: labelPreviewURL,
 	} ) );
-	generatePDF( value, labels ).then( ( url ) => dispatch( { type: UPDATE_PREVIEW, url } ) );
+	generatePDF( form.preview.paperSize, labels ).then( ( url ) => dispatch( { type: UPDATE_PREVIEW, url } ) );
+};
+
+export const updatePaperSize = ( value ) => ( dispatch, getState, context ) => {
+	dispatch( {
+		type: UPDATE_PAPER_SIZE,
+		value,
+	} );
+
+	refreshPreview( dispatch, getState, context );
 };
 
 export const purchaseLabel = () => ( dispatch, getState, { purchaseURL, addressNormalizationURL, labelImageURL, nonce } ) => {
@@ -332,6 +332,7 @@ export const purchaseLabel = () => ( dispatch, getState, { purchaseURL, addressN
 				products: flatten( pckg.items.map( ( item ) => fill( new Array( item.quantity ), item.product_id ) ) ),
 			} ) ),
 			order_id: form.orderId,
+			paper_size: form.preview.paperSize,
 		};
 
 		saveForm( setIsSaving, setSuccess, noop, setError, purchaseURL, nonce, 'POST', formData );

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -13,6 +13,7 @@ import _ from 'lodash';
 import printDocument from 'lib/utils/print-document';
 import * as NoticeActions from 'state/notices/actions';
 import getFormErrors from 'shipping-label/state/selectors/errors';
+import canPurchase from 'shipping-label/state/selectors/can-purchase';
 import { hasNonEmptyLeaves } from 'lib/utils/tree';
 import normalizeAddress from './normalize-address';
 import getRates from './get-rates';
@@ -252,12 +253,18 @@ export const confirmPackages = () => ( dispatch, getState, { getRatesURL, storeO
 	getLabelRates( dispatch, getState, handleResponse, { getRatesURL, nonce } );
 };
 
-export const updateRate = ( packageId, value ) => {
-	return {
+export const updateRate = ( packageId, value ) => ( dispatch, getState, context ) => {
+	const couldPurchase = canPurchase( getState(), context.storeOptions );
+
+	dispatch( {
 		type: UPDATE_RATE,
 		packageId,
 		value,
-	};
+	} );
+
+	if ( ! couldPurchase && canPurchase( getState(), context.storeOptions ) ) {
+		refreshPreview( dispatch, getState, context );
+	}
 };
 
 const refreshPreview = ( dispatch, getState, { labelPreviewURL, nonce } ) => {

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -9,6 +9,7 @@ import find from 'lodash/find';
 import isEmpty from 'lodash/isEmpty';
 import map from 'lodash/map';
 import every from 'lodash/every';
+import _ from 'lodash';
 import printDocument from 'lib/utils/print-document';
 import * as NoticeActions from 'state/notices/actions';
 import getFormErrors from 'shipping-label/state/selectors/errors';
@@ -17,6 +18,7 @@ import normalizeAddress from './normalize-address';
 import getRates from './get-rates';
 import { sprintf } from 'sprintf-js';
 import { translate as __ } from 'lib/mixins/i18n';
+import generatePDF from 'lib/pdf-label-generator';
 export const OPEN_PRINTING_FLOW = 'OPEN_PRINTING_FLOW';
 export const EXIT_PRINTING_FLOW = 'EXIT_PRINTING_FLOW';
 export const TOGGLE_STEP = 'TOGGLE_STEP';
@@ -28,6 +30,8 @@ export const EDIT_ADDRESS = 'EDIT_ADDRESS';
 export const CONFIRM_ADDRESS_SUGGESTION = 'CONFIRM_ADDRESS_SUGGESTION';
 export const UPDATE_PACKAGE_WEIGHT = 'UPDATE_PACKAGE_WEIGHT';
 export const UPDATE_RATE = 'UPDATE_RATE';
+export const UPDATE_PAPER_SIZE = 'UPDATE_PAPER_SIZE';
+export const UPDATE_PREVIEW = 'UPDATE_PREVIEW';
 export const PURCHASE_LABEL_REQUEST = 'PURCHASE_LABEL_REQUEST';
 export const PURCHASE_LABEL_RESPONSE = 'PURCHASE_LABEL_RESPONSE';
 export const RATES_RETRIEVAL_IN_PROGRESS = 'RATES_RETRIEVAL_IN_PROGRESS';
@@ -254,6 +258,25 @@ export const updateRate = ( packageId, value ) => {
 		packageId,
 		value,
 	};
+};
+
+export const updatePaperSize = ( value ) => ( dispatch, getState, { labelPreviewURL } ) => {
+	const form = getState().shippingLabel.form;
+	if ( form.preview.paperSize === value ) {
+		return;
+	}
+
+	dispatch( {
+		type: UPDATE_PAPER_SIZE,
+		value,
+	} );
+
+	let pckgIndex = 1;
+	const labels = _.map( form.packages.values, () => ( {
+		text: sprintf( __( 'Package %d (of %d)' ), pckgIndex++, Object.keys( form.packages.values ).length ).toUpperCase(),
+		imageURL: labelPreviewURL,
+	} ) );
+	generatePDF( value, labels ).then( ( url ) => dispatch( { type: UPDATE_PREVIEW, url } ) );
 };
 
 export const purchaseLabel = () => ( dispatch, getState, { purchaseURL, addressNormalizationURL, labelImageURL, nonce } ) => {

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -163,7 +163,9 @@ reducers[ UPDATE_RATE ] = ( state, { packageId, value } ) => {
 };
 
 reducers[ UPDATE_PAPER_SIZE ] = ( state, { value } ) => {
-	URL.revokeObjectURL( state.form.preview.labelPreviewURL );
+	if ( state.form.preview.labelPreviewURL ) {
+		URL.revokeObjectURL( state.form.preview.labelPreviewURL );
+	}
 	return { ...state,
 		paperSize: value,
 		form: { ...state.form,

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -165,9 +165,9 @@ reducers[ UPDATE_RATE ] = ( state, { packageId, value } ) => {
 reducers[ UPDATE_PAPER_SIZE ] = ( state, { value } ) => {
 	URL.revokeObjectURL( state.form.preview.labelPreviewURL );
 	return { ...state,
+		paperSize: value,
 		form: { ...state.form,
 			preview: { ...state.form.preview,
-				paperSize: value,
 				labelPreviewURL: null,
 			},
 		},

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -10,6 +10,8 @@ import {
 	CONFIRM_ADDRESS_SUGGESTION,
 	UPDATE_PACKAGE_WEIGHT,
 	UPDATE_RATE,
+	UPDATE_PAPER_SIZE,
+	UPDATE_PREVIEW,
 	PURCHASE_LABEL_REQUEST,
 	PURCHASE_LABEL_RESPONSE,
 	RATES_RETRIEVAL_IN_PROGRESS,
@@ -155,6 +157,28 @@ reducers[ UPDATE_RATE ] = ( state, { packageId, value } ) => {
 		form: { ...state.form,
 			rates: { ...state.form.rates,
 				values: newRates,
+			},
+		},
+	};
+};
+
+reducers[ UPDATE_PAPER_SIZE ] = ( state, { value } ) => {
+	URL.revokeObjectURL( state.form.preview.labelPreviewURL );
+	return { ...state,
+		form: { ...state.form,
+			preview: { ...state.form.preview,
+				paperSize: value,
+				labelPreviewURL: null,
+			},
+		},
+	};
+};
+
+reducers[ UPDATE_PREVIEW ] = ( state, { url } ) => {
+	return { ...state,
+		form: { ...state.form,
+			preview: { ...state.form.preview,
+				labelPreviewURL: url,
 			},
 		},
 	};

--- a/client/shipping-label/state/selectors/can-purchase.js
+++ b/client/shipping-label/state/selectors/can-purchase.js
@@ -7,6 +7,7 @@ export default createSelector(
 	getErrors,
 	( state ) => state.shippingLabel.form,
 	( errors, form ) => (
+		! _.isEmpty( form ) &&
 		! hasNonEmptyLeaves( errors ) &&
 		! form.origin.normalizationInProgress &&
 		! form.destination.normalizationInProgress &&

--- a/client/shipping-label/state/selectors/can-purchase.js
+++ b/client/shipping-label/state/selectors/can-purchase.js
@@ -1,0 +1,16 @@
+import { createSelector } from 'reselect';
+import { hasNonEmptyLeaves } from 'lib/utils/tree';
+import getErrors from './errors';
+import _ from 'lodash';
+
+export default createSelector(
+	getErrors,
+	( state ) => state.shippingLabel.form,
+	( errors, form ) => (
+		! hasNonEmptyLeaves( errors ) &&
+		! form.origin.normalizationInProgress &&
+		! form.destination.normalizationInProgress &&
+		! form.rates.retrievalInProgress &&
+		! _.isEmpty( form.rates.available )
+	)
+);

--- a/client/shipping-label/state/selectors/errors.js
+++ b/client/shipping-label/state/selectors/errors.js
@@ -45,18 +45,19 @@ const getPackagesErrors = ( values ) => mapValues( values, ( pckg ) => {
 
 const getRatesErrors = ( values ) => mapValues( values, ( ( rate ) => rate ? null : __( 'Please choose a rate' ) ) );
 
-const getPreviewErrors = ( previewData ) => {
+const getPreviewErrors = ( paperSize ) => {
 	const errors = {};
-	if ( ! previewData.paperSize ) {
+	if ( ! paperSize ) {
 		errors.paperSize = __( 'This field is required' );
 	}
 	return errors;
 };
 
 export default createSelector(
-	( state ) => state.shippingLabel.form,
+	( state ) => state.shippingLabel,
 	( state, { countriesData } ) => countriesData,
-	( form, countriesData ) => {
+	( shippingLabel, countriesData ) => {
+		const { form, paperSize } = shippingLabel;
 		if ( isEmpty( form ) ) {
 			return;
 		}
@@ -65,7 +66,7 @@ export default createSelector(
 			destination: getAddressErrors( form.destination, countriesData ),
 			packages: getPackagesErrors( form.packages.values ),
 			rates: getRatesErrors( form.rates.values ),
-			preview: getPreviewErrors( form.preview ),
+			preview: getPreviewErrors( paperSize ),
 		};
 	}
 );

--- a/client/shipping-label/state/selectors/errors.js
+++ b/client/shipping-label/state/selectors/errors.js
@@ -45,6 +45,14 @@ const getPackagesErrors = ( values ) => mapValues( values, ( pckg ) => {
 
 const getRatesErrors = ( values ) => mapValues( values, ( ( rate ) => rate ? null : __( 'Please choose a rate' ) ) );
 
+const getPreviewErrors = ( previewData ) => {
+	const errors = {};
+	if ( ! previewData.paperSize ) {
+		errors.paperSize = __( 'This field is required' );
+	}
+	return errors;
+};
+
 export default createSelector(
 	( state ) => state.shippingLabel.form,
 	( state, { countriesData } ) => countriesData,
@@ -57,7 +65,7 @@ export default createSelector(
 			destination: getAddressErrors( form.destination, countriesData ),
 			packages: getPackagesErrors( form.packages.values ),
 			rates: getRatesErrors( form.rates.values ),
-			preview: {},
+			preview: getPreviewErrors( form.preview ),
 		};
 	}
 );

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -13,6 +13,7 @@ import * as ShippingLabelActions from 'shipping-label/state/actions';
 import notices from 'notices';
 import GlobalNotices from 'components/global-notices';
 import getFormErrors from 'shipping-label/state/selectors/errors';
+import canPurchase from 'shipping-label/state/selectors/can-purchase';
 
 let labelsStatusUpdateTriggered = false;
 
@@ -110,6 +111,7 @@ function mapStateToProps( state, { storeOptions } ) {
 	return {
 		shippingLabel: state.shippingLabel,
 		errors: getFormErrors( state, storeOptions ),
+		canPurchase: canPurchase( state, storeOptions ),
 	};
 }
 

--- a/client/shipping-label/views/purchase/index.js
+++ b/client/shipping-label/views/purchase/index.js
@@ -56,8 +56,7 @@ const PrintLabelDialog = ( props ) => {
 						<PreviewStep
 							{ ...props }
 							{ ...props.form.preview }
-							errors={ props.errors.preview }
-							showPreview={ props.canPurchase } />
+							errors={ props.errors.preview } />
 					</div>
 				</div>
 				<ActionButtons buttons={ [

--- a/client/shipping-label/views/purchase/index.js
+++ b/client/shipping-label/views/purchase/index.js
@@ -6,19 +6,11 @@ import AddressStep from './steps/address';
 import PackagesStep from './steps/packages';
 import RatesStep from './steps/rates';
 import PreviewStep from './steps/preview';
-import { hasNonEmptyLeaves } from 'lib/utils/tree';
 import { sprintf } from 'sprintf-js';
-import isEmpty from 'lodash/isEmpty';
 import { getRatesTotal } from 'shipping-label/state/selectors/rates';
 
 const PrintLabelDialog = ( props ) => {
 	const currencySymbol = props.storeOptions.currency_symbol;
-
-	const canPurchase = ! hasNonEmptyLeaves( props.errors ) &&
-		! props.form.origin.normalizationInProgress &&
-		! props.form.destination.normalizationInProgress &&
-		! props.form.rates.retrievalInProgress &&
-		! isEmpty( props.form.rates.available );
 
 	const getPurchaseButtonLabel = () => {
 		let label = __( 'Buy & Print' );
@@ -26,7 +18,7 @@ const PrintLabelDialog = ( props ) => {
 		if ( nPackages ) {
 			label += ' ' + ( 1 === nPackages ? __( '1 Label' ) : sprintf( __( '%d Labels' ), nPackages ) );
 		}
-		if ( canPurchase ) {
+		if ( props.canPurchase ) {
 			label += ' (' + currencySymbol + getRatesTotal( props.form.rates ) + ')';
 		}
 		return label;
@@ -65,12 +57,12 @@ const PrintLabelDialog = ( props ) => {
 							{ ...props }
 							{ ...props.form.preview }
 							errors={ props.errors.preview }
-							showPreview={ canPurchase }/>
+							showPreview={ props.canPurchase } />
 					</div>
 				</div>
 				<ActionButtons buttons={ [
 					{
-						isDisabled: ! canPurchase || props.form.isSubmitting,
+						isDisabled: ! props.canPurchase || props.form.isSubmitting,
 						onClick: props.labelActions.purchaseLabel,
 						isPrimary: true,
 						label: getPurchaseButtonLabel(),

--- a/client/shipping-label/views/purchase/steps/preview/index.js
+++ b/client/shipping-label/views/purchase/steps/preview/index.js
@@ -1,19 +1,41 @@
 import React, { PropTypes } from 'react';
 import { translate as __ } from 'lib/mixins/i18n';
+import Dropdown from 'components/dropdown';
+import Spinner from 'components/spinner';
+import { PAPER_SIZES } from 'lib/pdf-label-generator';
+import _ from 'lodash';
 
-const PreviewStep = ( { labelPreviewURL, showPreview } ) => {
+const PreviewStep = ( { labelPreviewURL, showPreview, paperSize, labelActions, errors } ) => {
+	let preview = null;
+	if ( showPreview ) {
+		if ( labelPreviewURL ) {
+			preview = <iframe src={ labelPreviewURL } />;
+		} else {
+			preview = <Spinner size={ 24 } />;
+		}
+	}
+
+	const paperSizeOptions = _.mapValues( PAPER_SIZES, ( value, key ) => key );
+
 	return (
 		<div>
 			<span className="preview-title">{ __( 'Preview' ) }</span>
 			<div className="preview-placeholder">
-				{ showPreview && <img src={ labelPreviewURL } /> }
+				{ preview }
 			</div>
+			<Dropdown
+				id={ 'paper_size' }
+				valuesMap={ { '': __( 'Select one...' ), ...paperSizeOptions } }
+				title={ __( 'Paper size' ) }
+				value={ paperSize }
+				updateValue={ labelActions.updatePaperSize }
+				error={ errors.paperSize } />
 		</div>
 	);
 };
 
 PreviewStep.propTypes = {
-	labelPreviewURL: PropTypes.string.isRequired,
+	labelPreviewURL: PropTypes.string,
 	showPreview: PropTypes.bool.isRequired,
 };
 

--- a/client/shipping-label/views/purchase/steps/preview/index.js
+++ b/client/shipping-label/views/purchase/steps/preview/index.js
@@ -5,9 +5,9 @@ import Spinner from 'components/spinner';
 import { PAPER_SIZES } from 'lib/pdf-label-generator';
 import _ from 'lodash';
 
-const PreviewStep = ( { labelPreviewURL, showPreview, paperSize, labelActions, errors } ) => {
+const PreviewStep = ( { labelPreviewURL, canPurchase, paperSize, labelActions, errors } ) => {
 	let preview = null;
-	if ( showPreview ) {
+	if ( canPurchase ) {
 		if ( labelPreviewURL ) {
 			preview = <iframe src={ labelPreviewURL } />;
 		} else {
@@ -34,7 +34,7 @@ const PreviewStep = ( { labelPreviewURL, showPreview, paperSize, labelActions, e
 
 PreviewStep.propTypes = {
 	labelPreviewURL: PropTypes.string,
-	showPreview: PropTypes.bool.isRequired,
+	canPurchase: PropTypes.bool.isRequired,
 };
 
 export default PreviewStep;

--- a/client/shipping-label/views/purchase/steps/preview/index.js
+++ b/client/shipping-label/views/purchase/steps/preview/index.js
@@ -15,8 +15,6 @@ const PreviewStep = ( { labelPreviewURL, showPreview, paperSize, labelActions, e
 		}
 	}
 
-	const paperSizeOptions = _.mapValues( PAPER_SIZES, ( value, key ) => key );
-
 	return (
 		<div>
 			<span className="preview-title">{ __( 'Preview' ) }</span>
@@ -25,7 +23,7 @@ const PreviewStep = ( { labelPreviewURL, showPreview, paperSize, labelActions, e
 			</div>
 			<Dropdown
 				id={ 'paper_size' }
-				valuesMap={ { '': __( 'Select one...' ), ...paperSizeOptions } }
+				valuesMap={ { '': __( 'Select one...' ), ..._.mapValues( PAPER_SIZES, 'name' ) } }
 				title={ __( 'Paper size' ) }
 				value={ paperSize }
 				updateValue={ labelActions.updatePaperSize }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -244,6 +244,44 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "dev": true
     },
+    "ast-transform": {
+      "version": "0.0.0",
+      "from": "ast-transform@0.0.0",
+      "resolved": "https://registry.npmjs.org/ast-transform/-/ast-transform-0.0.0.tgz",
+      "dependencies": {
+        "escodegen": {
+          "version": "1.2.0",
+          "from": "escodegen@>=1.2.0 <1.3.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.2.0.tgz"
+        },
+        "esprima": {
+          "version": "1.0.4",
+          "from": "esprima@>=1.0.4 <1.1.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+        },
+        "estraverse": {
+          "version": "1.5.1",
+          "from": "estraverse@~1.5.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+        },
+        "esutils": {
+          "version": "1.0.0",
+          "from": "esutils@~1.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@~0.1.30",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "optional": true
+        }
+      }
+    },
+    "ast-types": {
+      "version": "0.7.8",
+      "from": "ast-types@>=0.7.0 <0.8.0",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz"
+    },
     "async": {
       "version": "2.0.1",
       "from": "async@>=2.0.0 <3.0.0",
@@ -735,8 +773,7 @@
     "base64-js": {
       "version": "1.2.0",
       "from": "base64-js@^1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
     },
     "base64id": {
       "version": "0.1.0",
@@ -749,6 +786,13 @@
       "from": "batch@^0.5.3",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
       "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.0",
+      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+      "dev": true,
+      "optional": true
     },
     "benchmark": {
       "version": "1.0.0",
@@ -790,8 +834,12 @@
     "blob": {
       "version": "0.0.4",
       "from": "blob@0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
+    },
+    "blob-stream": {
+      "version": "0.1.3",
+      "from": "blob-stream@latest",
+      "resolved": "https://registry.npmjs.org/blob-stream/-/blob-stream-0.1.3.tgz"
     },
     "block-stream": {
       "version": "0.0.9",
@@ -836,6 +884,26 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "dev": true
     },
+    "brfs": {
+      "version": "1.4.3",
+      "from": "brfs@>=1.4.3 <1.5.0",
+      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.4.3.tgz"
+    },
+    "brotli": {
+      "version": "1.3.1",
+      "from": "brotli@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.1.tgz"
+    },
+    "browser-resolve": {
+      "version": "1.11.2",
+      "from": "browser-resolve@>=1.8.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
+    },
+    "browserify-optional": {
+      "version": "1.0.0",
+      "from": "browserify-optional@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-optional/-/browserify-optional-1.0.0.tgz"
+    },
     "browserify-zlib": {
       "version": "0.1.4",
       "from": "browserify-zlib@~0.1.4",
@@ -859,6 +927,11 @@
       "from": "buffer-crc32@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
       "dev": true
+    },
+    "buffer-equal": {
+      "version": "0.0.1",
+      "from": "buffer-equal@0.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
     },
     "buffer-shims": {
       "version": "1.0.0",
@@ -1028,8 +1101,7 @@
     "clone": {
       "version": "1.0.2",
       "from": "clone@^1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
     },
     "co": {
       "version": "4.6.0",
@@ -1250,8 +1322,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "from": "core-util-is@~1.0.0",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "crc32-stream": {
       "version": "1.0.0",
@@ -1407,6 +1478,11 @@
         }
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "from": "deep-equal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+    },
     "deep-is": {
       "version": "0.1.3",
       "from": "deep-is@~0.1.3",
@@ -1493,6 +1569,30 @@
       "version": "0.8.3",
       "from": "dompurify@>=0.8.0 <0.9.0",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-0.8.3.tgz"
+    },
+    "duplexer2": {
+      "version": "0.0.2",
+      "from": "duplexer2@>=0.0.2 <0.1.0",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.9 <1.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "dev": true,
+      "optional": true
     },
     "ee-first": {
       "version": "1.1.1",
@@ -1658,6 +1758,13 @@
           "from": "estraverse@>=1.9.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "from": "source-map@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -1882,6 +1989,23 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "dev": true
     },
+    "falafel": {
+      "version": "1.2.0",
+      "from": "falafel@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "1.2.2",
+          "from": "acorn@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        }
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.5",
       "from": "fast-levenshtein@~2.0.4",
@@ -2000,6 +2124,11 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "dev": true
     },
+    "fontkit": {
+      "version": "1.4.2",
+      "from": "fontkit@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.4.2.tgz"
+    },
     "for-in": {
       "version": "0.1.6",
       "from": "for-in@^0.1.5",
@@ -2011,6 +2140,11 @@
       "from": "for-own@^0.1.3",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
       "dev": true
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "from": "foreach@>=2.0.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2051,8 +2185,7 @@
     "function-bind": {
       "version": "1.1.0",
       "from": "function-bind@^1.0.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
     },
     "gauge": {
       "version": "2.6.0",
@@ -2202,8 +2335,7 @@
     "has": {
       "version": "1.0.1",
       "from": "has@^1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -2435,8 +2567,7 @@
     "inherits": {
       "version": "2.0.3",
       "from": "inherits@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "inquirer": {
       "version": "0.12.0",
@@ -2636,8 +2767,7 @@
     "isarray": {
       "version": "1.0.0",
       "from": "isarray@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
     "isbinaryfile": {
       "version": "3.0.1",
@@ -2893,6 +3023,13 @@
       "from": "jade-walk@>=0.0.3 <0.0.4",
       "resolved": "https://registry.npmjs.org/jade-walk/-/jade-walk-0.0.3.tgz"
     },
+    "jodid25519": {
+      "version": "1.0.2",
+      "from": "jodid25519@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "dev": true,
+      "optional": true
+    },
     "js-base64": {
       "version": "2.1.9",
       "from": "js-base64@^2.1.9",
@@ -2914,6 +3051,13 @@
       "from": "js-yaml@~3.6.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "dev": true
+    },
+    "jsbn": {
+      "version": "0.1.0",
+      "from": "jsbn@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+      "dev": true,
+      "optional": true
     },
     "jsdom": {
       "version": "9.2.1",
@@ -3158,6 +3302,18 @@
       "from": "levn@^0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "dev": true
+    },
+    "linebreak": {
+      "version": "0.1.2",
+      "from": "linebreak@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-0.1.2.tgz",
+      "dependencies": {
+        "unicode-trie": {
+          "version": "0.1.2",
+          "from": "unicode-trie@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-0.1.2.tgz"
+        }
+      }
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -3758,6 +3914,16 @@
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "dev": true
     },
+    "object-inspect": {
+      "version": "0.4.0",
+      "from": "object-inspect@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz"
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "from": "object-keys@>=1.0.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+    },
     "object-path-immutable": {
       "version": "0.4.0",
       "from": "object-path-immutable@>=0.4.0 <0.5.0",
@@ -3882,8 +4048,7 @@
     "pako": {
       "version": "0.2.9",
       "from": "pako@~0.2.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
     },
     "parse-glob": {
       "version": "3.0.4",
@@ -3979,6 +4144,11 @@
       "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
       "dev": true
     },
+    "pdfkit": {
+      "version": "0.8.0",
+      "from": "pdfkit@latest",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.8.0.tgz"
+    },
     "pify": {
       "version": "2.3.0",
       "from": "pify@^2.0.0",
@@ -4008,6 +4178,11 @@
       "from": "pluralize@^1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "dev": true
+    },
+    "png-js": {
+      "version": "0.1.1",
+      "from": "png-js@>=0.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-0.1.1.tgz"
     },
     "postcss": {
       "version": "5.2.4",
@@ -4281,8 +4456,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "from": "process-nextick-args@~1.0.6",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "progress": {
       "version": "1.1.8",
@@ -4354,6 +4528,11 @@
       "from": "querystringify@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
       "dev": true
+    },
+    "quote-stream": {
+      "version": "1.0.2",
+      "from": "quote-stream@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz"
     },
     "randomatic": {
       "version": "1.1.5",
@@ -4590,6 +4769,11 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "dev": true
     },
+    "restructure": {
+      "version": "0.5.3",
+      "from": "restructure@>=0.5.2 <0.6.0",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-0.5.3.tgz"
+    },
     "right-align": {
       "version": "0.1.3",
       "from": "right-align@^0.1.1",
@@ -4698,6 +4882,11 @@
       "from": "sha.js@2.2.6",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
       "dev": true
+    },
+    "shallow-copy": {
+      "version": "0.0.1",
+      "from": "shallow-copy@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -4904,6 +5093,108 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
       "dev": true
     },
+    "static-eval": {
+      "version": "0.2.4",
+      "from": "static-eval@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
+      "dependencies": {
+        "escodegen": {
+          "version": "0.0.28",
+          "from": "escodegen@>=0.0.24 <0.1.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz"
+        },
+        "esprima": {
+          "version": "1.0.4",
+          "from": "esprima@>=1.0.2 <1.1.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+        },
+        "estraverse": {
+          "version": "1.3.2",
+          "from": "estraverse@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz"
+        }
+      }
+    },
+    "static-module": {
+      "version": "1.3.1",
+      "from": "static-module@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.3.1.tgz",
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.4.10",
+          "from": "concat-stream@>=1.4.5 <1.5.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.14",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+            }
+          }
+        },
+        "escodegen": {
+          "version": "1.3.3",
+          "from": "escodegen@>=1.3.2 <1.4.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz"
+        },
+        "esprima": {
+          "version": "1.1.1",
+          "from": "esprima@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz"
+        },
+        "estraverse": {
+          "version": "1.5.1",
+          "from": "estraverse@>=1.5.0 <1.6.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+        },
+        "esutils": {
+          "version": "1.0.0",
+          "from": "esutils@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "from": "object-keys@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+        },
+        "quote-stream": {
+          "version": "0.0.0",
+          "from": "quote-stream@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "readable-stream@>=1.0.27-1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@>=0.1.33 <0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "optional": true
+        },
+        "through2": {
+          "version": "0.4.2",
+          "from": "through2@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz"
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "from": "xtend@>=2.1.1 <2.2.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
+        }
+      }
+    },
     "statuses": {
       "version": "1.3.0",
       "from": "statuses@>= 1.3.0 < 2",
@@ -4945,8 +5236,7 @@
     "string_decoder": {
       "version": "0.10.31",
       "from": "string_decoder@~0.10.x",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "string-width": {
       "version": "1.0.2",
@@ -5076,14 +5366,30 @@
     "through": {
       "version": "2.3.8",
       "from": "through@^2.3.6",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+    },
+    "through2": {
+      "version": "2.0.1",
+      "from": "through2@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.0.6",
+          "from": "readable-stream@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+        }
+      }
     },
     "timers-browserify": {
       "version": "1.4.2",
       "from": "timers-browserify@^1.0.1",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "dev": true
+    },
+    "tiny-inflate": {
+      "version": "1.0.2",
+      "from": "tiny-inflate@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.2.tgz"
     },
     "to-array": {
       "version": "0.1.4",
@@ -5119,6 +5425,11 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "dev": true
     },
+    "transform-loader": {
+      "version": "0.2.3",
+      "from": "transform-loader@latest",
+      "resolved": "https://registry.npmjs.org/transform-loader/-/transform-loader-0.2.3.tgz"
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "from": "trim-newlines@^1.0.0",
@@ -5143,6 +5454,13 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "dev": true
     },
+    "tweetnacl": {
+      "version": "0.14.3",
+      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+      "dev": true,
+      "optional": true
+    },
     "type-check": {
       "version": "0.3.2",
       "from": "type-check@~0.3.2",
@@ -5164,8 +5482,7 @@
     "typedarray": {
       "version": "0.0.6",
       "from": "typedarray@~0.0.5",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "ua-parser-js": {
       "version": "0.7.10",
@@ -5225,6 +5542,16 @@
       "from": "underscore@>=1.6.0 <1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
       "dev": true
+    },
+    "unicode-properties": {
+      "version": "1.1.0",
+      "from": "unicode-properties@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.1.0.tgz"
+    },
+    "unicode-trie": {
+      "version": "0.3.1",
+      "from": "unicode-trie@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-0.3.1.tgz"
     },
     "uniq": {
       "version": "1.0.1",
@@ -5320,8 +5647,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "from": "util-deprecate@~1.0.1",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "utils-merge": {
       "version": "1.0.0",
@@ -9124,6 +9450,36 @@
               "version": "1.0.0",
               "from": "assert-plus@1.0.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.0",
+              "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+              "optional": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+              "optional": true
+            },
+            "jodid25519": {
+              "version": "1.0.2",
+              "from": "jodid25519@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+              "optional": true
+            },
+            "jsbn": {
+              "version": "0.1.0",
+              "from": "jsbn@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+              "optional": true
+            },
+            "tweetnacl": {
+              "version": "0.14.3",
+              "from": "tweetnacl@>=0.14.0 <0.15.0",
+              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+              "optional": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
+    "blob-stream": "^0.1.3",
+    "brfs": "^1.4.3",
     "classnames": "^2.2.5",
     "debug": "2.2.0",
     "dompurify": "^0.8.0",
@@ -81,6 +83,7 @@
     "lodash": "4.13.1",
     "object-path-immutable": "^0.4.0",
     "objectpath": "^1.2.1",
+    "pdfkit": "^0.8.0",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "react-redux": "^4.4.1",
@@ -88,6 +91,7 @@
     "redux-thunk": "^2.1.0",
     "reselect": "^2.5.1",
     "sprintf-js": "1.0.3",
+    "transform-loader": "^0.2.3",
     "wp-calypso": "github:automattic/wp-calypso"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,6 +44,7 @@ module.exports = {
 			{
 				test: /\.jsx?$/,
 				loaders: [
+					'transform/cacheable?brfs',
 					'babel?' + JSON.stringify( babelSettings ),
 					'eslint'
 				],


### PR DESCRIPTION
This PR includes:
* PDF generation client-side using the `pdfkit` library.
* UI changes needed (adding a `Paper size` selector to the Labels UI, and remembering that selection).
* Completely generate the PDFs client-side, both for Preview, Purchase and Reprint labels.
* "Smarts" built-in: automatically put 2 labels in 1 page if they fit.

This doesn't work in IE/Edge, and there is no way to make it work. Hopefully I'll be able to reuse most of the code for re-implementing this server-side.

Note: You'll need also the `try/pdf-manipulation` server branch to try this.