### PR TITLE
Generate anonymous UUID

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -366,6 +366,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 
 			// Add interesting fields to the body of each request
 			$body['settings'] = wp_parse_args( $body['settings'], array(
+				'store_guid' => $this->get_guid(),
 				'base_city' => WC()->countries->get_base_city(),
 				'base_country' => WC()->countries->get_base_country(),
 				'base_state' => WC()->countries->get_base_state(),
@@ -456,6 +457,36 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				) ) . "\n";
 
 			return base64_encode( hash_hmac( 'sha1', $normalized_request_string, $token_secret, true ) );
+		}
+
+		private function get_guid() {
+			$guid = get_option( 'wc_connect_store_guid', false );
+			if ( false === $guid ) {
+				$guid = $this->generate_guid();
+				update_option( 'wc_connect_store_guid', $guid );
+			}
+
+			return $guid;
+		}
+
+		/**
+		 * Generates a GUID.
+		 * This code is based of a snippet found in https://github.com/alixaxel/phunction,
+		 * which was referenced in http://php.net/manual/en/function.com-create-guid.php
+		 *
+		 * @return string
+		 */
+		private function generate_guid() {
+			return strtolower( sprintf( '%04X%04X-%04X-%04X-%04X-%04X%04X%04X',
+				mt_rand( 0, 65535 ),
+				mt_rand( 0, 65535 ),
+				mt_rand( 0, 65535 ),
+				mt_rand( 16384, 20479 ),
+				mt_rand( 32768, 49151 ),
+				mt_rand( 0, 65535 ),
+				mt_rand( 0, 65535 ),
+				mt_rand( 0, 65535 )
+			) );
 		}
 	}
 

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -316,7 +316,6 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			update_option( 'wc_connect_packages', $packages );
 		}
 
-
 		private function translate_unit( $value ) {
 			switch ( $value ) {
 				case 'kg':

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -31,9 +31,9 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		 * @return object|array
 		 */
 		public function get_store_options() {
-			$currency_symbol = sanitize_text_field( html_entity_decode( get_woocommerce_currency_symbol() ), array() );
-			$dimension_unit = sanitize_text_field( strtolower( get_option( 'woocommerce_dimension_unit' ) ), array() );
-			$weight_unit = sanitize_text_field( strtolower( get_option( 'woocommerce_weight_unit' ) ), array() );
+			$currency_symbol = sanitize_text_field( html_entity_decode( get_woocommerce_currency_symbol() ) );
+			$dimension_unit = sanitize_text_field( strtolower( get_option( 'woocommerce_dimension_unit' ) ) );
+			$weight_unit = sanitize_text_field( strtolower( get_option( 'woocommerce_weight_unit' ) ) );
 
 			return array(
 				'currency_symbol' => $currency_symbol,


### PR DESCRIPTION
Closes #651 

This PR includes code to create and store a GUID as a store option, and send that GUID with all API requests to the server. This is needed to collect anonymized stats on the server side.

To test:
- Test with pending server PR 607 if it's not merged yet.
- Open up the settings page or anything that requires communication with the server
- Check that there is now a `wc_connect_store_guid` field in the database
- Check that the field is sent with API requests
- Check that if the option is deleted, it is automatically regenerated
- Check that the field is not regenerated if it already exists

@allendav @jeffstieler @DanReyLop @robobot3000 