### PR TITLE
Fix clicking outside a dialog not closing it sometimes.

### DIFF
--- a/client/components/modal/index.js
+++ b/client/components/modal/index.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 
 const Modal = ( props ) => {
 	// Only close the modal if the click was in the dialog backdrop, *not* in any other element like global notices
-	const shouldStayOpen = ( event ) => ! closest( event.target, '.dialog__backdrop' );
+	const shouldStayOpen = ( event ) => ! closest( event.target, '.dialog__backdrop', true );
 
 	return (
 		<Dialog


### PR DESCRIPTION
I've noticed this error while reviewing another PR.

Calypso uses `closest-component@0.1.4` ( https://github.com/Automattic/wp-calypso/blob/master/package.json#L40 ), and `woocommerce-connect-client` uses `1.0`. Webpack shenanigans means that when our code requires `component-closest`, sometimes `v0.1.4` is required, and sometimes `v1.0`, which has a backwards-incompatible change. Hence, when `v0.1.4` was included, our logic to close a dialog when the user clicks outside of it was not working correctly and the dialog didn't close.

I've modified the code so it works the same way in both versions of `component-closest`, so now when you click outside a dialog it should **always** close.

Since this bug was non-deterministic, there is no reliable way to test it.