### PR TITLE
Remove the "isError" prop for FormTextarea, since it isn't supported

### DIFF
--- a/client/components/text-area/index.js
+++ b/client/components/text-area/index.js
@@ -19,7 +19,6 @@ const TextArea = ( { id, readonly, title, description, value, placeholder, updat
 				readOnly={ readonly }
 				value={ value }
 				onChange={ handleChangeEvent }
-				isError={ Boolean( error ) }
 			/>
 			{ error ? <FieldError text={ error } /> : <FieldDescription text={ description } /> }
 		</FormFieldset>


### PR DESCRIPTION
Fixes #630

The `isError` prop was being passed to the Calypso `<FormTextarea>` component, but since it was always `undefined`, it was being ignored (yay, Javascript!). With a recent fix that made all the `isError` props be `Boolean`, this warning slipped through.

To test:
* Go to the Self-Help page.
* Check there are no errors on the console and the Log textarea shows fine.

@allendav @jeffstieler @robobot3000 @nabsul 