### PR TITLE
Add/669 store shipping details

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -300,7 +300,15 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 			wp_enqueue_style( 'wc_connect_admin' );
 
 			?>
-			<div class="wc-connect-admin-container" id="<?php echo esc_attr( $root_view ) ?>"><span class="form-troubles" style="opacity: 0"><?php printf( __( 'Shipping labels not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.', 'connectforwoocommerce' ), $debug_page_uri ); ?></span></div>
+			<div class="wc-connect-admin-container" id="<?php echo esc_attr( $root_view ) ?>">
+				<span class="form-troubles" style="opacity: 0">
+					<?php printf( __(
+						'Shipping labels not loading? Visit the <a href="%s">status page</a> for troubleshooting steps.',
+						'connectforwoocommerce' ),
+						$debug_page_uri
+					); ?>
+				</span>
+			</div>
 			<?php
 		}
 

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -71,7 +71,7 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WP_REST_Controller {
 		$payload[ 'carrier' ] = 'usps';
 
 		// Exclude extraneous package fields
-		$whitelist = array_fill_keys( array( 'length', 'width', 'height', 'weight', 'template' ), true );
+		$whitelist = array_fill_keys( array( 'length', 'width', 'height', 'weight', 'template', 'service_id' ), true );
 		$formatted_packages = array();
 
 		foreach ( $payload[ 'packages' ] as $package_id => $package ) {

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -468,7 +468,14 @@ reducers[ RATES_RETRIEVAL_COMPLETED ] = ( state, { rates } ) => {
 	return { ...state,
 		form: { ...state.form,
 			rates: {
-				values: _.mapValues( state.form.rates.values, () => '' ),
+				values: _.mapValues( rates, ( rate ) => {
+					const selected = rate.rates.find( ( r ) => r.is_selected );
+					if ( selected ) {
+						return selected.service_id;
+					}
+
+					return '';
+				} ),
 				retrievalInProgress: false,
 				available: rates,
 			},


### PR DESCRIPTION
Closes #669 

This PR includes the following changes:
- Pass `service_id` field to connect server
- Check for `is_selected` in label rate response and use it if it's there
- Minor refactoring of a really long line of code

To test: 
- Test with corresponding server PR 
- Buy an item as a customer and select a shipping rate that is recognized in the mapping https://github.com/Automattic/woocommerce-connect-server/blob/master/lib/shipping/usps/easypost-service-mapping.js#L1
- Log in as an admin and open the order page
- Open the modal for printing a shipping label, and observe that the rate is pre-selected
- Server should also continue to work as usual with current client

@allendav @jeffstieler @robobot3000 @DanReyLop 
