### PR TITLE
Status page - fixed React errors

### DIFF
--- a/classes/class-wc-connect-help-view.php
+++ b/classes/class-wc-connect-help-view.php
@@ -672,13 +672,14 @@ if ( ! class_exists( 'WC_Connect_Help_View' ) ) {
 
 			$root_view = 'wc-connect-admin-help';
 			$admin_array = array(
-				'storeOptions' => $this->service_settings_store->get_store_options(),
-				'formSchema'   => $this->get_form_schema(),
-				'formLayout'   => $this->get_form_layout(),
-				'formData'     => $this->get_form_data(),
-				'callbackURL'  => get_rest_url( null, "/wc/v1/connect/self-help" ),
-				'nonce'        => wp_create_nonce( 'wp_rest' ),
-				'rootView'     => $root_view,
+				'storeOptions'       => $this->service_settings_store->get_store_options(),
+				'formSchema'         => $this->get_form_schema(),
+				'formLayout'         => $this->get_form_layout(),
+				'formData'           => $this->get_form_data(),
+				'predefinedPackages' => array(),
+				'callbackURL'        => get_rest_url( null, "/wc/v1/connect/self-help" ),
+				'nonce'              => wp_create_nonce( 'wp_rest' ),
+				'rootView'           => $root_view,
 			);
 
 			wp_localize_script( 'wc_connect_admin', 'wcConnectData', $admin_array );


### PR DESCRIPTION
Fixes #709

To test:
Open the status page and verify that there are no errors about required props logged in the console.

CC @nabsul 