### PR TITLE
Editable packaging solution

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -166,9 +166,21 @@
 			@include breakpoint( ">480px" ) {
 				top: 10%;
 				right: calc(50% - 250px);
-				bottom: 10%;
+				bottom: 40%;
 				left: calc(50% - 250px);
 				width: 500px;
+			}
+		}
+
+		&.wcc-label-packages-dialog {
+			top: -46px;
+
+			@include breakpoint( ">480px" ) {
+				top: 10%;
+				right: calc(50% - 200px);
+				bottom: 10%;
+				left: calc(50% - 200px);
+				width: 400px;
 			}
 		}
 

--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -80,7 +80,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			return sprintf( '%s - %s', $identifier, $product->get_title() );
 		}
 
-		protected function get_packages( WC_Order $order ) {
+		protected function get_selected_packages(WC_Order $order ) {
 			$packages = $this->get_packaging_metadata( $order );
 			if ( ! $packages ) {
 				return $this->get_items_as_individual_packages( $order );
@@ -105,6 +105,23 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 					}
 					$formatted_packages[ $package_id ][ 'items' ][ $item_index ] = $product_data;
 				}
+			}
+
+			return $formatted_packages;
+		}
+
+		protected function get_all_packages() {
+			$packages = $this->settings_store->get_packages();
+
+			if ( ! $packages ) {
+				return new stdClass();
+			}
+
+			$formatted_packages = array();
+
+			foreach( $packages as $package ) {
+				$package_id = $package[ 'name' ];
+				$formatted_packages[ $package_id ] = $package;
 			}
 
 			return $formatted_packages;
@@ -166,17 +183,18 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 		}
 
 		protected function get_form_data( WC_Order $order ) {
-			$packages        = $this->get_packages( $order );
-			$is_packed       = ( false !== $this->get_packaging_metadata( $order ) );
-			$origin          = $this->get_origin_address();
-			$selected_rates  = $this->get_selected_rates( $order );
-			$destination     = $this->get_destination_address( $order );
+			$selected_packages = $this->get_selected_packages( $order );
+			$all_packages      = $this->get_all_packages();
+			$is_packed         = ( false !== $this->get_packaging_metadata( $order ) );
+			$origin            = $this->get_origin_address();
+			$selected_rates    = $this->get_selected_rates( $order );
+			$destination       = $this->get_destination_address( $order );
 
 			if ( ! $destination[ 'country' ] ) {
 				$destination[ 'country' ] = $origin[ 'country' ];
 			}
 
-			$form_data = compact( 'is_packed', 'packages', 'origin', 'destination' );
+			$form_data = compact( 'is_packed', 'selected_packages', 'all_packages', 'origin', 'destination' );
 
 			$form_data[ 'rates' ] = array(
 				'selected'  => (object) $selected_rates,

--- a/client/lib/utils/get-box-dimensions.js
+++ b/client/lib/utils/get-box-dimensions.js
@@ -1,0 +1,12 @@
+export default ( box ) => {
+	let dimensions;
+	if ( box.outer_dimensions ) {
+		dimensions = box.outer_dimensions.match( /([-.0-9]+).+?([-.0-9]+).+?([-.0-9]+)/ );
+	} else {
+		dimensions = box.inner_dimensions.match( /([-.0-9]+).+?([-.0-9]+).+?([-.0-9]+)/ );
+	}
+
+	const [ length, width, height ] = dimensions.slice( 1 ).map( Number );
+
+	return { length, width, height };
+};

--- a/client/shipping-label/index.js
+++ b/client/shipping-label/index.js
@@ -45,8 +45,11 @@ export default ( { formData, labelsData, storeOptions, labelPreviewURL } ) => ( 
 						allowChangeCountry: false,
 					},
 					packages: {
-						values: formData.packages,
+						all: formData.all_packages,
+						selected: formData.selected_packages,
+						unpacked: [],
 						isPacked: formData.is_packed,
+						saved: true,
 					},
 					rates: {
 						values: _.isEmpty( formData.rates.selected ) ? _.mapValues( formData.packages, () => ( '' ) ) : formData.rates.selected,
@@ -57,6 +60,7 @@ export default ( { formData, labelsData, storeOptions, labelPreviewURL } ) => ( 
 						labelPreviewURL,
 					},
 				},
+				openedPackageId: labelsData ? '' : Object.keys( formData.selected_packages )[ 0 ] || '',
 			},
 		};
 	},

--- a/client/shipping-label/state/selectors/errors.js
+++ b/client/shipping-label/state/selectors/errors.js
@@ -54,7 +54,7 @@ export default createSelector(
 		return {
 			origin: getAddressErrors( form.origin, countriesData ),
 			destination: getAddressErrors( form.destination, countriesData ),
-			packages: getPackagesErrors( form.packages.values ),
+			packages: getPackagesErrors( form.packages.selected ),
 			rates: getRatesErrors( form.rates.values ),
 			preview: {},
 		};

--- a/client/shipping-label/state/test/reducer.js
+++ b/client/shipping-label/state/test/reducer.js
@@ -1,0 +1,224 @@
+import reducer from '../reducer';
+import {
+	moveItem,
+	addPackage,
+	removePackage,
+	setPackageType,
+	savePackages,
+} from '../actions';
+import hoek from 'hoek';
+
+const initialState = {
+	form: {
+		packages: {
+			all: {
+				customPackage1: {
+					inner_dimensions: '1 x 2 x 3',
+					box_weight: 3.5,
+				},
+				customPackage2: {},
+			},
+			selected: {
+				weight_0_custom1: {
+					items: [
+						{
+							product_id: 123,
+							weight: 1.2,
+						},
+					],
+				},
+				weight_1_custom1: {
+					items: [
+						{
+							product_id: 456,
+							weight: 2.3,
+						},
+					],
+				},
+			},
+			unpacked: [],
+			isPacked: true,
+		},
+	},
+	openedPackageId: 'weight_0_custom1',
+};
+
+describe( 'Label purchase form reducer', () => {
+	let stateBefore;
+
+	beforeEach( () => {
+		stateBefore = hoek.clone( initialState );
+	} );
+
+	afterEach( () => {
+		// make sure the state hasn't been mutated
+		// after each test
+		expect( initialState ).to.eql( stateBefore );
+	} );
+
+	it( 'MOVE_ITEM moves items between selected packages', () => {
+		const action = moveItem( 'weight_0_custom1', 0, 'weight_1_custom1' );
+		const state = reducer( initialState, action );
+
+		expect( state.form.packages.selected.weight_0_custom1.items.length ).to.eql( 0 );
+		expect( state.form.packages.selected.weight_1_custom1.items.length ).to.eql( 2 );
+		expect( state.form.packages.selected.weight_1_custom1.items ).to.include( initialState.form.packages.selected.weight_0_custom1.items[ 0 ] );
+		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.rates.available ).to.eql( {} );
+	} );
+
+	it( 'MOVE_ITEM moves items from selected packages to original packaging', () => {
+		const action = moveItem( 'weight_0_custom1', 0, 'individual' );
+		const state = reducer( initialState, action );
+
+		expect( state.form.packages.selected.weight_0_custom1.items.length ).to.eql( 0 );
+		expect( state.form.packages.selected ).to.include.keys( 'client_individual_0' );
+		expect( state.form.packages.selected.client_individual_0.box_id ).to.eql( 'individual' );
+		expect( state.form.packages.selected.client_individual_0.items.length ).to.eql( 1 );
+		expect( state.form.packages.selected.client_individual_0.items ).to.include( initialState.form.packages.selected.weight_0_custom1.items[ 0 ] );
+		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.rates.available ).to.eql( {} );
+	} );
+
+	it( 'MOVE_ITEM moves items from selected packages to saved for later', () => {
+		const action = moveItem( 'weight_0_custom1', 0, '' );
+		const state = reducer( initialState, action );
+
+		expect( state.form.packages.selected.weight_0_custom1.items.length ).to.eql( 0 );
+		expect( state.form.packages.unpacked.length ).to.eql( 1 );
+		expect( state.form.packages.unpacked ).to.include( initialState.form.packages.selected.weight_0_custom1.items[ 0 ] );
+		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.rates.available ).to.eql( {} );
+	} );
+
+	it( 'MOVE_ITEM moves items from saved for later to selected packages', () => {
+		const existingState = hoek.clone( initialState );
+		existingState.form.packages.unpacked.push( {
+			product_id: 789,
+		} );
+
+		const action = moveItem( '', 0, 'weight_0_custom1' );
+		const state = reducer( existingState, action );
+
+		expect( state.form.packages.unpacked.length ).to.eql( 0 );
+		expect( state.form.packages.selected.weight_0_custom1.items.length ).to.eql( 2 );
+		expect( state.form.packages.selected.weight_0_custom1.items ).to.include( existingState.form.packages.unpacked[ 0 ] );
+		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.rates.available ).to.eql( {} );
+	} );
+
+	it( 'MOVE_ITEM moves items from saved for later to original packaging', () => {
+		const existingState = hoek.clone( initialState );
+		existingState.form.packages.unpacked.push( {
+			product_id: 789,
+		} );
+
+		const action = moveItem( '', 0, 'individual' );
+		const state = reducer( existingState, action );
+
+		expect( state.form.packages.unpacked.length ).to.eql( 0 );
+		expect( state.form.packages.selected ).to.include.keys( 'client_individual_0' );
+		expect( state.form.packages.selected.client_individual_0.box_id ).to.eql( 'individual' );
+		expect( state.form.packages.selected.client_individual_0.items.length ).to.eql( 1 );
+		expect( state.form.packages.selected.client_individual_0.items ).to.include( existingState.form.packages.unpacked[ 0 ] );
+		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.rates.available ).to.eql( {} );
+	} );
+
+	it( 'MOVE_ITEM moves items from original packaging to selected packages and deletes original package', () => {
+		const existingState = hoek.clone( initialState );
+		existingState.form.packages.selected.client_individual_0 = {
+			items: [ {
+				product_id: 789,
+			} ],
+			box_id: 'individual',
+		};
+		existingState.openedPackageId = 'client_individual_0';
+
+		const action = moveItem( 'client_individual_0', 0, 'weight_0_custom1' );
+		const state = reducer( existingState, action );
+
+		expect( state.form.packages.selected.weight_0_custom1.items.length ).to.eql( 2 );
+		expect( state.form.packages.selected.weight_0_custom1.items ).to.include( existingState.form.packages.selected.client_individual_0.items[ 0 ] );
+		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.form.rates.available ).to.eql( {} );
+	} );
+
+	it( 'MOVE_ITEM moves items from original packaging to saved for later and deletes original package', () => {
+		const existingState = hoek.clone( initialState );
+		existingState.form.packages.selected.client_individual_0 = {
+			items: [ {
+				product_id: 789,
+			} ],
+			box_id: 'individual',
+		};
+		existingState.openedPackageId = 'client_individual_0';
+
+		const action = moveItem( 'client_individual_0', 0, '' );
+		const state = reducer( existingState, action );
+
+		expect( state.form.packages.unpacked.length ).to.eql( 1 );
+		expect( state.form.packages.unpacked ).to.include( existingState.form.packages.selected.client_individual_0.items[ 0 ] );
+		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.form.rates.available ).to.eql( {} );
+	} );
+
+	it( 'ADD_PACKAGE adds a new package', () => {
+		const action = addPackage();
+		const state = reducer( initialState, action );
+
+		expect( state.form.packages.selected ).to.include.keys( 'client_custom_0' );
+		expect( state.form.packages.selected.client_custom_0.items.length ).to.eql( 0 );
+		expect( state.form.packages.selected.client_custom_0.box_id ).to.eql( 'customPackage1' );
+		expect( state.form.packages.selected.client_custom_0.length ).to.eql( 1 );
+		expect( state.form.packages.selected.client_custom_0.width ).to.eql( 2 );
+		expect( state.form.packages.selected.client_custom_0.height ).to.eql( 3 );
+		expect( state.form.packages.selected.client_custom_0.weight ).to.eql( 3.5 );
+		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.openedPackageId ).to.eql( 'client_custom_0' );
+		expect( state.form.rates.available ).to.eql( {} );
+	} );
+
+	it( 'REMOVE_PACKAGE removes the package and moves all the items to saved for later', () => {
+		const action = removePackage( 'weight_0_custom1' );
+		const state = reducer( initialState, action );
+
+		expect( state.form.packages.selected ).to.not.include.keys( 'weight_0_custom1' );
+		expect( state.form.packages.unpacked.length ).to.eql( 1 );
+		expect( state.form.packages.unpacked ).to.include( initialState.form.packages.selected.weight_0_custom1.items[ 0 ] );
+		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.form.rates.available ).to.eql( {} );
+	} );
+
+	it( 'SET_PACKAGE_TYPE changes an existing package', () => {
+		const action = setPackageType( 'weight_0_custom1', 'customPackage1' );
+		const state = reducer( initialState, action );
+
+		expect( state.form.packages.selected.weight_0_custom1.items.length ).to.eql( 1 );
+		expect( state.form.packages.selected.weight_0_custom1.box_id ).to.eql( 'customPackage1' );
+		expect( state.form.packages.selected.weight_0_custom1.length ).to.eql( 1 );
+		expect( state.form.packages.selected.weight_0_custom1.width ).to.eql( 2 );
+		expect( state.form.packages.selected.weight_0_custom1.height ).to.eql( 3 );
+		expect( state.form.packages.selected.weight_0_custom1.weight ).to.eql( 4.7 );
+		expect( state.form.packages.saved ).to.eql( false );
+		expect( state.form.rates.values ).to.include.all.keys( Object.keys( state.form.packages.selected ) );
+		expect( state.form.rates.available ).to.eql( {} );
+	} );
+
+	it( 'SAVE_PACKAGES changes the saved state', () => {
+		const existingState = hoek.clone( initialState );
+		existingState.form.packages.saved = false;
+
+		const action = savePackages();
+		const state = reducer( existingState, action );
+
+		expect( state.form.packages.saved ).to.eql( true );
+	} );
+} );

--- a/client/shipping-label/views/purchase/index.js
+++ b/client/shipping-label/views/purchase/index.js
@@ -22,7 +22,7 @@ const PrintLabelDialog = ( props ) => {
 
 	const getPurchaseButtonLabel = () => {
 		let label = __( 'Buy & Print' );
-		const nPackages = props.form.packages.values.length;
+		const nPackages = props.form.packages.selected.length;
 		if ( nPackages ) {
 			label += ' ' + ( 1 === nPackages ? __( '1 Label' ) : sprintf( __( '%d Labels' ), nPackages ) );
 		}
@@ -39,7 +39,7 @@ const PrintLabelDialog = ( props ) => {
 			additionalClassNames="wcc-modal" >
 			<div className="wcc-shipping-label-dialog__content">
 				<h3 className="form-section-heading">
-					{ 1 === props.form.packages.values.length ? __( 'Create shipping label' ) : __( 'Create shipping labels' ) }
+					{ 1 === props.form.packages.selected.length ? __( 'Create shipping label' ) : __( 'Create shipping labels' ) }
 				</h3>
 				<div className="wcc-shipping-label-dialog__body">
 					<div className="wcc-shipping-label-dialog__main-section">

--- a/client/shipping-label/views/purchase/steps/packages/add-item.js
+++ b/client/shipping-label/views/purchase/steps/packages/add-item.js
@@ -1,0 +1,93 @@
+import React, { PropTypes } from 'react';
+import { translate as __ } from 'lib/mixins/i18n';
+import Dialog from 'components/dialog';
+import FormRadio from 'components/forms/form-radio';
+import FormLabel from 'components/forms/form-label';
+import ActionButtons from 'components/action-buttons';
+import { sprintf } from 'sprintf-js';
+import getPackageDescriptions from './get-package-descriptions';
+
+const AddItemDialog = ( {
+	showAddItemDialog,
+	movedItemIndex,
+	sourcePackageId,
+	openedPackageId,
+	selected,
+	all,
+	unpacked,
+	closeAddItem,
+	setAddedItem,
+	confirmAddItem } ) => {
+	if ( ! showAddItemDialog ) {
+		return null;
+	}
+
+	const renderRadioButton = ( pckgId, itemIdx, label ) => {
+		return (
+			<FormLabel
+				key={ `${ pckgId }-${ itemIdx }` }
+				className="wcc-move-item-dialog__package-option">
+				<FormRadio checked={ pckgId === sourcePackageId && itemIdx === movedItemIndex } onChange={ () => ( setAddedItem( pckgId, itemIdx ) ) } />
+				<span dangerouslySetInnerHTML={ { __html: label } } />
+			</FormLabel>
+		);
+	};
+
+	const packageLabels = getPackageDescriptions( selected, all, true );
+	const getPackageNameHtml = ( pckgId ) => {
+		return `<span class="wcc-move-item-dialog__package-name">${ packageLabels[ pckgId ] }</span>`;
+	};
+
+	const itemOptions = [];
+
+	Object.keys( selected ).forEach( ( pckgId ) => {
+		if ( pckgId === openedPackageId ) {
+			return;
+		}
+
+		let itemIdx = 0;
+		selected[ pckgId ].items.forEach( ( item ) => {
+			const label = sprintf( '%s from %s', item.name, getPackageNameHtml( pckgId ) );
+			itemOptions.push( renderRadioButton( pckgId, itemIdx, label ) );
+			itemIdx++;
+		} );
+	} );
+
+	let unpackedIdx = 0;
+	unpacked.forEach( ( item ) => {
+		itemOptions.push( renderRadioButton( '', unpackedIdx, item.name ) );
+		unpackedIdx++;
+	} );
+
+	return (
+		<Dialog isVisible={ showAddItemDialog }
+				isFullScreen={ false }
+				onClickOutside={ closeAddItem }
+				onClose={ closeAddItem }
+				additionalClassNames="wcc-modal wcc-label-packages-dialog" >
+			<div className="wcc-label-packages-dialog__content">
+				<h1 className="form-section-heading">{ __( 'Add item' ) }</h1>
+				<div className="wcc-label-packages-dialog__body">
+					<p dangerouslySetInnerHTML={ { __html: sprintf( __( 'Which item would you like to add to %s?' ), getPackageNameHtml( openedPackageId ) ) } } />
+					{ itemOptions }
+				</div>
+				<ActionButtons buttons={ [
+					{ label: __( 'Add' ), isPrimary: true, onClick: () => ( confirmAddItem( sourcePackageId, movedItemIndex, openedPackageId ) ) },
+					{ label: __( 'Cancel' ), onClick: closeAddItem },
+				] } />
+			</div>
+		</Dialog>
+	);
+};
+
+AddItemDialog.propTypes = {
+	showAddItemDialog: PropTypes.bool.isRequired,
+	movedItemIndex: PropTypes.number,
+	sourcePackageId: PropTypes.string,
+	openedPackageId: PropTypes.string.isRequired,
+	selected: PropTypes.object.isRequired,
+	all: PropTypes.object.isRequired,
+	unpacked: PropTypes.array,
+};
+
+export default AddItemDialog;

--- a/client/shipping-label/views/purchase/steps/packages/get-package-descriptions.js
+++ b/client/shipping-label/views/purchase/steps/packages/get-package-descriptions.js
@@ -1,0 +1,23 @@
+import { translate as __ } from 'lib/mixins/i18n';
+import { sprintf } from 'sprintf-js';
+import _ from 'lodash';
+
+export default ( selected, all, addNames ) => {
+	let pckgCount = 0;
+
+	return _.mapValues( selected, ( pckg ) => {
+		if ( 'individual' === pckg.box_id ) {
+			return pckg.items[ 0 ].name;
+		}
+
+		let pckgType = __( 'Package %d' );
+		const pckgData = all[ pckg.box_id ];
+		if ( pckgData ) {
+			pckgType = all[ pckg.box_id ].is_letter ? __( 'Envelope %d' ) : __( 'Box %d' );
+		}
+
+		pckgCount++;
+		const pckgName = addNames && pckgData ? ': ' + pckgData.name : '';
+		return sprintf( pckgType, pckgCount ) + pckgName;
+	} );
+};

--- a/client/shipping-label/views/purchase/steps/packages/index.js
+++ b/client/shipping-label/views/purchase/steps/packages/index.js
@@ -1,59 +1,164 @@
 import React, { PropTypes } from 'react';
 import { translate as __ } from 'lib/mixins/i18n';
-import OrderPackages from './list';
+import PackageList from './list';
+import PackageInfo from './package-info';
+import MoveItemDialog from './move-item';
+import AddItemDialog from './add-item';
+import Unpacked from './unpacked';
 import FormButton from 'components/forms/form-button';
 import { hasNonEmptyLeaves } from 'lib/utils/tree';
 import { sprintf } from 'sprintf-js';
 import StepContainer from '../../step-container';
 
-const PackagesStep = ( { values, storeOptions, labelActions, errors, expanded } ) => {
-	const packageIds = Object.keys( values );
-	const firstPackageId = packageIds[ 0 ];
-	const firstPackage = values[ firstPackageId ];
-	const isValid = 0 < firstPackage.weight;
+const PackagesStep = ( {
+	openedPackageId,
+	selected,
+	all,
+	unpacked,
+	storeOptions,
+	labelActions,
+	errors,
+	expanded,
+	showItemMoveDialog,
+	movedItemIndex,
+	targetPackageId,
+	showAddItemDialog,
+	sourcePackageId } ) => {
+	const packageIds = Object.keys( selected );
+	const itemsCount = packageIds.reduce( ( result, pId ) => ( result + selected[ pId ].items.length ), 0 );
+	const totalWeight = packageIds.reduce( ( result, pId ) => ( result + selected[ pId ].weight ), 0 );
+	const isValidWeight = packageIds.reduce( ( result, pId ) => ( result && 0 < selected[ pId ].weight ), true );
+	const isValidPackages = 0 < packageIds.length;
+
 	const renderSummary = () => {
-		if ( ! isValid ) {
+		if ( ! isValidPackages ) {
+			return __( 'No packages selected' );
+		}
+
+		if ( ! isValidWeight ) {
 			return __( 'Weight not entered' );
 		}
-		if ( 1 < values.length ) {
-			return sprintf( __( '%d packages' ), packageIds.length );
+
+		if ( 1 === packageIds.length && 1 === itemsCount ) {
+			return sprintf( __( '1 item in 1 package: %f %s total' ), totalWeight, storeOptions.weight_unit );
 		}
-		return firstPackage.weight + ' ' + storeOptions.weight_unit;
+
+		if ( 1 === packageIds.length ) {
+			return sprintf( __( '%d items in 1 package: %f %s total' ), itemsCount, totalWeight, storeOptions.weight_unit );
+		}
+
+		return sprintf( __( '%d items in %d packages: %f %s total' ), itemsCount, packageIds.length, totalWeight, storeOptions.weight_unit );
+	};
+
+	const renderContents = () => {
+		const elements = [
+			<PackageList
+				key="packages-list"
+				openPackage={ labelActions.openPackage }
+				packageId={ openedPackageId }
+				selected={ selected }
+				all={ all }
+				unpacked={ unpacked }
+				addPackage={ labelActions.addPackage }/>,
+		];
+
+		if ( ! packageIds.length && ! unpacked.length ) {
+			elements.push(
+				<div key="no-packages" className="wcc-package">{ __( 'There are no packages or items associated with this order' ) }</div>
+			);
+		} else {
+			elements.push(
+				<PackageInfo
+					key="package-info"
+					packageId={ openedPackageId }
+					selected={ selected }
+					all={ all }
+					unpacked={ unpacked }
+					dimensionUnit={ storeOptions.dimension_unit }
+					weightUnit={ storeOptions.weight_unit }
+					errors={ errors }
+					updateWeight={ labelActions.updatePackageWeight }
+					openItemMove={ labelActions.openItemMove }
+					removeItem={ labelActions.removeItem }
+					removePackage={ labelActions.removePackage }
+					setPackageType={ labelActions.setPackageType }
+					openAddItem={ labelActions.openAddItem } />
+			);
+			elements.push(
+				<Unpacked
+					key="unpacked"
+					packageId={ openedPackageId }
+					unpacked={ unpacked }
+					openItemMove={ labelActions.openItemMove }
+					moveItem={ labelActions.moveItem } />
+			);
+		}
+
+		return (
+			<div className="wcc-packages-container">
+				{ elements }
+			</div>
+		);
 	};
 
 	return (
 		<StepContainer
 			title={ __( 'Packages' ) }
-			isSuccess={ isValid }
-			isError={ ! isValid }
+			isSuccess={ isValidWeight && isValidPackages }
+			isError={ ! isValidWeight || ! isValidPackages }
 			summary={ renderSummary() }
 			expanded={ expanded }
 			toggleStep={ () => labelActions.toggleStep( 'packages' ) } >
-			<OrderPackages
-				packages={ values }
-				updateWeight={ labelActions.updatePackageWeight }
-				dimensionUnit={ storeOptions.dimension_unit }
-				weightUnit={ storeOptions.weight_unit }
-				errors={ errors } />
+			{ renderContents() }
 			<div className="step__confirmation-container">
 				<FormButton
 					type="button"
 					className="packages__confirmation step__confirmation"
-					disabled={ hasNonEmptyLeaves( errors ) }
+					disabled={ hasNonEmptyLeaves( errors ) || ! packageIds.length }
 					onClick={ labelActions.confirmPackages }
 					isPrimary >
-					{ __( 'Use this package' ) }
+					{ __( 'Save packages' ) }
 				</FormButton>
 			</div>
+			<MoveItemDialog
+				showItemMoveDialog={ showItemMoveDialog || false }
+				movedItemIndex={ isNaN( movedItemIndex ) ? -1 : movedItemIndex }
+				openedPackageId={ openedPackageId }
+				targetPackageId={ targetPackageId }
+				selected={ selected }
+				all={ all }
+				unpacked={ unpacked }
+				closeItemMove={ labelActions.closeItemMove }
+				setTargetPackage={ labelActions.setTargetPackage }
+				confirmItemMove={ labelActions.confirmItemMove } />
+			<AddItemDialog
+				showAddItemDialog={ showAddItemDialog || false }
+				movedItemIndex={ movedItemIndex }
+				sourcePackageId={ sourcePackageId }
+				openedPackageId={ openedPackageId }
+				selected={ selected }
+				all={ all }
+				unpacked={ unpacked }
+				closeAddItem={ labelActions.closeAddItem }
+				setAddedItem={ labelActions.setAddedItem }
+				confirmAddItem={ labelActions.confirmAddItem } />
 		</StepContainer>
 	);
 };
 
 PackagesStep.propTypes = {
-	values: PropTypes.object.isRequired,
+	openedPackageId: PropTypes.string,
+	showItemMoveDialog: PropTypes.bool,
+	selected: PropTypes.object.isRequired,
+	all: PropTypes.object.isRequired,
 	labelActions: PropTypes.object.isRequired,
 	storeOptions: PropTypes.object.isRequired,
 	errors: PropTypes.object.isRequired,
+	expanded: PropTypes.bool,
+	movedItemIndex: PropTypes.number,
+	targetPackageId: PropTypes.string,
+	showAddItemDialog: PropTypes.bool,
+	sourcePackageId: PropTypes.string,
 };
 
 export default PackagesStep;

--- a/client/shipping-label/views/purchase/steps/packages/item-info.js
+++ b/client/shipping-label/views/purchase/steps/packages/item-info.js
@@ -1,0 +1,42 @@
+import React, { PropTypes } from 'react';
+import { translate as __ } from 'lib/mixins/i18n';
+import Gridicon from 'components/gridicon';
+import Button from 'components/button';
+
+const ItemInfo = ( { item, itemIndex, packageId, showRemove, openItemMove, removeItem } ) => {
+	const renderRemove = () => {
+		if ( ! showRemove ) {
+			return null;
+		}
+
+		return (
+			<Button className="wcc-package-item__remove" compact borderless onClick={ () => removeItem( packageId, itemIndex ) }>
+				<Gridicon icon="cross" />
+			</Button>
+		);
+	};
+
+	return (
+		<div key={ itemIndex } className="wcc-package-item">
+			<div className="wcc-package-item__name">
+					<span className="wcc-package-item__title">
+						<a href={ item.url } target="_blank">{ item.name }</a>
+					</span>
+				{ item.attributes && <p>{ item.attributes }</p> }
+			</div>
+			<div className="wcc-package-item__actions">
+				<Button className="wcc-package-item__move" compact onClick={ () => ( openItemMove( itemIndex ) ) }>{ __( 'Move' ) }</Button>
+				{ renderRemove() }
+			</div>
+		</div>
+	);
+};
+
+ItemInfo.propTypes = {
+	item: PropTypes.object.isRequired,
+	itemIndex: PropTypes.number.isRequired,
+	showRemove: PropTypes.bool,
+	packageId: PropTypes.string.isRequired,
+};
+
+export default ItemInfo;

--- a/client/shipping-label/views/purchase/steps/packages/move-item.js
+++ b/client/shipping-label/views/purchase/steps/packages/move-item.js
@@ -1,0 +1,120 @@
+import React, { PropTypes } from 'react';
+import { translate as __ } from 'lib/mixins/i18n';
+import Dialog from 'components/dialog';
+import FormRadio from 'components/forms/form-radio';
+import FormLabel from 'components/forms/form-label';
+import ActionButtons from 'components/action-buttons';
+import { sprintf } from 'sprintf-js';
+import getPackageDescriptions from './get-package-descriptions';
+
+const MoveItemDialog = ( {
+	showItemMoveDialog,
+	movedItemIndex,
+	targetPackageId,
+	openedPackageId,
+	selected,
+	all,
+	unpacked,
+	closeItemMove,
+	setTargetPackage,
+	confirmItemMove } ) => {
+	if ( -1 === movedItemIndex || ! showItemMoveDialog ) {
+		return null;
+	}
+
+	const renderRadioButton = ( pckgId, label ) => {
+		return (
+			<FormLabel
+				key={ pckgId }
+				className="wcc-move-item-dialog__package-option">
+				<FormRadio checked={ pckgId === targetPackageId } onChange={ () => ( setTargetPackage( pckgId ) ) } />
+				{ label }
+			</FormLabel>
+		);
+	};
+
+	const openedPackage = selected[ openedPackageId ];
+	const items = '' !== openedPackageId ? openedPackage.items : unpacked;
+	const item = items[ movedItemIndex ];
+	const itemLink = sprintf( '<a href="%s" target="_blank">%s</a>', item.url, item.name );
+	let desc;
+
+	const packageLabels = getPackageDescriptions( selected, all, true );
+
+	const renderPackedOptions = () => {
+		const elements = [];
+		Object.keys( selected ).forEach( ( pckgId ) => {
+			const pckg = selected[ pckgId ];
+			if ( pckgId === openedPackageId || 'individual' === pckg.box_id ) {
+				return;
+			}
+
+			elements.push( renderRadioButton( pckgId, packageLabels[ pckgId ] ) );
+		} );
+
+		return elements;
+	};
+
+	const renderIndividualOption = () => {
+		if ( openedPackage && 'individual' === openedPackage.box_id ) {
+			return null;
+		}
+
+		return renderRadioButton( 'individual', __( 'Ship in original packaging' ) );
+	};
+
+	const renderSaveForLaterOption = () => {
+		if ( '' === openedPackageId ) {
+			return null;
+		}
+
+		return renderRadioButton( '', __( 'Save for later' ) );
+	};
+
+	if ( '' === openedPackageId ) {
+		desc = sprintf( '%s is currently saved for a later shipment.', itemLink );
+	} else if ( 'individual' === openedPackage.box_id ) {
+		desc = sprintf( '%s is currently shipped in its original packaging.', itemLink );
+	} else {
+		desc = sprintf(
+			__( '%s is currently in %s.' ),
+			itemLink,
+			sprintf( '<span class="wcc-move-item-dialog__package-name">%s</a>', packageLabels[ openedPackageId ] )
+		);
+	}
+
+	return (
+		<Dialog isVisible={ showItemMoveDialog }
+				isFullScreen={ false }
+				onClickOutside={ closeItemMove }
+				onClose={ closeItemMove }
+				additionalClassNames="wcc-modal wcc-label-packages-dialog" >
+			<div className="wcc-label-packages-dialog__content">
+				<h1 className="form-section-heading">{ __( 'Move item' ) }</h1>
+				<div className="wcc-label-packages-dialog__body">
+					<p dangerouslySetInnerHTML={ { __html: desc } }/>
+					<p>{ __( 'Where would you like to move it?' ) }</p>
+					{ renderPackedOptions() }
+					{ renderIndividualOption() }
+					{ renderSaveForLaterOption() }
+				</div>
+				<ActionButtons buttons={ [
+					{ label: __( 'Move' ), isPrimary: true, onClick: () => ( confirmItemMove( openedPackageId, movedItemIndex, targetPackageId ) ) },
+					{ label: __( 'Cancel' ), onClick: closeItemMove },
+				] } />
+			</div>
+		</Dialog>
+	);
+};
+
+MoveItemDialog.propTypes = {
+	showItemMoveDialog: PropTypes.bool.isRequired,
+	movedItemIndex: PropTypes.number.isRequired,
+	targetPackageId: PropTypes.string,
+	openedPackageId: PropTypes.string.isRequired,
+	selected: PropTypes.object.isRequired,
+	all: PropTypes.object.isRequired,
+	unpacked: PropTypes.array,
+};
+
+export default MoveItemDialog;

--- a/client/shipping-label/views/purchase/steps/packages/package-info.js
+++ b/client/shipping-label/views/purchase/steps/packages/package-info.js
@@ -1,0 +1,124 @@
+import React, { PropTypes } from 'react';
+import { translate as __ } from 'lib/mixins/i18n';
+import ItemInfo from './item-info';
+import NumberField from 'components/number-field';
+import FormLegend from 'components/forms/form-legend';
+import FormSelect from 'components/forms/form-select';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import getBoxDimensions from 'lib/utils/get-box-dimensions';
+import _ from 'lodash';
+
+const renderPackageDimensions = ( dimensions, dimensionUnit ) => {
+	return `${dimensions.length} ${dimensionUnit} x ${dimensions.width} ${dimensionUnit} x ${dimensions.height} ${dimensionUnit}`;
+};
+
+const PackageInfo = ( { packageId, selected, all, unpacked, dimensionUnit, weightUnit, errors, updateWeight, openItemMove, removeItem, removePackage, setPackageType, openAddItem } ) => {
+	if ( ! packageId ) {
+		return null;
+	}
+
+	const renderItemInfo = ( item, itemIndex ) => {
+		return (
+			<ItemInfo key={ itemIndex } item={ item } itemIndex={ itemIndex } packageId={ packageId } showRemove={ true } openItemMove={ openItemMove } removeItem={ removeItem } />
+		);
+	};
+
+	const renderPackageOption = ( box, boxId ) => {
+		const dimensions = getBoxDimensions( box );
+		return ( <option value={ boxId } key={ boxId }>{ box.name } - { renderPackageDimensions( dimensions, dimensionUnit ) }</option> );
+	};
+
+	const renderAddItemButton = () => {
+		return ( <Button className="wcc-package__add-item-btn" compact onClick={ () => ( openAddItem() ) }>{ __( 'Add item' ) }</Button> );
+	};
+
+	const packageOptionChange = ( e ) => {
+		setPackageType( packageId, e.target.value );
+	};
+
+	const pckg = selected[ packageId ];
+
+	const renderItems = () => {
+		const canAddItems = unpacked.length || _.some( selected, ( sel, selId ) => ( packageId !== selId && sel.items.length ) );
+
+		if ( ! pckg.items.length ) {
+			return (
+				<div className="wcc-package__add-item-row">
+					<div className="wcc-package__no-items-message">
+						{ __( 'There are no items in this package.' ) }
+						{ canAddItems ? renderAddItemButton() : null }
+					</div>
+				</div>
+			);
+		}
+
+		const elements = pckg.items.map( renderItemInfo );
+		if ( canAddItems ) {
+			elements.push( <div key={ elements.length } className="wcc-package__add-item-row">
+				{ renderAddItemButton() }
+			</div> );
+		}
+
+		return elements;
+	};
+
+	const renderPackageSelect = () => {
+		if ( ! all[ pckg.box_id ] ) {
+			return ( <div className="wcc-package__desc"><span className="wcc-package__desc-name">Package - </span><span className="wcc-package__desc-dimensions">{ renderPackageDimensions( pckg, dimensionUnit ) }</span></div> );
+		}
+
+		const packageOptions = _.map( all, renderPackageOption );
+
+		return (
+			<FormSelect onChange={ packageOptionChange } value={ pckg.box_id }>
+				{ packageOptions }
+			</FormSelect>
+		);
+	};
+
+	const pckgErrors = errors[ packageId ] || {};
+
+	return (
+		<div className="wcc-package">
+			{ renderPackageSelect() }
+
+			<div>
+				<div className="wcc-package-items-header">
+					<FormLegend className="wcc-package-item__name">{ __( 'Contents' ) }</FormLegend>
+				</div>
+				{ renderItems() }
+			</div>
+
+			<div>
+				<NumberField
+					id={ `weight_${packageId}` }
+					className="wcc-package__weight"
+					title={ __( 'Total Weight' ) }
+					value={ pckg.weight }
+					updateValue={ ( value ) => updateWeight( packageId, value ) }
+					error={ pckgErrors.weight } />
+				<span className="wcc-package__weight-unit">{ weightUnit }</span>
+			</div>
+			<div>
+				<Button className="wcc-package__remove" borderless compact onClick={ () => ( removePackage( packageId ) ) }>
+					<Gridicon icon="trash" />
+					<span className="wcc-package__remove-label">{ __( 'Remove this package' ) }</span>
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+PackageInfo.propTypes = {
+	packageId: PropTypes.string.isRequired,
+	selected: PropTypes.object.isRequired,
+	all: PropTypes.object.isRequired,
+	unpacked: PropTypes.array.isRequired,
+	updateWeight: PropTypes.func.isRequired,
+	dimensionUnit: PropTypes.string.isRequired,
+	weightUnit: PropTypes.string.isRequired,
+	errors: PropTypes.object.isRequired,
+};
+
+export default PackageInfo;

--- a/client/shipping-label/views/purchase/steps/packages/style.scss
+++ b/client/shipping-label/views/purchase/steps/packages/style.scss
@@ -1,62 +1,169 @@
-.wcc-package-package-number {
-	margin-bottom: 16px;
-	color: $gray;
+.wcc-packages-container {
+	display: flex;
+	padding-bottom: 24px;
+}
+
+.wcc-packages-list {
+	width: 25%;
+	padding: 0 24px 0 0;
+	flex-shrink: 0;
+}
+
+.wcc-packages-list__item {
+	border-bottom: solid 1px lighten( $gray, 30% );
+}
+
+.wcc-packages-list__header {
+	color: lighten( $gray, 10% );
 	text-transform: uppercase;
+	font-size: 80%;
+}
+
+.wcc-packages-list-package {
+	display: flex;
+	padding: 4px 8px;
+	margin: 4px 0;
+	border-radius: 2px;
+	cursor: pointer;
+
+	&.selected {
+		background-color: $gray;
+		color: $white;
+		font-weight: bold;
+
+		.wcc-packages-list-package__count {
+			color: white;
+		}
+	}
+}
+
+.wcc-packages-list-package__name {
+	flex-grow: 1;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin-right: 2px;
+}
+
+.wcc-packages-list-package__count {
+	display: inline-block;
+	padding: 1px 6px;
+	border: solid 1px lighten( $gray, 10% );
+	border-radius: 12px;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 14px;
+	color: $gray;
+	text-align: center;
+	align-self: flex-end;
+}
+
+.wcc-packages-list__add-container {
+	position: relative;
+	margin: 8px 0 32px;
+
+	& a svg {
+		position: relative;
+		top: 3px;
+	}
+}
+
+.wcc-packages-list__unpacked {
+	margin: 32px 0 0 0;
+	border-top: 1px solid $gray-light;
+	display: flex;
+	padding: 8px;
+
+	.wcc-packages-list__link {
+		font-style: italic;
+		color: darken( $gray, 30% );
+	}
+}
+
+.wcc-packages-list__link {
+	text-decoration: none;
+	flex-grow: 1;
+}
+
+.wcc-package {
+	flex-grow: 1;
+	padding: 8px 4px 4px 4px;
+}
+
+.wcc-package__add-item-row {
+	padding: 8px 0;
+	display: flex;
+}
+
+.wcc-package__no-items-message {
+	padding: 8px 0;
+	font-style: italic;
+	flex-grow: 1;
+}
+
+.wcc-package__no-items-message .wcc-package__add-item-btn {
+	vertical-align: middle;
+	margin-left: 8px;
+}
+
+.wcc-package__desc-name {
+	font-weight: bold;
 }
 
 .wcc-package-items-header {
 	display: flex;
-	border-bottom: 1px solid lighten( $gray, 30% );
-	margin-top: 24px;
+	border-bottom: 1px solid lighten( $gray, 20% );
+	margin-top: 16px;
 }
 
 .wcc-package-item {
 	display: flex;
 	padding: 8px 0;
-}
+	border-bottom: 1px solid lighten( $gray, 30% );
 
-.wcc-package-item__name {
-	margin-bottom: 8px;
-}
-
-.wcc-package-item__name,
-.wcc-package-item__title {
-	width: 80%;
-}
-
-.wcc-package-item__quantity {
-	width: 20%;
-}
-
-.wcc-package-weight {
-	display: inline-block;
-	width: 140px;
-	margin-top: 16px;
-}
-
-.wcc-package-weight-unit {
-	position: absolute;
-	margin-top: 50px;
-	margin-left: 8px;
-}
-
-.wcc-package-package-dimension {
-	vertical-align: top;
-
-	@include breakpoint( ">960px" ) {
-		display: inline-block;
-		margin-top: 16px;
-		margin-left: 80px;
+	&:last-child {
+		border-color: lighten( $gray, 20% );
 	}
 }
 
-.wcc-package-package-dimension__unit {
-	border: 1px solid lighten( $gray, 20% );
-	background: $gray-light;
-	color: $gray;
+.wcc-package-item__name {
+	flex-grow: 1;
+	padding: 8px 0;
+}
+
+.wcc-package-item__move {
+	margin: 4px 16px;
+}
+
+.button.wcc-package-item__remove {
+	padding: 12px 0;
+}
+
+.wcc-package__weight {
 	display: inline-block;
-	padding: 7px 14px;
-	width: 160px;
-	font-size: 16px;
-	line-height: 1.5;
+	width: 140px;
+	margin-top: 24px;
+}
+
+.wcc-package__weight-unit {
+	margin-left: 8px;
+}
+
+.wcc-package__remove-label {
+	margin-left: 4px;
+}
+
+.wcc-move-item-dialog__package-option {
+	font-weight: normal;
+	margin-bottom: 10px;
+}
+
+.wcc-move-item-dialog__package-name {
+	font-weight: bold;
+}
+
+.wcc-label-packages-dialog__body {
+	@include breakpoint( "<480px" ) {
+		padding: 0 16px;
+	}
 }

--- a/client/shipping-label/views/purchase/steps/packages/unpacked.js
+++ b/client/shipping-label/views/purchase/steps/packages/unpacked.js
@@ -1,0 +1,30 @@
+import React, { PropTypes } from 'react';
+import { translate as __ } from 'lib/mixins/i18n';
+import ItemInfo from './item-info';
+import FormLegend from 'components/forms/form-legend';
+
+const Unpacked = ( { packageId, unpacked, openItemMove, moveItem } ) => {
+	if ( '' !== packageId ) {
+		return null;
+	}
+
+	const renderItemInfo = ( item, itemIndex ) => {
+		return (
+			<ItemInfo key={ itemIndex } item={ item } itemIndex={ itemIndex } packageId={ packageId } openItemMove={ openItemMove } moveItem={ moveItem } />
+		);
+	};
+
+	return (
+		<div className="wcc-package">
+			<FormLegend className="wcc-package-item__name">{ __( 'Saved for later' ) }</FormLegend>
+			{ unpacked.length ? unpacked.map( renderItemInfo ) : <div>{ __( 'There are no items saved for a later delivery' ) }</div> }
+		</div>
+	);
+};
+
+Unpacked.propTypes = {
+	packageId: PropTypes.string.isRequired,
+	unpacked: PropTypes.array.isRequired,
+};
+
+export default Unpacked;

--- a/client/shipping-label/views/purchase/steps/rates/index.js
+++ b/client/shipping-label/views/purchase/steps/rates/index.js
@@ -7,7 +7,11 @@ import _ from 'lodash';
 import { hasNonEmptyLeaves } from 'lib/utils/tree';
 import { getRatesTotal } from 'shipping-label/state/selectors/rates';
 
-const ratesSummary = ( selectedRates, availableRates, total, currencySymbol ) => {
+const ratesSummary = ( selectedRates, availableRates, total, currencySymbol, packagesSaved ) => {
+	if ( ! packagesSaved ) {
+		return __( 'Unsaved changes made to packages' );
+	}
+
 	const packageIds = Object.keys( selectedRates );
 
 	// Show the service name and cost when only one service/package exists
@@ -35,7 +39,7 @@ const ratesSummary = ( selectedRates, availableRates, total, currencySymbol ) =>
 	} );
 };
 
-const getRatesStatus = ( { retrievalInProgress, errors, available } ) => {
+const getRatesStatus = ( { retrievalInProgress, errors, available, form } ) => {
 	if ( retrievalInProgress ) {
 		return { isProgress: true };
 	}
@@ -46,6 +50,10 @@ const getRatesStatus = ( { retrievalInProgress, errors, available } ) => {
 
 	if ( _.isEmpty( available ) ) {
 		return {};
+	}
+
+	if ( ! form.packages.saved ) {
+		return { isWarning: true };
 	}
 
 	return { isSuccess: true };
@@ -61,7 +69,7 @@ const RatesStep = ( props ) => {
 		errors,
 		expanded,
 	} = props;
-	const summary = ratesSummary( values, available, getRatesTotal( form.rates ), storeOptions.currency_symbol );
+	const summary = ratesSummary( values, available, getRatesTotal( form.rates ), storeOptions.currency_symbol, form.packages.saved );
 
 	return (
 		<StepContainer
@@ -73,7 +81,8 @@ const RatesStep = ( props ) => {
 			<ShippingRates
 				id="rates"
 				showRateNotice={ false }
-				packages={ form.packages.values }
+				selectedPackages={ form.packages.selected }
+				allPackages={ form.packages.all }
 				selectedRates={ values }
 				availableRates={ available }
 				updateRate={ labelActions.updateRate }

--- a/client/shipping-label/views/purchase/steps/rates/list.js
+++ b/client/shipping-label/views/purchase/steps/rates/list.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import Dropdown from 'components/dropdown';
 import Notice from 'components/notice';
+import getPackageDescriptions from '../packages/get-package-descriptions';
 import { translate as __ } from 'lib/mixins/i18n';
 import { sprintf } from 'sprintf-js';
 import _ from 'lodash';
@@ -22,20 +23,21 @@ const ShippingRates = ( {
 		id,
 		selectedRates, // Store owner selected rates, not customer
 		availableRates,
-		packages,
+		selectedPackages,
+		allPackages,
 		updateRate,
 		currencySymbol,
 		errors,
 		showRateNotice,
 	} ) => {
-	const renderTitle = ( pckg, index ) => {
-		if ( 1 === Object.keys( packages ).length ) {
+	const packageNames = getPackageDescriptions( selectedPackages, allPackages, true );
+
+	const renderTitle = ( pckg, pckgId ) => {
+		if ( 1 === Object.keys( selectedPackages ).length ) {
 			return __( 'Choose rate' );
 		}
-		return sprintf( __( 'Choose rate: Package %(index)d' ), { index } );
+		return sprintf( __( 'Choose rate: %s' ), packageNames[ pckgId ] );
 	};
-
-	let packageNum = 1;
 
 	const renderSinglePackage = ( pckg, pckgId ) => {
 		const selectedRate = selectedRates[ pckgId ] || '';
@@ -47,11 +49,11 @@ const ShippingRates = ( {
 		} );
 
 		return (
-			<div key={ packageNum }>
+			<div key={ pckgId }>
 				<Dropdown
-					id={ id + '_' + packageNum }
+					id={ id + '_' + pckgId }
 					valuesMap={ valuesMap }
-					title={ renderTitle( pckg, packageNum++ ) }
+					title={ renderTitle( pckg, pckgId ) }
 					value={ selectedRate }
 					updateValue={ ( value ) => updateRate( pckgId, value ) }
 					error={ errors[ pckgId ] } />
@@ -62,7 +64,7 @@ const ShippingRates = ( {
 	return (
 		<div>
 			{ renderRateNotice( showRateNotice ) }
-			{ Object.values( _.mapValues( packages, renderSinglePackage ) ) }
+			{ Object.values( _.mapValues( selectedPackages, renderSinglePackage ) ) }
 		</div>
 	);
 };
@@ -71,7 +73,8 @@ ShippingRates.propTypes = {
 	id: PropTypes.string.isRequired,
 	selectedRates: PropTypes.object.isRequired,
 	availableRates: PropTypes.object.isRequired,
-	packages: PropTypes.object.isRequired,
+	selectedPackages: PropTypes.object.isRequired,
+	allPackages: PropTypes.object.isRequired,
 	updateRate: PropTypes.func.isRequired,
 	dimensionUnit: PropTypes.string.isRequired,
 	weightUnit: PropTypes.string.isRequired,


### PR DESCRIPTION
Adds #568 #569 #570 

Adds editable packing solution:
![oct-25-2016 13-05-13](https://cloud.githubusercontent.com/assets/800604/19681903/e7b19590-9ab3-11e6-8bc3-3dfdf2c21693.gif)

Left to do:
- [x] Use a dropdown to select a box type instead of a modal
- [x] Flat rate packages. Should we allow to select them?

CC @allendav @kellychoffman @DanReyLop 
