### PR TITLE
Fixed the incorrect service counts when predefined packages are disabled

### DIFF
--- a/client/settings/views/services/entry.js
+++ b/client/settings/views/services/entry.js
@@ -4,6 +4,7 @@ import FormSelect from 'components/forms/form-select';
 import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import NumberInput from 'components/number-field/number-input';
+import { translate as __ } from 'lib/mixins/i18n';
 
 const ShippingServiceEntry = ( props ) => {
 	const {
@@ -11,6 +12,7 @@ const ShippingServiceEntry = ( props ) => {
 		updateValue,
 		errors,
 		service,
+		isManageable,
 	} = props;
 
 	const {
@@ -23,23 +25,24 @@ const ShippingServiceEntry = ( props ) => {
 	const hasError = errors[ service.id ];
 
 	return (
-		<div className={ classNames( 'wcc-shipping-service-entry', { 'wcc-error': hasError } ) }>
+		<div className={ classNames( 'wcc-shipping-service-entry', { 'wcc-error': hasError } ) } title={ isManageable ? '' : __( 'You can manage this service after enabling the corresponding package in the Packaging Manager' ) }>
 			<label className="wcc-shipping-service-entry-title">
 				<FormCheckbox
-					checked={ enabled }
+					checked={ enabled && isManageable }
+					disabled={ ! isManageable }
 					onChange={ ( event ) => updateValue( 'enabled', event.target.checked ) }
 				/>
 				<span>{ name }</span>
 			</label>
 			{ hasError ? <Gridicon icon="notice" /> : null }
 			<NumberInput
-				disabled={ ! enabled }
+				disabled={ ! enabled || ! isManageable }
 				value={ adjustment }
 				onChange={ ( event ) => updateValue( 'adjustment', event.target.value ) }
 				isError={ hasError }
 			/>
 			<FormSelect
-				disabled={ ! enabled }
+				disabled={ ! enabled || ! isManageable }
 				value={ adjustment_type }
 				onChange={ ( event ) => updateValue( 'adjustment_type', event.target.value ) }
 			>
@@ -64,6 +67,7 @@ ShippingServiceEntry.propTypes = {
 	currencySymbol: PropTypes.string.isRequired,
 	updateValue: PropTypes.func.isRequired,
 	settingsKey: PropTypes.string.isRequired,
+	isManageable: PropTypes.bool.isRequired,
 };
 
 ShippingServiceEntry.defaultProps = {

--- a/client/settings/views/services/group.js
+++ b/client/settings/views/services/group.js
@@ -32,14 +32,16 @@ const ShippingServiceGroup = ( props ) => {
 		errors,
 		predefinedPackages,
 	} = props;
-	const summary = summaryLabel( services );
 	const actionButton = (
 		<button className="foldable-card__action foldable-card__expand" type="button">
 			<span className="screen-reader-text">{ __( 'Expand Services' ) }</span>
 			<Gridicon icon="chevron-down" size={ 24 } />
 		</button>
 	);
-	const allChecked = _.every( services, ( service ) => service.enabled );
+	//filter out the services that have a disabled corresponding predefined package
+	const manageableServices = services.filter( ( service ) => ! service.predefined_package || predefinedPackages.includes( service.predefined_package ) );
+	const allChecked = _.every( manageableServices, ( service ) => service.enabled );
+	const summary = summaryLabel( manageableServices );
 
 	return (
 		<FoldableCard
@@ -56,7 +58,7 @@ const ShippingServiceGroup = ( props ) => {
 				<label className="wcc-shipping-service-header-container">
 					<CheckBox
 						onClick={ ( event ) => event.stopPropagation() }
-						onChange={ ( event ) => updateAll( event, updateValue, services ) }
+						onChange={ ( event ) => updateAll( event, updateValue, manageableServices ) }
 						checked={ allChecked }
 					/>
 					<span className="wcc-shipping-service-header service-name">{ __( 'Service' ) }</span>
@@ -64,18 +66,15 @@ const ShippingServiceGroup = ( props ) => {
 				</label>
 			</div>
 
-			{ services.map( ( service, idx ) => {
-				if ( service.predefined_package && ! predefinedPackages.includes( service.predefined_package ) ) {
-					return null;
-				}
-
-				return <ShippingServiceEntry
+			{ services.map( ( service, idx ) => (
+				<ShippingServiceEntry
 					{ ...props }
 					{ ...{ service } }
+					isManageable={ manageableServices.includes( service ) }
 					updateValue={ ( key, val ) => updateValue( [ service.id ].concat( key ), val ) }
 					key={ idx }
-				/>;
-			} ) }
+				/>
+				) ) }
 		</FoldableCard>
 	);
 };


### PR DESCRIPTION
Fixes #715 

I fixed this by still showing the flat rate services when the corresponding flat rate package has been disabled, but instead marking them as disabled as well:
<img width="534" alt="screen shot 2016-11-17 at 13 30 45" src="https://cloud.githubusercontent.com/assets/800604/20387719/256f4ada-acca-11e6-9eca-3d91118e4446.png">
The disabled rows have a `title` attribute that reads: `You can manage this service after enabling the corresponding package in the Packaging Manager`
CC @allendav to approve this change. I can always revert back to the simple fix for the service count

CC @jeffstieler 