### PR TITLE
Since all the dates stored in the server and the merchant host are UTC-based, add the "UTC" timezone before parsing them for display

### DIFF
--- a/client/lib/utils/format-date.js
+++ b/client/lib/utils/format-date.js
@@ -1,7 +1,7 @@
 export default ( date ) => {
 	// Note: Safari ignores the 'locale' and 'options' argument. It will display
 	// the full date (with timezone and everything) in the browser's locale (instead of WP lang)
-	return new Date( date ).toLocaleDateString( document.documentElement.lang, {
+	return new Date( date + ' UTC' ).toLocaleDateString( document.documentElement.lang, {
 		day: 'numeric',
 		month: 'long',
 		year: 'numeric',


### PR DESCRIPTION
Fixes #687 

All the dates stored in the WCC server and returned by it are in the `YYYY-MM-DD HH:MM:SS` format. Note that there's no timezone information in the date string, so `UTC` is assumed by default when the date is serialized, but local timezone is assumed when parsing a date without an explicit timezone set.

We have 2 options:
1) Making sure that in the future, dates are stored with their corresponding timezone information.
2) Keep assuming that all dates are UTC, and make sure they are treated accordingly just for display purposes.

Solution `2)` turned out to be far easier (plus, it's retroactive). In the client, before parsing a date string to be displayed, it's enough to add the ` UTC` suffix so that date is interpreted as UTC instead of local time.

To test:
* Make sure you are in a non-UTC timezone. If you are in a UTC timezone, catch a plane and go somewhere else. Alternatively, you can change the timezone setting in your computer and refresh the page.
* Purchase a label.
* In the meta-box, check that the `Purchase date` shown is correct (it matches the local time when you purchased it).

Fun fact: I live in the `UTC` timezone. I would have never spotted this issue 😄 

@jeffstieler @nabsul @allendav @robobot3000 