### PR TITLE
Packaging manager link: remove target="_blank"

### DIFF
--- a/client/packages/views/style.scss
+++ b/client/packages/views/style.scss
@@ -19,8 +19,6 @@
 
 	.package-type-icon {
 		fill: $gray;
-		padding: 4px;
-		margin-bottom: -4px;
 	}
 }
 

--- a/client/settings/views/wcc-settings-form/settings-item.js
+++ b/client/settings/views/wcc-settings-form/settings-item.js
@@ -104,7 +104,7 @@ const SettingsItem = ( {
 
 		case 'packages':
 			const packagesMsg = sprintf(
-				__( 'Add and edit saved packages using the <a href="%(url)s" target="_blank">Packaging Manager</a>.' ),
+				__( 'Add and edit saved packages using the <a href="%(url)s">Packaging Manager</a>.' ),
 				{
 					url: 'admin.php?page=wc-settings&tab=connect&section=packages',
 				}


### PR DESCRIPTION
Fixes: https://github.com/Automattic/woocommerce-connect-client/issues/725

Quick trash pickup because I kept having an unnecessary amount of tabs at the end of a UX testing session. 

To test, go to the Packaging section on the USPS shipping method and click the Packaging manager link. It doesn't open in a new tab anymore. 

Also, the icons on the Type column are now vertically aligned in the the Custom packages section on the Packaging Manager page. 