### PR TITLE
Put a higher remote request timeout (1 minute) in the server, disable default PHP script timeout.

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -291,14 +291,15 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				return $headers;
 			}
 
-			set_time_limit( 0 ); // Disable PHP timeout (30 seconds default)
+			$http_timeout = 60; // 1 minute
+			wc_set_time_limit( $http_timeout + 10 );
 			$args = array(
 				'headers' => $headers,
 				'method' => $method,
 				'body' => $body,
 				'redirection' => 0,
 				'compress' => true,
-				'timeout' => 60,
+				'timeout' => $http_timeout,
 			);
 			$args = apply_filters( 'wc_connect_request_args', $args );
 

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -291,13 +291,14 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 				return $headers;
 			}
 
+			set_time_limit( 0 ); // Disable PHP timeout (30 seconds default)
 			$args = array(
 				'headers' => $headers,
 				'method' => $method,
 				'body' => $body,
 				'redirection' => 0,
 				'compress' => true,
-				'timeout' => 20,
+				'timeout' => 60,
 			);
 			$args = apply_filters( 'wc_connect_request_args', $args );
 

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -292,7 +292,9 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			}
 
 			$http_timeout = 60; // 1 minute
-			wc_set_time_limit( $http_timeout + 10 );
+			if ( function_exists( 'wc_set_time_limit' ) ) {
+				wc_set_time_limit( $http_timeout + 10 );
+			}
 			$args = array(
 				'headers' => $headers,
 				'method' => $method,


### PR DESCRIPTION
As surfaced in this discussion: https://github.com/Automattic/woocommerce-connect-client/pull/693#discussion_r87910303

We need to raise the configured REST request timeout (from merchant host to WCC server) because 20 seconds is too low for complex operations like multiple label purchasing. The problem is, the default PHP timeout (for a whole PHP script execution) is 30 seconds in my machine (I assume I don't have a very exotic configuration), and that can be too low too, so we need to at least try to increase the PHP timeout.

@jeffstieler said: I'm not sure we want to mess with PHP timeout

My reponse:
The `set_time_limit()` option only affects the current request. What happened is that I put the "request timeout" to 60 seconds, but since the default PHP timeout (in my machine) was 30 seconds, the process was killed anyways, so the `set_time_limit()` call was needed. Do you think it would be better if I put an explicit PHP timeout, like `set_time_limit(60)` instead of infinite?

Either way, it makes sense to separate this issue into a different PR.

@jeffstieler @robobot3000 @allendav @nabsul 