### PR TITLE
Add flat rate packages to labels

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -165,7 +165,7 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 *		),
 		 *		array(
 		 *			'id' => 'box_2',
-		 *			'template' => 'medium_flat_box_top',
+		 *			'box_id' => 'medium_flat_box_top',
 		 *			'weight' => 5,
 		 *		),
 		 *		...

--- a/classes/class-wc-connect-service-schemas-store.php
+++ b/classes/class-wc-connect-service-schemas-store.php
@@ -195,5 +195,16 @@ if ( ! class_exists( 'WC_Connect_Service_Schemas_Store' ) ) {
 
 			return ( object ) $predefined_packages;
 		}
+
+		public function get_predefined_packages_schema_for_service( $service_id ) {
+			$package_schemas = $this->get_predefined_packages_schema();
+
+			if ( is_null( $package_schemas )
+			     || ! property_exists( $package_schemas, $service_id ) ) {
+				return array();
+			}
+
+			return $package_schemas->{ $service_id };
+		}
 	}
 }

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -70,19 +70,6 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WP_REST_Controller {
 		// Hardcode USPS rates for now
 		$payload[ 'carrier' ] = 'usps';
 
-		// Exclude extraneous package fields
-		$whitelist = array_fill_keys( array( 'length', 'width', 'height', 'weight', 'template', 'service_id' ), true );
-		$formatted_packages = array();
-
-		foreach ( $payload[ 'packages' ] as $package_id => $package ) {
-			$formatted_package = array_intersect_key( $package, $whitelist );
-			$formatted_package[ 'id' ] = $package_id;
-
-			$formatted_packages[] = $formatted_package;
-		}
-
-		$payload[ 'packages' ] = $formatted_packages;
-
 		$response = $this->api_client->get_label_rates( $payload );
 
 		if ( is_wp_error( $response ) ) {

--- a/client/shipping-label/index.js
+++ b/client/shipping-label/index.js
@@ -47,6 +47,7 @@ export default ( { formData, labelsData, paperSize, storeOptions } ) => ( {
 					},
 					packages: {
 						all: formData.all_packages,
+						flatRateGroups: formData.flat_rate_groups,
 						selected: formData.selected_packages,
 						unpacked: [],
 						isPacked: formData.is_packed,

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -102,6 +102,10 @@ export const submitStep = ( stepName ) => ( dispatch, getState, { storeOptions }
 	expandFirstErroneousStep( dispatch, getState, storeOptions, stepName );
 };
 
+const convertToApiPackage = ( pckg ) => {
+	return _.pick( pckg, [ 'id', 'box_id', 'service_id', 'length', 'width', 'height', 'weight' ] );
+};
+
 const getLabelRates = ( dispatch, getState, handleResponse, { getRatesURL, nonce } ) => {
 	const formState = getState().shippingLabel.form;
 	const {
@@ -110,7 +114,7 @@ const getLabelRates = ( dispatch, getState, handleResponse, { getRatesURL, nonce
 		packages,
 	} = formState;
 
-	return getRates( dispatch, origin.values, destination.values, packages.selected, getRatesURL, nonce )
+	return getRates( dispatch, origin.values, destination.values, _.map( packages.selected, convertToApiPackage ), getRatesURL, nonce )
 		.then( handleResponse )
 		.catch( ( error ) => {
 			console.error( error );
@@ -474,7 +478,7 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 			packages: _.map( form.packages.selected, ( pckg, pckgId ) => {
 				const rate = _.find( form.rates.available[ pckgId ].rates, { service_id: form.rates.values[ pckgId ] } );
 				return {
-					..._.omit( pckg, [ 'items', 'id', 'box_id' ] ),
+					...convertToApiPackage( pckg ),
 					shipment_id: form.rates.available[ pckgId ].shipment_id,
 					rate_id: rate.rate_id,
 					service_id: form.rates.values[ pckgId ],

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -367,7 +367,7 @@ reducers[ SET_PACKAGE_TYPE ] = ( state, { packageId, boxTypeId } ) => {
 	const oldPackage = newPackages[ packageId ];
 
 	newPackages[ packageId ] = {
-		...oldPackage,
+		..._.omit( oldPackage, 'service_id' ),
 		height, length, width,
 		weight: box.box_weight + _.sumBy( oldPackage.items, 'weight' ),
 		box_id: boxTypeId,

--- a/client/shipping-label/views/purchase/steps/packages/index.js
+++ b/client/shipping-label/views/purchase/steps/packages/index.js
@@ -14,6 +14,7 @@ const PackagesStep = ( {
 	openedPackageId,
 	selected,
 	all,
+	flatRateGroups,
 	unpacked,
 	storeOptions,
 	labelActions,
@@ -73,6 +74,7 @@ const PackagesStep = ( {
 					packageId={ openedPackageId }
 					selected={ selected }
 					all={ all }
+					flatRateGroups={ flatRateGroups }
 					unpacked={ unpacked }
 					dimensionUnit={ storeOptions.dimension_unit }
 					weightUnit={ storeOptions.weight_unit }
@@ -151,6 +153,7 @@ PackagesStep.propTypes = {
 	showItemMoveDialog: PropTypes.bool,
 	selected: PropTypes.object.isRequired,
 	all: PropTypes.object.isRequired,
+	flatRateGroups: PropTypes.object.isRequired,
 	labelActions: PropTypes.object.isRequired,
 	storeOptions: PropTypes.object.isRequired,
 	errors: PropTypes.object.isRequired,

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -732,7 +732,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		}
 
 		public function add_meta_boxes() {
-			$shipping_label = new WC_Connect_Shipping_Label( $this->api_client, $this->service_settings_store );
+			$shipping_label = new WC_Connect_Shipping_Label( $this->api_client, $this->service_settings_store, $this->service_schemas_store );
 			if ( $shipping_label->should_show_meta_box() ) {
 				add_meta_box( 'woocommerce-order-label', __( 'Shipping Label', 'connectforwoocommerce' ), array( $shipping_label, 'meta_box' ), null, 'side', 'default' );
 			}


### PR DESCRIPTION
Adds #671

Test with https://github.com/Automattic/woocommerce-connect-server/pull/625 

To test:
* open the label print UI
* verify that the flat rate packages appear in the packaging editor
  * at the moment all flat rate packages are shown, regardless of what has been enabled/disabled in the packaging manager
* select one or more flat rate packages
* verify that the prices that appear are for flat rate deliveries
* check that purchasing a label works