### PR TITLE
During activation and deactivation, test for dependencies before using them

### DIFF
--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -70,7 +70,7 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 				$wc_version = WC()->version;
 			}
 
-			$jp_version = "unavailable";
+			$jp_version = 'unavailable';
 			if ( defined( 'JETPACK__VERSION' ) ) {
 				$jp_version = JETPACK__VERSION;
 			}

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -65,11 +65,13 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 			$user = wp_get_current_user();
 			$site_url = get_option( 'siteurl' );
 
+			// Check for WooCommerce
 			$wc_version = 'unavailable';
 			if ( function_exists( 'WC' ) ) {
 				$wc_version = WC()->version;
 			}
 
+			// Check for Jetpack
 			$jp_version = 'unavailable';
 			if ( defined( 'JETPACK__VERSION' ) ) {
 				$jp_version = JETPACK__VERSION;

--- a/classes/class-wc-connect-tracks.php
+++ b/classes/class-wc-connect-tracks.php
@@ -15,7 +15,7 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 		 */
 		protected $logger;
 
-		public function __construct( WC_Connect_Logger $logger ) {
+		public function __construct( WC_Connect_Logger $logger = null ) {
 			$this->logger = $logger;
 			add_action( 'wc_connect_shipping_zone_method_added', array( $this, 'shipping_zone_method_added' ), 10, 3 );
 			add_action( 'wc_connect_shipping_zone_method_deleted', array( $this, 'shipping_zone_method_deleted' ), 10, 3 );
@@ -58,26 +58,47 @@ if ( ! class_exists( 'WC_Connect_Tracks' ) ) {
 
 		public function record_user_event( $event_type, $data = array() ) {
 			if ( ! function_exists( 'jetpack_tracks_record_event' ) ) {
-				$this->logger->log( 'Error. jetpack_tracks_record_event is not defined.' );
+				$this->log( 'Error. jetpack_tracks_record_event is not defined.' );
 				return;
 			}
 
 			$user = wp_get_current_user();
 			$site_url = get_option( 'siteurl' );
 
+			$wc_version = 'unavailable';
+			if ( function_exists( 'WC' ) ) {
+				$wc_version = WC()->version;
+			}
+
+			$jp_version = "unavailable";
+			if ( defined( 'JETPACK__VERSION' ) ) {
+				$jp_version = JETPACK__VERSION;
+			}
+
+			$jetpack_blog_id = -1;
+			if ( class_exists( 'Jetpack_Options' ) && method_exists( 'Jetpack_Options', 'get_option' ) ) {
+				$jetpack_blog_id = Jetpack_Options::get_option( 'id' );
+			}
+
 			$data['_via_ua'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
 			$data['_via_ip'] = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '';
 			$data['_lg'] = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : '';
 			$data['blog_url'] = $site_url;
-			$data['blog_id'] = Jetpack_Options::get_option( 'id' );
-			$data['jetpack_version'] = JETPACK__VERSION;
-			$data['wc_version'] = WC()->version;
+			$data['blog_id'] = $jetpack_blog_id;
+			$data['jetpack_version'] = $jp_version;
+			$data['wc_version'] = $wc_version;
 			$data['wp_version'] = get_bloginfo( 'version' );
 
 			$event_type = self::$product_name . '_' . $event_type;
 
-			$this->logger->log( 'Tracked the following event: ' . $event_type );
+			$this->log( 'Tracked the following event: ' . $event_type );
 			return jetpack_tracks_record_event( $user, $event_type, $data );
+		}
+
+		protected function log( $message ) {
+			if ( ! is_null( $this->logger ) ) {
+				$this->logger->log( $message );
+			}
 		}
 
 	}

--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -139,9 +139,11 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 		static function load_tracks_for_activation_hooks() {
 			require_once( plugin_basename( 'classes/class-wc-connect-logger.php' ) );
 			require_once( plugin_basename( 'classes/class-wc-connect-tracks.php' ) );
-			$logger = new WC_Connect_Logger( new WC_Logger() );
+			$logger = null;
+			if ( class_exists( 'WC_Logger' ) ) {
+				$logger = new WC_Connect_Logger( new WC_Logger() );
+			}
 			return new WC_Connect_Tracks( $logger );
-
 		}
 
 		static function plugin_activation() {


### PR DESCRIPTION
Fixes #688 

To test:
* Install and activate WooCommerce and WooCommerce Connect
* Install, activate and connect Jetpack
* Make sure WP_DEBUG is enabled
* Tail the admin error log
* Deactivate and activate Connect for WooCommerce and make sure deactivation/activation succeeds and  no errors display on the screen.
* The following may be logged from time to time - this is normal
 * `jetpack_data_class_not_found Unable to send request to Connect for WooCommerce server. Jetpack_Data was not found. (fetch_service_schemas_from_connect_server)`
 * `Error. jetpack_tracks_record_event is not defined.`
* Repeat without Jetpack activated
* Repeat without WooCommerce activated
* Repeat without neither Jetpack nor WooCommerce activated

