### PR TITLE
Fix label Preview

### DIFF
--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -378,8 +378,8 @@ const refreshPreview = ( dispatch, getState, context ) => {
 	const state = getState().shippingLabel;
 	const { form, paperSize } = state;
 	let pckgIndex = 1;
-	const labels = _.map( form.packages.values, () => ( {
-		caption: sprintf( __( 'PACKAGE %d (OF %d)' ), pckgIndex++, Object.keys( form.packages.values ).length ),
+	const labels = _.map( form.packages.selected, () => ( {
+		caption: sprintf( __( 'PACKAGE %d (OF %d)' ), pckgIndex++, Object.keys( form.packages.selected ).length ),
 	} ) );
 
 	dispatch( {


### PR DESCRIPTION
With one of the Packaging PRs, the state tree structure changes, so `form.packages.values` doesn't exist anymore, and to iterate on the selected packages we must use `form.packages.selelcted` instead. This was broken during a rebase (or maybe a merge).

@nabsul