### PR TITLE
Add support for rate_id and carrier_id fields

### DIFF
--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -471,13 +471,18 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 		const formData = {
 			origin: form.origin.selectNormalized ? form.origin.normalized : form.origin.values,
 			destination: form.destination.selectNormalized ? form.destination.normalized : form.destination.values,
-			packages: _.map( form.packages.selected, ( pckg, pckgId ) => ( {
-				..._.omit( pckg, [ 'items', 'id', 'box_id' ] ),
-				shipment_id: form.rates.available[ pckgId ].shipment_id,
-				service_id: form.rates.values[ pckgId ],
-				service_name: _.find( form.rates.available[ pckgId ].rates, { service_id: form.rates.values[ pckgId ] } ).title,
-				products: _.flatten( pckg.items.map( ( item ) => _.fill( new Array( item.quantity ), item.product_id ) ) ),
-			} ) ),
+			packages: _.map( form.packages.selected, ( pckg, pckgId ) => {
+				const rate = _.find( form.rates.available[ pckgId ].rates, { service_id: form.rates.values[ pckgId ] } );
+				return {
+					..._.omit( pckg, [ 'items', 'id', 'box_id' ] ),
+					shipment_id: form.rates.available[ pckgId ].shipment_id,
+					rate_id: rate.rate_id,
+					service_id: form.rates.values[ pckgId ],
+					carrier_id: rate.carrier_id,
+					service_name: rate.title,
+					products: _.flatten( pckg.items.map( ( item ) => _.fill( new Array( item.quantity ), item.product_id ) ) ),
+				}
+			} ),
 			order_id: form.orderId,
 		};
 

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -481,7 +481,7 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 					carrier_id: rate.carrier_id,
 					service_name: rate.title,
 					products: _.flatten( pckg.items.map( ( item ) => _.fill( new Array( item.quantity ), item.product_id ) ) ),
-				}
+				};
 			} ),
 			order_id: form.orderId,
 		};


### PR DESCRIPTION
Closes #667

This change is needed to support the new handling of rates on the server side.

It adds new fields to the label purchase request: rate_id and carrier_id

To test:
- Buy a label against server PR 615

@allendav @jeffstieler  @DanReyLop @robobot3000 