### PR TITLE
Logic to auto-accept address normalizations if the response has a special flag

### DIFF
--- a/classes/class-wc-connect-service-settings-store.php
+++ b/classes/class-wc-connect-service-settings-store.php
@@ -123,7 +123,7 @@ if ( ! class_exists( 'WC_Connect_Service_Settings_Store' ) ) {
 		}
 
 		public function update_origin_address( $address ) {
-			return update_option( 'wc_connect_origin_address', ( array ) $address );
+			return update_option( 'wc_connect_origin_address', $address );
 		}
 
 		protected function sort_services( $a, $b ) {

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -100,6 +100,7 @@ class WC_REST_Connect_Address_Normalization_Controller extends WP_REST_Controlle
 		return array(
 			'success' => true,
 			'normalized' => $response->normalized,
+			'is_trivial_normalization' => isset( $response->is_trivial_normalization ) ? $response->is_trivial_normalization : false,
 		);
 	}
 

--- a/classes/class-wc-rest-connect-address-normalization-controller.php
+++ b/classes/class-wc-rest-connect-address-normalization-controller.php
@@ -97,10 +97,6 @@ class WC_REST_Connect_Address_Normalization_Controller extends WP_REST_Controlle
 		$response->normalized->company = $company;
 		$response->normalized->phone = $phone;
 
-		if ( 'origin' === $request->type ) {
-			$this->settings_store->update_origin_address( $response->normalized );
-		}
-
 		return array(
 			'success' => true,
 			'normalized' => $response->normalized,

--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -61,6 +61,8 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 	public function update_items( $request ) {
 		$request_body = $request->get_body();
 		$settings = json_decode( $request_body, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
+		$this->settings_store->update_origin_address( $settings[ 'origin' ] );
+
 		$order_id = $settings[ 'order_id' ];
 
 		$settings[ 'payment_method_id' ] = $this->settings_store->get_selected_payment_method_id();

--- a/client/shipping-label/state/normalize-address.js
+++ b/client/shipping-label/state/normalize-address.js
@@ -22,6 +22,7 @@ export default ( dispatch, address, type, addressNormalizationURL, nonce ) => {
 					type: ADDRESS_NORMALIZATION_COMPLETED,
 					group: type,
 					normalized: ( response || {} ).normalized,
+					isTrivialNormalization: ( response || {} ).is_trivial_normalization,
 					error,
 				} );
 				if ( error ) {

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -100,8 +100,8 @@ reducers[ ADDRESS_NORMALIZATION_IN_PROGRESS ] = ( state, { group } ) => {
 	};
 };
 
-reducers[ ADDRESS_NORMALIZATION_COMPLETED ] = ( state, { group, normalized } ) => {
-	return { ...state,
+reducers[ ADDRESS_NORMALIZATION_COMPLETED ] = ( state, { group, normalized, isTrivialNormalization } ) => {
+	const newState = { ...state,
 		form: { ...state.form,
 			[ group ]: { ...state.form[ group ],
 				normalizationInProgress: false,
@@ -111,6 +111,10 @@ reducers[ ADDRESS_NORMALIZATION_COMPLETED ] = ( state, { group, normalized } ) =
 			},
 		},
 	};
+	if ( isTrivialNormalization ) {
+		newState.form[ group ].values = normalized;
+	}
+	return newState;
 };
 
 reducers[ SELECT_NORMALIZED_ADDRESS ] = ( state, { group, selectNormalized } ) => {


### PR DESCRIPTION
Fixes #600 

This PR is totally backwards and forwards-compatible, but you won't be able to test it properly without the `update/auto-accept-address-normalization` branch on the server.

When sending an address to normalize to the server, if the response has the `is_trivial_normalization` property set to `true`, then the normalized address will be automatically accepted without user intervention. As its name indicates, that flag will be set when the changes made by the address normalizator were trivial, such as adding the `+4` portion to a ZIP code, or changing capitalization, or changing `street` to `st` for example.

To test:
* Go purchase a label.
* Make sure the origin address is normalized (the step has the green checkmark icon).
* Make *only* trivial changes, such as:
  * Change some things to lowercase or mixed case.
  * Remove the `+4` part of the ZIP code.
  * Change the address suffix ('RD', 'ST', etc) to its non-abbreviated form ('road', 'street', etc).
* Click the "Use this address" button and check that the form auto-skips to the next step, and the address was corrected automatically.
* Make a different change, such as mispelling the City name, and check that you're prompted to select the original address or the corrected address.

@nabsul @jeffstieler @allendav @robobot3000 