### PR TITLE
"0" and "0.0" dimensions are treated differently for shipping rate requests

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -97,25 +97,25 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 						);
 					}
 
-					$weight = floatval( $product->get_weight() );
+					$weight = $product->get_weight();
 
 					$height = 0;
 					$length = 0;
 					$width = 0;
 
 					if ( $product->has_dimensions() ) {
-						$height = floatval( $product->get_height() );
-						$length = floatval( $product->get_length() );
-						$width  = floatval( $product->get_width() );
+						$height = $product->get_height();
+						$length = $product->get_length();
+						$width  = $product->get_width();
 					}
 
 					$contents[] = array(
-						'height' => $height,
+						'height' => ( float ) $height,
 						'product_id' => isset( $values['data']->variation_id ) ? $values['data']->variation_id : $values['data']->id,
-						'length' => $length,
+						'length' => ( float ) $length,
 						'quantity' => $values['quantity'],
-						'weight' => $weight,
-						'width' => $width
+						'weight' => ( float ) $weight,
+						'width' => ( float ) $width,
 					);
 				}
 			}

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -103,9 +103,9 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 					$width = 0;
 
 					if ( $product->has_dimensions() ) {
-						$height = $product->get_height();
-						$length = $product->get_length();
-						$width  = $product->get_width();
+						$height = floatval( $product->get_height() );
+						$length = floatval( $product->get_length() );
+						$width  = floatval( $product->get_width() );
 					}
 
 					$contents[] = array(

--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -97,9 +97,10 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 						);
 					}
 
+					$weight = floatval( $product->get_weight() );
+
 					$height = 0;
 					$length = 0;
-					$weight = $product->get_weight();
 					$width = 0;
 
 					if ( $product->has_dimensions() ) {


### PR DESCRIPTION
Closes #724 

Something fishy is going on in the WooCommerce product object. the function objects `get_length()`, `get_width()`, `get_height()`are returning an empty string when the value of the dimension is "0". This doesn't seem to happen if the value is "0".

To mitigate this issue I'm forcing whatever these functions return into a float using `floatval()`. I thought about putting some error checking and logging in place for this situation, but decided to just go with the simplest solution.

I've submitted a report to WooCommerce Core:
https://github.com/woocommerce/woocommerce/issues/12455

To test:
- Try setting a product dimension to "0" from some non-zero value (this seems to be important)
- Add that product to the cart and try requesting shipping rates for that product
- Observe that the current client from master returns a 400
- Observe that with this change rates are successfully fetched

@allendav @DanReyLop @jeffstieler @robobot3000 
