### PR TITLE
Allow layout schema to provide Text component body.

### DIFF
--- a/client/settings/views/wcc-settings-form/settings-item.js
+++ b/client/settings/views/wcc-settings-form/settings-item.js
@@ -130,7 +130,7 @@ const SettingsItem = ( {
 					id={ id }
 					title={ layout.title }
 					className={ layout.class }
-					value={ fieldValue }
+					value={ fieldValue || layout.description }
 				/>
 			);
 


### PR DESCRIPTION
Allow layout schema to provide `Text` component body.

This avoids having to add non-settings to the form schema, which is how the Self Help page `Text` component is currently rendered.