### PR TITLE
Allow payment methods to be managed in jetpack dev mode

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -406,3 +406,12 @@
 		}
 	}
 }
+
+.wc-connect-admin-dev-notice {
+	width: 700px;
+
+	p {
+		font-style: italic;
+		color: $gray;
+	}
+}


### PR DESCRIPTION
Fixes #748 

To test, try browsing payment methods on a dev mode site and a non dev mode site

Adds a note below the container to warn you if you are in dev mode, since the only payment methods you can see then are based on local server configuration, e.g.:

<img width="775" alt="screen shot 2016-12-08 at 10 34 36 am" src="https://cloud.githubusercontent.com/assets/1595739/21022561/f5c059c8-bd31-11e6-937a-236aa333a0eb.png">

