### PR TITLE
Fix incorrect handling of get_master_user response

### DIFF
--- a/classes/class-wc-connect-settings-pages.php
+++ b/classes/class-wc-connect-settings-pages.php
@@ -112,7 +112,8 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 		}
 
 		/**
-		 * Helper method to get the Jetpack master user id, IF we are connected
+		 * Helper method to get the Jetpack master user, IF we are connected
+		 * @return WP_User | false
 		 */
 		protected function get_master_user() {
 			include_once ( ABSPATH . 'wp-admin/includes/plugin.php' );
@@ -138,7 +139,8 @@ if ( ! class_exists( 'WC_Connect_Settings_Pages' ) ) {
 			global $current_user;
 
 			if ( '' === $current_section ) {
-				if ( $current_user->ID == $this->get_master_user() ) {
+				$master_user = $this->get_master_user();
+				if ( is_a( $master_user, 'WP_User' ) && $current_user->ID == $master_user->ID ) {
 					$this->output_account_screen();
 				} else {
 					$this->output_no_priv_account_screen();


### PR DESCRIPTION
Fixes #745 

To test:
- on a site with WP_DEBUG enabled and an active Jetpack connection, log in as the primary user and navigate to wp-admin > WooCommerce > Settings > Connect for WooCommerce > Account Settings
- make sure you can see your payment methods you have saved
- make sure no error is displayed
- log out
- log in as another user with admin privledge or at least store management privledge and navigate to wp-admin > WooCommerce > Settings > Connect for WooCommerce > Account Settings
- make sure you cannot see payment methods
- make sure no error is displayed
