### PR TITLE
Fix casing on automattic and woothemes contributors

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Connect for WooCommerce ===
-Contributors: Automattic, WooThemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel
+Contributors: automattic, woothemes, allendav, kellychoffman, jkudish, jeffstieler, nabsul, robobot3000, danreylop, mikeyarce, shaunkuschel
 Tags: canada-post, shipping, stamps, usps, woocommerce
 Requires at least: 4.6.1
 Tested up to: 4.6.1


### PR DESCRIPTION
Fixes #707 

No real way to test this until this is pushed to WordPress.org in the next tag, but you can compare against the WooCommerce repo's readme.txt and ensure the case matches