### PR TITLE
Changed date prop from string to number (timestamp)

### DIFF
--- a/client/shipping-label/views/refund/index.js
+++ b/client/shipping-label/views/refund/index.js
@@ -51,7 +51,7 @@ RefundDialog.propTypes = {
 	refundDialog: PropTypes.object,
 	labelActions: PropTypes.object.isRequired,
 	storeOptions: PropTypes.object.isRequired,
-	created: PropTypes.string,
+	created: PropTypes.number,
 	refundable_amount: PropTypes.number,
 };
 


### PR DESCRIPTION
Fixes #721 

Now that all our dates are timestamps (numbers) until they are displayed to the user, it's safe (and required) to change all React PropTypes regarding dates from `string` to `number`. I could only find one, in the Refund Dialog view.

To test:
* Make sure your `woocommerce-connect-server` is in the latest version of `master`.
* Purchase a label (or go to an order with an already purchased label).
* Check that in the console, it doesn't appear an eror like `Failed prop type: invalid prop 'created' of type 'number' supplied to RefundDialog, expected 'string'`.

@nabsul @allendav @jeffstieler @robobot3000 