### PR TITLE
Added UI for managing flat rate packages

### DIFF
--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -177,5 +177,23 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 
 			return $service_schemas->boxes;
 		}
+
+		public function get_predefined_packages_schema() {
+			$service_schemas = $this->get_service_schemas();
+			if ( ! is_object( $service_schemas ) ) {
+				return null;
+			}
+
+			$predefined_packages = array();
+			foreach( $service_schemas->shipping as $service_schema ) {
+				if ( ! isset( $service_schema->packages ) ) {
+					continue;
+				}
+
+				$predefined_packages[ $service_schema->id ] = $service_schema->packages;
+			}
+
+			return ( object ) $predefined_packages;
+		}
 	}
 }

--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -316,6 +316,39 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 			update_option( 'wc_connect_packages', $packages );
 		}
 
+		/**
+		 * Returns a global list of enabled predefined packages for all services
+		 *
+		 * @return array
+		 */
+		public function get_predefined_packages() {
+			return get_option( 'wc_connect_predefined_packages', array() );
+		}
+
+		/**
+		 * Returns a list of enabled predefined packages for the specified service
+		 *
+		 * @param $service_id
+		 * @return array
+		 */
+		public function get_predefined_packages_for_service( $service_id ) {
+			$packages = $this->get_predefined_packages();
+			if ( ! isset( $packages[ $service_id ] ) ) {
+				return array();
+			}
+
+			return $packages[ $service_id ];
+		}
+
+		/**
+		 * Updates the global list of enabled predefined packages for all services
+		 *
+		 * @param array packages
+		 */
+		public function update_predefined_packages( $packages ) {
+			update_option( 'wc_connect_predefined_packages', $packages );
+		}
+
 		private function translate_unit( $value ) {
 			switch ( $value ) {
 				case 'kg':

--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -155,6 +155,20 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			<?php
 		}
 
+		public function get_packages_form_data() {
+			return array(
+				'custom' => $this->service_settings_store->get_packages(),
+				'predefined' => $this->service_settings_store->get_predefined_packages()
+			);
+		}
+
+		public function get_packages_form_schema() {
+			return array(
+				'custom' => $this->service_schemas_store->get_packages_schema(),
+				'predefined' => $this->service_schemas_store->get_predefined_packages_schema()
+			);
+		}
+
 		public function output_packages_screen() {
 			$debug_page_uri = esc_url( add_query_arg(
 				array(
@@ -168,8 +182,8 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 
 			$admin_array = array(
 				'storeOptions' => $store_options,
-				'formSchema'   => $this->service_schemas_store->get_packages_schema(),
-				'formData'     => $this->service_settings_store->get_packages(),
+				'formSchema'   => $this->get_packages_form_schema(),
+				'formData'     => $this->get_packages_form_data(),
 				'callbackURL'  => get_rest_url( null, '/wc/v1/connect/packages' ),
 				'nonce'        => wp_create_nonce( 'wp_rest' ),
 				'submitMethod' => 'POST',

--- a/classes/class-wc-rest-connect-packages-controller.php
+++ b/classes/class-wc-rest-connect-packages-controller.php
@@ -56,7 +56,8 @@ class WC_REST_Connect_Packages_Controller extends WP_REST_Controller {
 		$request_body = $request->get_body();
 		$packages = json_decode( $request_body, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
 
-		$this->service_settings_store->update_packages( $packages );
+		$this->service_settings_store->update_packages( $packages[ 'custom' ] );
+		$this->service_settings_store->update_predefined_packages( $packages[ 'predefined' ] );
 
 		return new WP_REST_Response( array( 'success' => true ), 200 );
 	}

--- a/client/packages/index.js
+++ b/client/packages/index.js
@@ -33,7 +33,8 @@ export default ( { formData, formSchema, storeOptions } ) => ( {
 				packageData: {
 					is_user_defined: true,
 				},
-				packageSchema: formSchema.items,
+				packageSchema: formSchema.custom.items,
+				predefinedSchema: formSchema.predefined,
 			},
 		};
 	},

--- a/client/packages/state/actions.js
+++ b/client/packages/state/actions.js
@@ -10,6 +10,8 @@ export const SET_SELECTED_PRESET = 'SET_SELECTED_PRESET';
 export const SAVE_PACKAGE = 'SAVE_PACKAGE';
 export const UPDATE_PACKAGES_FIELD = 'UPDATE_PACKAGES_FIELD';
 export const TOGGLE_OUTER_DIMENSIONS = 'TOGGLE_OUTER_DIMENSIONS';
+export const TOGGLE_ALL = 'TOGGLE_ALL';
+export const TOGGLE_PACKAGE = 'TOGGLE_PACKAGE';
 
 export const addPackage = () => ( {
 	type: ADD_PACKAGE,
@@ -46,6 +48,18 @@ export const updatePackagesField = ( newValues ) => ( {
 
 export const toggleOuterDimensions = () => ( {
 	type: TOGGLE_OUTER_DIMENSIONS,
+} );
+
+export const toggleAll = ( serviceId, groupId ) => ( {
+	type: TOGGLE_ALL,
+	serviceId,
+	groupId,
+} );
+
+export const togglePackage = ( serviceId, packageId ) => ( {
+	type: TOGGLE_PACKAGE,
+	serviceId,
+	packageId,
 } );
 
 export const setModalErrors = ( value ) => ( {

--- a/client/packages/state/test/reducer.js
+++ b/client/packages/state/test/reducer.js
@@ -15,7 +15,7 @@ import {
 const initialState = {
 	showModal: false,
 	packageData: null,
-	packages: [ 1, 2, 3 ],
+	packages: { custom: [ 1, 2, 3 ] },
 	pristine: true,
 	isSaving: false,
 };
@@ -27,7 +27,7 @@ describe( 'Packages form reducer', () => {
 		expect( initialState ).to.eql( {
 			showModal: false,
 			packageData: null,
-			packages: [ 1, 2, 3 ],
+			packages: { custom: [ 1, 2, 3 ] },
 			pristine: true,
 			isSaving: false,
 		} );
@@ -171,12 +171,12 @@ describe( 'Packages form reducer', () => {
 			mode: 'add',
 			packageData,
 			showOuterDimensions: false,
-			packages: [ 1, 2, 3 ],
+			packages: { custom: [ 1, 2, 3 ] },
 		};
 		const action = savePackage( packageData );
 		const state = reducer( initialSavePackageState, action );
 
-		expect( state.packages[ 3 ] ).to.eql( {
+		expect( state.packages.custom[ 3 ] ).to.eql( {
 			is_user_defined: true,
 			name: 'Test Box',
 		} );
@@ -193,12 +193,12 @@ describe( 'Packages form reducer', () => {
 			mode: 'edit',
 			packageData,
 			showOuterDimensions: false,
-			packages: [ 1, 2, 3 ],
+			packages: { custom: [ 1, 2, 3 ] },
 		};
 		const action = savePackage( packageData );
 		const state = reducer( initialSavePackageState, action );
 
-		expect( state.packages[ 1 ] ).to.eql( {
+		expect( state.packages.custom[ 1 ] ).to.eql( {
 			is_user_defined: true,
 			name: 'Test Box',
 		} );
@@ -215,7 +215,7 @@ describe( 'Packages form reducer', () => {
 			mode: 'edit',
 			packageData,
 			showOuterDimensions: false,
-			packages: [ 1, 2, 3 ],
+			packages: { custom: [ 1, 2, 3 ] },
 		};
 		const action = savePackage( packageData );
 		const state = reducer( initialSavePackageState, action );
@@ -225,7 +225,7 @@ describe( 'Packages form reducer', () => {
 			is_user_defined: true,
 		} );
 		expect( state.mode ).to.eql( 'add' );
-		expect( state.packages[ 1 ] ).to.eql( {
+		expect( state.packages.custom[ 1 ] ).to.eql( {
 			is_user_defined: true,
 			name: 'Test Box',
 		} );
@@ -263,7 +263,7 @@ describe( 'Packages form reducer', () => {
 		const action = removePackage( 1 );
 
 		const state = reducer( initialState, action );
-		expect( state.packages ).to.eql( [ 1, 3 ] );
+		expect( state.packages.custom ).to.eql( [ 1, 3 ] );
 	} );
 
 	it( 'SET_IS_SAVING', () => {

--- a/client/packages/views/add-package.js
+++ b/client/packages/views/add-package.js
@@ -56,9 +56,12 @@ const AddPackageDialog = ( props ) => {
 		weightUnit,
 		packages,
 		packageSchema,
+		predefinedSchema,
 		packageData,
 		showOuterDimensions,
 	} = form;
+
+	const customPackages = packages.custom;
 
 	const {
 		name,
@@ -74,8 +77,15 @@ const AddPackageDialog = ( props ) => {
 	const exampleDimensions = [ 100.25, 25, 5.75 ].map( ( val ) => val.toLocaleString() ).join( ' x ' );
 
 	const onSave = () => {
-		const editName = 'number' === typeof packageData.index ? packages[ packageData.index ].name : null;
-		const boxNames = _.difference( packages.map( ( boxPackage ) => boxPackage.name ), [ editName ] );
+		const editName = 'number' === typeof packageData.index ? customPackages[ packageData.index ].name : null;
+
+		//get reserved box names:
+		const boxNames = _.concat(
+			_.difference( customPackages.map( ( boxPackage ) => boxPackage.name ), [ editName ] ), //existing custom boxes
+			_.flatten( _.map( predefinedSchema, predef => _.map( predef, group => group.definitions ) ) ), //predefined boxes
+			[ 'individual' ] //reserved for items shipping in original packaging
+		);
+
 		const filteredPackageData = Object.assign( {}, packageData, {
 			name: inputFilters.string( packageData.name ),
 			inner_dimensions: inputFilters.dimensions( packageData.inner_dimensions ),

--- a/client/packages/views/index.js
+++ b/client/packages/views/index.js
@@ -4,6 +4,8 @@ import FormSectionHeading from 'components/forms/form-section-heading';
 import ActionButtons from 'components/action-buttons';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormButton from 'components/forms/form-button';
+import FoldableCard from 'components/foldable-card';
+import Gridicon from 'components/gridicon';
 import PackagesList from './packages-list';
 import AddPackageDialog from './add-package';
 import { translate as __ } from 'lib/mixins/i18n';
@@ -13,8 +15,66 @@ import * as PackagesActions from '../state/actions';
 import * as NoticeActions from 'state/notices/actions';
 import GlobalNotices from 'components/global-notices';
 import notices from 'notices';
+import _ from 'lodash';
+import { sprintf } from 'sprintf-js';
 
 const Packages = ( props ) => {
+	const foldableActionButton = (
+		<button className="foldable-card__action foldable-card__expand" type="button">
+			<span className="screen-reader-text">{ __( 'Expand Services' ) }</span>
+			<Gridicon icon="chevron-down" size={ 24 } />
+		</button>
+	);
+
+	const predefSummary = ( serviceSelected, groupDefinitions ) => {
+		const groupPackageIds = groupDefinitions.map( ( def ) => def.id );
+		const diffLen = _.difference( groupPackageIds, serviceSelected ).length;
+
+		if ( 0 >= diffLen ) {
+			return __( 'All packages selected' );
+		}
+
+		const selectedCount = groupPackageIds.length - diffLen;
+		return sprintf( 1 === selectedCount ? __( '%d package selected' ) : __( '%d packages selected' ), selectedCount );
+	};
+
+	const renderPredefinedPackages = () => {
+		const elements = [];
+
+		_.forEach( props.form.predefinedSchema, ( servicePackages, serviceId ) => {
+			const serviceSelected = props.form.packages.predefined[ serviceId ] || [];
+
+			_.forEach( servicePackages, ( predefGroup, groupId ) => {
+				const groupPackages = predefGroup.definitions;
+				const summary = predefSummary( serviceSelected, groupPackages );
+
+				elements.push( <FoldableCard
+					key={ `${serviceId}_${groupId}` }
+					header={ predefGroup.title }
+					summary={ summary }
+					expandedSummary={ summary }
+					clickableHeader={ true }
+					compact
+					actionButton={ foldableActionButton }
+					actionButtonExpanded={ foldableActionButton }
+					expanded={ false }
+				>
+					<PackagesList
+						packages={ groupPackages }
+						selected={ serviceSelected }
+						serviceId={ serviceId }
+						groupId={ groupId }
+						toggleAll={ props.toggleAll }
+						togglePackage={ props.togglePackage }
+						dimensionUnit={ props.form.dimensionUnit }
+						editable={ false } />
+				</FoldableCard> );
+			} );
+		} );
+
+		return elements;
+	};
+
 	const onSaveSuccess = () => props.noticeActions.successNotice( __( 'Your packages have been saved.' ), { duration: 2250 } );
 	const onSaveFailure = () => props.noticeActions.errorNotice( __( 'Unable to save your packages. Please try again.' ), { duration: 7000 } );
 	const onSaveChanges = () => props.saveForm( onSaveSuccess, onSaveFailure );
@@ -32,9 +92,14 @@ const Packages = ( props ) => {
 		<div className="wcc-container">
 			<GlobalNotices id="notices" notices={ notices.list } />
 			<CompactCard className="settings-group-card">
-				<FormSectionHeading className="settings-group-header">{ __( 'Packaging' ) }</FormSectionHeading>
+				<FormSectionHeading className="settings-group-header">{ __( 'Custom packages' ) }</FormSectionHeading>
 				<div className="settings-group-content">
-					<PackagesList { ...props } />
+					<PackagesList
+						packages={ props.form.packages.custom }
+						dimensionUnit={ props.form.dimensionUnit }
+						editable={ true }
+						removePackage={ props.removePackage }
+						editPackage={ props.editPackage } />
 					<AddPackageDialog { ...props } />
 					<FormFieldset className="add-package-button-field">
 						<FormButton
@@ -45,6 +110,12 @@ const Packages = ( props ) => {
 							{ __( 'Add a package' ) }
 						</FormButton>
 					</FormFieldset>
+				</div>
+			</CompactCard>
+			<CompactCard className="settings-group-card">
+				<FormSectionHeading className="settings-group-header">{ __( 'Predefined packages' ) }</FormSectionHeading>
+				<div className="settings-group-content">
+					{ renderPredefinedPackages() }
 				</div>
 			</CompactCard>
 			<CompactCard className="save-button-bar">

--- a/client/packages/views/packages-list-item.js
+++ b/client/packages/views/packages-list-item.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import Gridicon from 'components/gridicon';
 import Button from 'components/button';
+import FormCheckbox from 'components/forms/form-checkbox';
 import classNames from 'classnames';
 import _ from 'lodash';
 import { translate as __ } from 'lib/mixins/i18n';
@@ -12,10 +13,44 @@ const renderIcon = ( isLetter, isError, onClick ) => {
 	} else {
 		icon = isLetter ? 'mail' : 'product';
 	}
+
+	const gridicon = <Gridicon icon={ icon } className="package-type-icon" size={ isError ? 29 : 18 } />;
+	if ( ! onClick ) {
+		return gridicon;
+	}
+
 	return (
-		<a href="#" onClick={ onClick }>
-			<Gridicon icon={ icon } className="package-type-icon" size={ isError ? 29 : 18 } />
-		</a>
+		<a href="#" onClick={ onClick }>{ gridicon }</a>
+	);
+};
+
+const renderName = ( name, openModal ) => {
+	const nameEl = name && '' !== _.trim( name )
+		? name
+		: <span className="package-no-name">{ __( 'Untitled' ) }</span>;
+
+	if ( ! openModal ) {
+		return nameEl;
+	}
+
+	return ( <a href="#" onClick={ openModal }>{ nameEl }</a> );
+};
+
+const renderSelect = ( selected, onToggle ) => {
+	return (
+		<div className="package-actions">
+			<FormCheckbox checked={ selected } onChange={ onToggle } />
+		</div>
+	);
+};
+
+const renderActions = ( onRemove ) => {
+	return (
+		<div className="package-actions">
+			<Button compact borderless className="remove-package" onClick={ onRemove }>
+				<Gridicon icon="cross-small" size={ 18 } />
+			</Button>
+		</div>
 	);
 };
 
@@ -23,37 +58,31 @@ const PackagesListItem = ( {
 	index,
 	data,
 	dimensionUnit,
+	editable,
+	selected,
+	onToggle,
 	onRemove,
 	editPackage,
 	hasError,
 } ) => {
-	const openModal = ( event ) => {
+	const openModal = editable ? ( event ) => {
 		event.preventDefault();
 		editPackage( Object.assign( {}, data, { index } ) );
-	};
+	} : null;
 
 	return (
 		<div className={ classNames( 'wcc-shipping-packages-list-item', { 'wcc-error': hasError } ) }>
+			{ editable ? null : renderSelect( selected, onToggle ) }
 			<div className="package-type">
 				{ renderIcon( data.is_letter, hasError, openModal ) }
 			</div>
 			<div className="package-name">
-				<a href="#" onClick={ openModal }>
-					{
-						data.name && '' !== _.trim( data.name )
-						? data.name
-						: <span className="package-no-name">{ __( 'Untitled' ) }</span>
-					}
-				</a>
+				{ renderName( data.name, openModal ) }
 			</div>
 			<div className="package-dimensions">
 				<span>{ data.inner_dimensions } { dimensionUnit }</span>
 			</div>
-			<div className="package-actions">
-				<Button compact borderless className="remove-package" onClick={ onRemove }>
-					<Gridicon icon="cross-small" size={ 18 } />
-				</Button>
-			</div>
+			{ editable ? renderActions( onRemove ) : null }
 		</div>
 	);
 };
@@ -65,9 +94,12 @@ PackagesListItem.propTypes = {
 		is_letter: PropTypes.bool,
 		inner_dimensions: PropTypes.string,
 	} ).isRequired,
+	editable: PropTypes.bool.isRequired,
+	selected: PropTypes.bool,
 	dimensionUnit: PropTypes.string.isRequired,
-	onRemove: PropTypes.func.isRequired,
-	editPackage: PropTypes.func.isRequired,
+	onToggle: PropTypes.func,
+	onRemove: PropTypes.func,
+	editPackage: PropTypes.func,
 };
 
 export default PackagesListItem;

--- a/client/packages/views/packages-list.js
+++ b/client/packages/views/packages-list.js
@@ -1,9 +1,11 @@
 import React, { PropTypes } from 'react';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
+import FormCheckbox from 'components/forms/form-checkbox';
 import PackagesListItem from './packages-list-item';
 import Gridicon from 'components/gridicon';
 import { translate as __ } from 'lib/mixins/i18n';
+import _ from 'lodash';
 
 const noPackages = () => {
 	return (
@@ -16,18 +18,28 @@ const noPackages = () => {
 	);
 };
 
-const PackagesList = ( { form, removePackage, editPackage } ) => {
-	const {
-		packages,
-		dimensionUnit,
-	} = form;
+const PackagesList = ( { packages, dimensionUnit, editable, selected, serviceId, groupId, removePackage, editPackage, toggleAll, togglePackage } ) => {
+	const renderSelectAll = () => {
+		if ( ! selected ) {
+			return null;
+		}
+
+		const allPackageIds = packages.map( ( def ) => def.id );
+		const selectedAll = 0 === _.difference( allPackageIds, selected ).length;
+		return <FormLegend className="package-actions"><FormCheckbox checked={ selectedAll } onChange={ () => toggleAll( serviceId, groupId ) }/></FormLegend>;
+	};
 
 	const renderPackageListItem = ( pckg, idx ) => {
+		const isSelected = selected && selected.includes( pckg.id );
+
 		return (
 			<PackagesListItem
 				key={ idx }
 				index={ idx }
 				data={ pckg }
+				editable={ editable }
+				selected={ isSelected }
+				onToggle={ () => togglePackage( serviceId, pckg.id ) }
 				onRemove={ () => removePackage( idx ) }
 				{ ...{
 					dimensionUnit,
@@ -40,6 +52,7 @@ const PackagesList = ( { form, removePackage, editPackage } ) => {
 	return (
 		<FormFieldset className="wcc-shipping-packages-list">
 			<div className="wcc-shipping-packages-list-header">
+				{ renderSelectAll() }
 				<FormLegend className="package-type">{ __( 'Type' ) }</FormLegend>
 				<FormLegend className="package-name">{ __( 'Name' ) }</FormLegend>
 				<FormLegend className="package-dimensions">{ __( 'Dimensions (L x W x H)' ) }</FormLegend>
@@ -53,9 +66,16 @@ const PackagesList = ( { form, removePackage, editPackage } ) => {
 };
 
 PackagesList.propTypes = {
-	form: PropTypes.object.isRequired,
-	removePackage: PropTypes.func.isRequired,
-	editPackage: PropTypes.func.isRequired,
+	packages: PropTypes.array.isRequired,
+	dimensionUnit: PropTypes.string.isRequired,
+	editable: PropTypes.bool.isRequired,
+	selected: PropTypes.array,
+	serviceId: PropTypes.string,
+	groupId: PropTypes.string,
+	toggleAll: PropTypes.func,
+	togglePackage: PropTypes.func,
+	removePackage: PropTypes.func,
+	editPackage: PropTypes.func,
 };
 
 export default PackagesList;

--- a/client/packages/views/style.scss
+++ b/client/packages/views/style.scss
@@ -1,192 +1,185 @@
 .wcc-shipping-packages-list {
 
-    div {
-        box-sizing: border-box;
-    }
+	div {
+		box-sizing: border-box;
+	}
 
-    &.form-fieldset {
-        margin-bottom: 12px;
-        padding-bottom: 10px;
-        border-bottom: 1px solid lighten( $gray, 30% );
-    }
+	&.form-fieldset {
+		margin-bottom: 12px;
+		padding-bottom: 10px;
+		border-bottom: 1px solid lighten( $gray, 30% );
+	}
 
-    .package-type {
-        width: 10%;
-        @include breakpoint( '<660px' ) {
-            width: 11%;
-        }
+	.package-type {
+		width: 10%;
+		text-align: center;
+		@include breakpoint( '<660px' ) {
+			width: 11%;
+		}
 
-        .package-type-icon {
-            border-radius: 50%;
-            background-color: lighten( $gray, 10% );
-            fill: white;
-            padding: 4px;
-            margin-bottom: -4px;
-        }
-    }
+	.package-type-icon {
+		fill: $gray;
+		padding: 4px;
+		margin-bottom: -4px;
+	}
+}
 
-    .package-name {
-        width: 51%;
-        padding-right: 8px;
-        @include breakpoint( '<660px' ) {
-            width: 44%;
-        }
+	.package-name {
+		width: 46%;
+		padding-right: 8px;
+		@include breakpoint( '<660px' ) {
+			width: 44%;
+		}
 
-        &.form-legend {
-            padding-right: 0;
-        }
+		&.form-legend {
+			padding-right: 0;
+		}
 
-        .package-no-name {
-            font-style: italic;
-        }
-    }
+		.package-no-name {
+			font-style: italic;
+		}
+	}
 
-    .package-dimensions {
-        width: 34%;
-        cursor: default;
-        @include breakpoint( '<660px' ) {
-            width: 37%;
-        }
-        &.form-legend {
-            width: 39%;
-            @include breakpoint( '<660px' ) {
-                width: 45%;
-            }
-        }
-    }
+	.package-dimensions {
+		width: 39%;
+		cursor: default;
+		@include breakpoint( '<660px' ) {
+			width: 37%;
+		}
+	}
 
-    .package-actions {
-        width: 5%;
-        text-align: right;
-        @include breakpoint( '<660px' ) {
-            width: 8%;
-        }
-    }
+	.package-actions {
+		width: 5%;
+		text-align: right;
+		@include breakpoint( '<660px' ) {
+			width: 8%;
+		}
+	}
 
-    .packages-list-empty {
-        padding: 8px 0;
-    }
+	.packages-list-empty {
+		padding: 8px 0;
+	}
 
-    .package-list-empty-icon .gridicon {
-        margin-right: 8px;
-        margin-bottom: -4px;
-        fill: $gray;
-    }
+	.package-list-empty-icon .gridicon {
+		margin-right: 8px;
+		margin-bottom: -4px;
+		fill: $gray;
+	}
 
-    .packages-list-empty-description {
-        color: $gray;
-    }
+	.packages-list-empty-description {
+		color: $gray;
+	}
 
 }
 
 .wcc-shipping-packages-list-header {
-    display: flex;
-    height: 26px;
-    border-bottom: 1px solid lighten( $gray, 30% );
+	display: flex;
+	height: 26px;
+	border-bottom: 1px solid lighten( $gray, 30% );
 }
 
 .wcc-shipping-packages-list-item,
 .packages-list-empty {
-    margin-top: 8px;
-    display: flex;
-    align-items: center;
-    &.wcc-error {
-        color: red;
-        a {
-            color: red;
-        }
-        .package-type .gridicon {
-            background-color: unset;
-            border-radius: unset;
-            fill: red;
-            padding: unset;
-            margin-left: -1px;
-        }
-    }
+	margin-top: 8px;
+	display: flex;
+	//align-items: center;
+	&.wcc-error {
+		color: $alert-red;
+		a {
+			color: $alert-red;
+		}
+		.package-type .gridicon {
+			background-color: unset;
+			border-radius: unset;
+			fill: $alert-red;
+			padding: unset;
+			margin-left: -1px;
+		}
+	}
 }
 
 .wcc-shipping-add-package-weight {
-    margin-bottom: 8px;
-    @include breakpoint( '>660px' ) {
-        float:left;
-    }
+	margin-bottom: 8px;
+	@include breakpoint( '>660px' ) {
+		float:left;
+	}
 
-    &:nth-child(2) {
-        width: 100%;
-        @include breakpoint( '>660px' ) {
-            width: 54%;
-        }
-    }
+	&:nth-child(2) {
+		width: 100%;
+		@include breakpoint( '>660px' ) {
+			width: 54%;
+		}
+	}
 
-    #box_weight,
-    #max_weight {
-        width: 82%;
-    }
+	#box_weight,
+	#max_weight {
+		width: 82%;
+	}
 
-    #max_weight {
-        @include breakpoint( '>660px' ) {
-            width: 66%;
-        }
-    }
+	#max_weight {
+		@include breakpoint( '>660px' ) {
+			width: 66%;
+		}
+	}
 
-    .wcc-shipping-add-package-weight-unit {
-        width: 34%;
-        padding-left: 8px;
-    }
+	.wcc-shipping-add-package-weight-unit {
+		width: 34%;
+		padding-left: 8px;
+	}
 }
 
 #package_type {
-    display: block;
-    width: 100%;
+	display: block;
+	width: 100%;
 }
 
 .wcc-shipping-add-package-weight-group {
-    .form-setting-explanation {
-        @include breakpoint( '>660px' ) {
-            clear: both;
-        }
-    }
+	.form-setting-explanation {
+		@include breakpoint( '>660px' ) {
+			clear: both;
+		}
+	}
 }
 
 & .wcc-shipping-add-edit-package-dialog {
-    .form-setting-explanation {
-        display: inline-block;
-    }
+	.form-setting-explanation {
+		display: inline-block;
+	}
 }
 
 .button.is-borderless.remove-package {
-    color: lighten( $gray, 10% );
+	color: lighten( $gray, 10% );
 
-    &:hover {
-        color: $alert-red;
-    }
+	&:hover {
+		color: $alert-red;
+	}
 
-    &:focus {
-        box-shadow: 0 0 0 1px $blue-medium, 0 0 2px 1px rgba( $blue-medium, 0.8 );
-    }
+	&:focus {
+		box-shadow: 0 0 0 1px $blue-medium, 0 0 2px 1px rgba( $blue-medium, 0.8 );
+	}
 }
 
 .add-package-button-field .button {
-    float: left;
-    margin-left: 0;
+	float: left;
+	margin-left: 0;
 }
 
 .form-text-input.flat-rate-package__inner-dimensions__read-only:disabled,
 .form-text-input.flat-rate-package__outer-dimensions__read-only:disabled,
 .form-text-input.flat-rate-package__package-weight__read-only:disabled,
 .form-text-input.flat-rate-package__max-weight__read-only:disabled {
-    border: 0;
-    background: white !important;
-    padding: 0 32px 0 0;
-    cursor: default;
-    color: $gray-dark;
-    -webkit-text-fill-color: $gray-dark;
+	border: 0;
+	background: white !important;
+	padding: 0 32px 0 0;
+	cursor: default;
+	color: $gray-dark;
+	-webkit-text-fill-color: $gray-dark;
 
-    &::placeholder {
-        color: $gray-dark;
-    }
+	&::placeholder {
+		color: $gray-dark;
+	}
 
-    &:focus {
-        box-shadow: none;
-    }
+	&:focus {
+		box-shadow: none;
+	}
 }

--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -7,7 +7,7 @@ import form from './state/reducer';
 // from calypso
 import notices from 'state/notices/reducer';
 
-export default ( { formData, formSchema, formLayout, storeOptions } ) => ( {
+export default ( { formData, formSchema, formLayout, storeOptions, predefinedPackages } ) => ( {
 	getReducer() {
 		return combineReducers( {
 			form,
@@ -30,6 +30,7 @@ export default ( { formData, formSchema, formLayout, storeOptions } ) => ( {
 		<SettingsView
 			storeOptions={ storeOptions }
 			schema={ formSchema }
-			layout={ formLayout } />
+			layout={ formLayout }
+			predefinedPackages={ predefinedPackages } />
 	),
 } );

--- a/client/settings/views/index.js
+++ b/client/settings/views/index.js
@@ -18,6 +18,7 @@ Settings.propTypes = {
 	storeOptions: PropTypes.object.isRequired,
 	schema: PropTypes.object.isRequired,
 	layout: PropTypes.array.isRequired,
+	predefinedPackages: PropTypes.array.isRequired,
 };
 
 export default Settings;

--- a/client/settings/views/services/group.js
+++ b/client/settings/views/services/group.js
@@ -30,6 +30,7 @@ const ShippingServiceGroup = ( props ) => {
 		services,
 		updateValue,
 		errors,
+		predefinedPackages,
 	} = props;
 	const summary = summaryLabel( services );
 	const actionButton = (
@@ -63,14 +64,18 @@ const ShippingServiceGroup = ( props ) => {
 				</label>
 			</div>
 
-			{ services.map( ( service, idx ) => (
-				<ShippingServiceEntry
+			{ services.map( ( service, idx ) => {
+				if ( service.predefined_package && ! predefinedPackages.includes( service.predefined_package ) ) {
+					return null;
+				}
+
+				return <ShippingServiceEntry
 					{ ...props }
 					{ ...{ service } }
 					updateValue={ ( key, val ) => updateValue( [ service.id ].concat( key ), val ) }
 					key={ idx }
-				/>
-			) ) }
+				/>;
+			} ) }
 		</FoldableCard>
 	);
 };
@@ -88,6 +93,7 @@ ShippingServiceGroup.propTypes = {
 		adjustment_type: PropTypes.string,
 	} ) ).isRequired,
 	updateValue: PropTypes.func.isRequired,
+	predefinedPackages: PropTypes.array.isRequired,
 };
 
 export default ShippingServiceGroup;

--- a/client/settings/views/services/index.js
+++ b/client/settings/views/services/index.js
@@ -12,6 +12,7 @@ const ShippingServiceGroups = ( {
 	description,
 	services,
 	settings,
+	predefinedPackages,
 	currencySymbol,
 	updateValue,
 	settingsKey,
@@ -38,6 +39,7 @@ const ShippingServiceGroups = ( {
 				key={ serviceGroup }
 				title={ serviceGroups[ serviceGroup ][ 0 ].group_name }
 				services={ serviceGroups[ serviceGroup ] }
+				predefinedPackages={ predefinedPackages }
 				currencySymbol={ currencySymbol }
 				updateValue={ updateValue }
 				settingsKey={ settingsKey }
@@ -66,6 +68,7 @@ ShippingServiceGroups.propTypes = {
 	currencySymbol: PropTypes.string,
 	updateValue: PropTypes.func.isRequired,
 	settingsKey: PropTypes.string.isRequired,
+	predefinedPackages: PropTypes.array.isRequired,
 };
 
 ShippingServiceGroups.defaultProps = {

--- a/client/settings/views/wcc-settings-form/index.js
+++ b/client/settings/views/wcc-settings-form/index.js
@@ -30,6 +30,7 @@ WCCSettingsForm.propTypes = {
 	storeOptions: PropTypes.object.isRequired,
 	schema: PropTypes.object.isRequired,
 	layout: PropTypes.array.isRequired,
+	predefinedPackages: PropTypes.array.isRequired,
 };
 
 function mapStateToProps( state, props ) {

--- a/client/settings/views/wcc-settings-form/settings-group.js
+++ b/client/settings/views/wcc-settings-form/settings-group.js
@@ -97,6 +97,7 @@ SettingsGroup.propTypes = {
 	} ),
 	schema: PropTypes.object.isRequired,
 	storeOptions: PropTypes.object.isRequired,
+	predefinedPackages: PropTypes.array.isRequired,
 	saveForm: PropTypes.func.isRequired,
 	form: PropTypes.object.isRequired,
 	formActions: PropTypes.object.isRequired,

--- a/client/settings/views/wcc-settings-form/settings-item.js
+++ b/client/settings/views/wcc-settings-form/settings-item.js
@@ -18,6 +18,7 @@ const SettingsItem = ( {
 	form,
 	layout,
 	schema,
+	predefinedPackages,
 	formValueActions,
 	storeOptions,
 	errors,
@@ -91,6 +92,7 @@ const SettingsItem = ( {
 					services={ schema.definitions.services }
 					title={ fieldSchema.title }
 					description={ fieldSchema.description }
+					predefinedPackages={ predefinedPackages }
 					settings={ fieldValue }
 					currencySymbol={ storeOptions.currency_symbol }
 					updateValue={ updateSubValue }
@@ -197,6 +199,7 @@ SettingsItem.propTypes = {
 		PropTypes.object.isRequired,
 	] ).isRequired,
 	schema: PropTypes.object.isRequired,
+	predefinedPackages: PropTypes.array.isRequired,
 	storeOptions: PropTypes.object.isRequired,
 	form: PropTypes.object.isRequired,
 	formValueActions: PropTypes.object.isRequired,

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -489,13 +489,14 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			$path = $instance ? "/wc/v1/connect/services/{$id}/{$instance}" : "/wc/v1/connect/services/{$id}";
 
 			$admin_array = array(
-				'storeOptions' => $settings_store->get_store_options(),
-				'formSchema'   => $service_schema->service_settings,
-				'formLayout'   => $service_schema->form_layout,
-				'formData'     => $settings_store->get_service_settings( $id, $instance ),
-				'callbackURL'  => get_rest_url( null, $path ),
-				'nonce'        => wp_create_nonce( 'wp_rest' ),
-				'rootView'     => 'wc-connect-service-settings',
+				'storeOptions'       => $settings_store->get_store_options(),
+				'formSchema'         => $service_schema->service_settings,
+				'formLayout'         => $service_schema->form_layout,
+				'formData'           => $settings_store->get_service_settings( $id, $instance ),
+				'predefinedPackages' => $settings_store->get_predefined_packages_for_service( $id ),
+				'callbackURL'        => get_rest_url( null, $path ),
+				'nonce'              => wp_create_nonce( 'wp_rest' ),
+				'rootView'           => 'wc-connect-service-settings',
 			);
 
 			wp_localize_script( 'wc_connect_admin', 'wcConnectData', $admin_array );


### PR DESCRIPTION
Adds #670 

Should be tested with `add/centralized-flat-rates` checked out on the server-side.

To test:
- Check that you can see the predefined packages in the Packaging Manager:
<img width="710" alt="screen shot 2016-11-07 at 14 03 49" src="https://cloud.githubusercontent.com/assets/800604/20057224/1456b2f8-a4f3-11e6-8945-67251f4fdfff.png">
- Check that disabling the packages hides the corresponding services from the shipping instance settings:
<img width="724" alt="screen shot 2016-11-07 at 14 05 39" src="https://cloud.githubusercontent.com/assets/800604/20057254/4949fb1e-a4f3-11e6-94d9-6f72a0452417.png">
- Check that no flat rates are returned to the customers when flat rate packages are disabled in the packaging manager