### PR TITLE
Omitting the box_id field when purchasing a label

### DIFF
--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -294,7 +294,7 @@ export const purchaseLabel = () => ( dispatch, getState, { purchaseURL, addressN
 			origin: form.origin.selectNormalized ? form.origin.normalized : form.origin.values,
 			destination: form.destination.selectNormalized ? form.destination.normalized : form.destination.values,
 			packages: _.map( form.packages.values, ( pckg, pckgId ) => ( {
-				..._.omit( pckg, [ 'items', 'id' ] ),
+				..._.omit( pckg, [ 'items', 'id', 'box_id' ] ),
 				service_id: form.rates.values[ pckgId ],
 				service_name: _.find( form.rates.available[ pckgId ].rates, { service_id: form.rates.values[ pckgId ] } ).title,
 				products: _.flatten( pckg.items.map( ( item ) => _.fill( new Array( item.quantity ), item.product_id ) ) ),


### PR DESCRIPTION
Fixes the server's issue Automattic/woocommerce-connect-server#582 by handling the `box_id` field in the same way as the other unwanted fields.

CC @nabsul 