### PR TITLE
Rename /shipping/label/image/{id} to /shipping/label/{id}/image

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -203,7 +203,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		public function get_label_image( $label_id ) {
 			$url = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL );
 			$url = apply_filters( 'wc_connect_server_url', $url );
-			$url = trailingslashit( $url ) . 'shipping/label/image/' . $label_id;
+			$url = trailingslashit( $url ) . "shipping/label/{$label_id}/image";
 
 			$headers = $this->request_headers();
 			if ( is_wp_error( $headers ) ) {


### PR DESCRIPTION
Fixes #609

This renames the endpoint to something that is more syntactically correct. `/label/{label-id}/image` is more correct than `/label/image/{label-id}`.

To test:
- Test with: https://github.com/Automattic/woocommerce-connect-server/pull/579
- Try to buy a label, make sure you can print and reprint the cached label image

@allendav @jeffstieler @DanReyLop @robobot3000 

