### PR TITLE
Added an spinner to the "Purchase" button while the request is being processed

### DIFF
--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -177,6 +177,29 @@
 	.wcc-shipping-label-dialog__button-spinner {
 		margin-right: 6px;
 		margin-bottom: -8px;
+
+		.spinner__border {
+			fill: transparent;
+		}
+	}
+
+	.wcc-shipping-label-dialog__purchasing-label {
+		color: $blue-wordpress;
+		-webkit-animation: pulsate 2s ease-out;
+		-webkit-animation-iteration-count: infinite;
+		opacity: 0.5;
+	}
+
+	@-webkit-keyframes pulsate {
+		0% {
+			opacity: 0.5;
+		}
+		50% {
+			opacity: 1.0;
+		}
+		100% {
+			opacity: 0.5;
+		}
 	}
 }
 

--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -185,12 +185,12 @@
 
 	.wcc-shipping-label-dialog__purchasing-label {
 		color: $blue-wordpress;
-		-webkit-animation: pulsate 2s ease-out;
-		-webkit-animation-iteration-count: infinite;
+		animation: pulsate 2s ease-out;
+		animation-iteration-count: infinite;
 		opacity: 0.5;
 	}
 
-	@-webkit-keyframes pulsate {
+	@keyframes pulsate {
 		0% {
 			opacity: 0.5;
 		}

--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -173,6 +173,11 @@
 			text-transform: uppercase;
 		}
 	}
+
+	.wcc-shipping-label-dialog__button-spinner {
+		margin-right: 6px;
+		margin-bottom: -8px;
+	}
 }
 
 // Notice

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -41,13 +41,21 @@
         padding: 5px 14px 7px;
     }
 
-    .button.is-primary {
-        background: $blue-wordpress;
-        border-color: $blue-dark;
-        &:hover {
-            background: $button-hover;
-        }
-    }
+	.button.is-primary {
+		background: $blue-wordpress;
+		border-color: $blue-dark;
+		&:hover {
+			background: $button-hover;
+		}
+		// overwrite core styles
+		&:disabled {
+			background: tint( $blue-light, 50% ) !important;
+			border-color: tint( $blue-wordpress, 55% ) !important;
+			color: $white !important;
+			text-shadow: none !important;
+		}
+
+	}
 
     // Forms
     input[type="text"],

--- a/client/components/action-buttons/index.js
+++ b/client/components/action-buttons/index.js
@@ -22,7 +22,7 @@ const ActionButtons = ( { buttons, className } ) => {
 ActionButtons.propTypes = {
 	buttons: PropTypes.arrayOf(
 		PropTypes.shape( {
-			label: PropTypes.string.isRequired,
+			label: PropTypes.node.isRequired,
 			onClick: PropTypes.func.isRequired,
 			isPrimary: PropTypes.bool,
 			isDisabled: PropTypes.bool,

--- a/client/shipping-label/views/purchase/index.js
+++ b/client/shipping-label/views/purchase/index.js
@@ -14,7 +14,7 @@ const PrintLabelDialog = ( props ) => {
 	const currencySymbol = props.storeOptions.currency_symbol;
 
 	const getPurchaseButtonLabel = () => {
-		if ( true || props.form.isSubmitting ) {
+		if ( props.form.isSubmitting ) {
 			return (
 				<div>
 					<Spinner size={ 24 } className="wcc-shipping-label-dialog__button-spinner" />

--- a/client/shipping-label/views/purchase/index.js
+++ b/client/shipping-label/views/purchase/index.js
@@ -14,11 +14,11 @@ const PrintLabelDialog = ( props ) => {
 	const currencySymbol = props.storeOptions.currency_symbol;
 
 	const getPurchaseButtonLabel = () => {
-		if ( props.form.isSubmitting ) {
+		if ( true || props.form.isSubmitting ) {
 			return (
 				<div>
 					<Spinner size={ 24 } className="wcc-shipping-label-dialog__button-spinner" />
-					<span>{ __( 'Purchasing...' ) }</span>
+					<span className="wcc-shipping-label-dialog__purchasing-label">{ __( 'Purchasing...' ) }</span>
 				</div>
 			);
 		}

--- a/client/shipping-label/views/purchase/index.js
+++ b/client/shipping-label/views/purchase/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Dialog from 'components/dialog';
 import ActionButtons from 'components/action-buttons';
+import Spinner from 'components/spinner';
 import { translate as __ } from 'lib/mixins/i18n';
 import AddressStep from './steps/address';
 import PackagesStep from './steps/packages';
@@ -13,6 +14,14 @@ const PrintLabelDialog = ( props ) => {
 	const currencySymbol = props.storeOptions.currency_symbol;
 
 	const getPurchaseButtonLabel = () => {
+		if ( props.form.isSubmitting ) {
+			return (
+				<div>
+					<Spinner size={ 24 } className="wcc-shipping-label-dialog__button-spinner" />
+					<span>{ __( 'Purchasing...' ) }</span>
+				</div>
+			);
+		}
 		let label = __( 'Buy & Print' );
 		const nPackages = props.form.packages.selected.length;
 		if ( nPackages ) {


### PR DESCRIPTION
Fixes #603 

When the Purchase Label form is submitting, instead of just disabling the "Purchase" button, change its text and show a progress indicator (a Spinner).

Screenshot:
![submitting](https://cloud.githubusercontent.com/assets/1715800/20240752/7c9e55b8-a918-11e6-97fc-e371cebee95f.png)

To test, just go purchase a Label.

The only doubt I have about this one is maybe using `Buying...` instead of `Purchasing...`, since the original button label is `Buy & Print N Labels`.

@nabsul @allendav @jeffstieler @robobot3000 