### PR TITLE
Send the shipment ID for each package when requesting a label purchase

### DIFF
--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -293,8 +293,10 @@ export const purchaseLabel = () => ( dispatch, getState, { purchaseURL, addressN
 		const formData = {
 			origin: form.origin.selectNormalized ? form.origin.normalized : form.origin.values,
 			destination: form.destination.selectNormalized ? form.destination.normalized : form.destination.values,
+
 			packages: _.map( form.packages.values, ( pckg, pckgId ) => ( {
 				..._.omit( pckg, [ 'items', 'id', 'box_id' ] ),
+				shipment_id: form.rates.available[ pckgId ].shipment_id,
 				service_id: form.rates.values[ pckgId ],
 				service_name: _.find( form.rates.available[ pckgId ].rates, { service_id: form.rates.values[ pckgId ] } ).title,
 				products: _.flatten( pckg.items.map( ( item ) => _.fill( new Array( item.quantity ), item.product_id ) ) ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,12 +66,6 @@ module.exports = {
 		]
 	},
 	resolve: {
-		alias: {
-			'react': path.join( __dirname, 'node_modules', 'react' ),
-			'react-dom': path.join( __dirname, 'node_modules', 'react-dom' ),
-			'redux': path.join( __dirname, 'node_modules', 'redux' ),
-			'lib/mixins/i18n': path.join( __dirname, 'client', 'lib', 'mixins', 'i18n' )
-		},
 		extensions: [ '', '.json', '.js', '.jsx' ],
 		root: [
 			path.join( __dirname, 'client' ),


### PR DESCRIPTION
Related server issue: https://github.com/Automattic/woocommerce-connect-server/issues/507

When the available rates are fetched in the Purchase Label UI, the client stores the `Shipment ID` for each rate received from the server. That `Shipment ID` is sent back to the server in the `Purchase Label` request.

To fully test this, the server branch `add/correct-order-label-purchase` will be needed too. To test, purchase a Label and check (in the Chrome DevTools) that in the request sent to the server each package has, apart from the selected `service_id`, a `shipment_id` of the form `shp_123456789`.

@nabsul @jeffstieler @allendav @robobot3000 
