### PR TITLE
Changed the "report a bug" url

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -419,7 +419,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 					array(  'a' => array( 'href' => array() ) )
 				),
 				esc_url( 'https://docs.woocommerce.com/document/woocommerce-connect-faq/' ),
-				esc_url( 'https://github.com/Automattic/woocommerce-connect-client/issues/new' )
+				esc_url( 'https://wordpress.org/support/plugin/connect-for-woocommerce' )
 			);
 
 			$support_items[] = (object) array(


### PR DESCRIPTION
Fixes #475 

Set the url to https://wordpress.org/support/plugin/connect-for-woocommerce which should be what we get once we submit to .org