### PR TITLE
Only load the Babel polyfill if there hasn't already been loaded

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -1,3 +1,7 @@
+if ( ! global._babelPolyfill ) {
+	require( 'babel-polyfill' );
+}
+
 /*global wcConnectData */
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
 	babelSettings,
 	cache: true,
 	entry: {
-		'woocommerce-connect-client': [ 'babel-polyfill', './client/main.js' ],
+		'woocommerce-connect-client': [ './client/main.js' ],
 	},
 	output: {
 		path: path.join( __dirname, 'dist' ),


### PR DESCRIPTION
Fixes #634 

This issue is caused by a pre-condition check in `babel-polyfill` ([here](https://github.com/babel/babel/blob/de975b9660014a4533c90190b297352495636530/packages/babel-polyfill/src/index.js#L4)). Since the polyfill modifies the global scope (needed for adding methods to built-in types like `Array`, `Object`, etc), it has a check to make sure that it's loaded only once. Since virtually all React-based apps use babel + polyfill, that means 2 React apps can't coexist in the same page, at least without the work-around in this PR.

The risk of this PR is that the polyfill that runs first may be a different version that the one bundled in our app, so we would not be in total control of our environment, but that's always a risk when we develop for a platform like WordPress :)

To test:
* Install and activate a React-based plug-in, such as @nabsul's [Sift Science](https://wordpress.org/plugins/fermiac-siftscience-for-woocommerce/)
* Go to an order page (with both the Sift Science meta-box and the Shipping Labels meta-box).
* Check that both plug-ins load.

@allendav @nabsul @jeffstieler @robobot3000 
@coderkevin You should take a look too. I would argue that all React-based apps that are made to run in only part of a page should include this workaround.