### PR TITLE
Status page: Make the Jetpack error more clear

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -123,7 +123,7 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 					'jetpack_indicator',
 					'notice',
 					'indicator-error',
-					__( 'Please connect Jetpack to WordPress.com', 'connectforwoocommerce' ),
+					__( 'Jetpack is not connected to WordPress.com. Make sure the Jetpack plugin is installed, activated, and connected.', 'connectforwoocommerce' ),
 					''
 				);
 			} else if ( Jetpack::is_staging_site() ) {


### PR DESCRIPTION
Found this while testing the plugin on one of my live sites. I didn't have Jetpack and there was no clear indication that I needed to. I was linked to the Status page and saw this error:

> Please connect Jetpack to WordPress.com

It doesn't make much sense to someone who doesn't have Jetpack (or maybe hasn't heard of it). I updated the message to say: 

> Jetpack is not connected to WordPress.com. Make sure the Jetpack plugin is installed, activated, and connected.