### PR TITLE
Refund success message: Change 'correctly' to 'successfully'

### DIFF
--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -553,7 +553,7 @@ export const confirmRefund = () => ( dispatch, getState, { labelRefundURL, nonce
 			if ( error ) {
 				dispatch( NoticeActions.errorNotice( error.toString() ) );
 			} else {
-				dispatch( NoticeActions.successNotice( __( 'The refund request has been sent correctly' ), { duration: 5000 } ) );
+				dispatch( NoticeActions.successNotice( __( 'The refund request has been sent successfully.' ), { duration: 5000 } ) );
 			}
 		}
 	};

--- a/i18n/strings.php
+++ b/i18n/strings.php
@@ -110,7 +110,7 @@ $i18nStrings = array(
 	"There was a problem with one or more entries. Please fix the errors below and try saving again." => __( "There was a problem with one or more entries. Please fix the errors below and try saving again.", "connectforwoocommerce" ),
 	"Your changes have been saved." => __( "Your changes have been saved.", "connectforwoocommerce" ),
 	"Unexpected server error." => __( "Unexpected server error.", "connectforwoocommerce" ),
-	"The refund request has been sent correctly" => __( "The refund request has been sent correctly", "connectforwoocommerce" ),
+	"The refund request has been sent successfully." => __( "The refund request has been sent successfully", "connectforwoocommerce" ),
 	"Save Settings" => __( "Save Settings", "connectforwoocommerce" ),
 	"Saving…" => __( "Saving…", "connectforwoocommerce" ),
 );


### PR DESCRIPTION
Changed the copy on the refund request success message.

Before:
`The refund request has been sent correctly`
<img width="500" alt="screen shot 2016-12-05 at 10 59 02 am" src="https://cloud.githubusercontent.com/assets/5835847/20909146/0a1c2180-bb17-11e6-9d16-99f7dfe2958e.png">


After:
`The refund request has been sent successfully.`
