### PR TITLE
Allow scripts to enqueue even if no schemas are available

### DIFF
--- a/client/components/text/index.js
+++ b/client/components/text/index.js
@@ -32,7 +32,7 @@ const Text = ( { id, title, className, value } ) => {
 
 Text.propTypes = {
 	id: PropTypes.string.isRequired,
-	title: PropTypes.string.isRequired,
+	title: PropTypes.string,
 	className: PropTypes.string,
 	value: PropTypes.string.isRequired,
 };

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -391,15 +391,15 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 				add_filter( 'woocommerce_shipping_methods', array( $this, 'woocommerce_shipping_methods' ) );
 				add_action( 'woocommerce_load_shipping_methods', array( $this, 'woocommerce_load_shipping_methods' ) );
 				add_filter( 'woocommerce_payment_gateways', array( $this, 'woocommerce_payment_gateways' ) );
-				add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 				add_action( 'wc_connect_service_init', array( $this, 'init_service' ), 10, 2 );
-				add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
 				add_action( 'wc_connect_service_admin_options', array( $this, 'localize_and_enqueue_service_script' ), 10, 2 );
 				add_action( 'woocommerce_shipping_zone_method_added', array( $this, 'shipping_zone_method_added' ), 10, 3 );
 				add_action( 'woocommerce_shipping_zone_method_deleted', array( $this, 'shipping_zone_method_deleted' ), 10, 3 );
 				add_action( 'woocommerce_shipping_zone_method_status_toggled', array( $this, 'shipping_zone_method_status_toggled' ), 10, 4 );
 			}
 
+			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
+			add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
 			add_action( 'woocommerce_settings_saved', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_action( 'wc_connect_fetch_service_schemas', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_filter( 'woocommerce_hidden_order_itemmeta', array( $this, 'hide_wc_connect_package_meta_data' ) );


### PR DESCRIPTION
Allow admin scripts to enqueue even if no schemas are available since only shipping method instance admin views require schemas.

To test:
* kill your local server so that the client cannot get schemas from it
* delete the wc_connect_services option
* go to wp-admin > WooCommerce > System Status > Connect for WooCommerce
* verify you are able to see self-help and that you are able to toggle debug logging on and off

Fixes #613 