### PR TITLE
Add id and box_id when preparing labels from a free shipping order

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -45,7 +45,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 				$name = html_entity_decode( $product->get_formatted_name() );
 
 				for ( $i = 0; $i < $item[ 'qty' ]; $i++ ) {
-					$packages[ "weight_{$i}_individual" ] = array(
+					$id = "weight_{$i}_individual";
+					$packages[ $id ] = array(
+						'id' => $id,
+						'box_id' => 'individual',
 						'height' => ( float ) $height,
 						'length' => ( float ) $length,
 						'weight' => ( float ) $weight,


### PR DESCRIPTION
Fixes #751

To test, complete an order for a shippable item with free shipping as the shipping method.  Make sure you do not get a "packages" error in the labels ui. Make sure you are prompted to select from various shipping options, e.g.:

<img width="790" alt="screen shot 2016-12-09 at 3 16 35 pm" src="https://cloud.githubusercontent.com/assets/1595739/21067803/840ac81c-be22-11e6-888d-8801f9fd4c28.png">

cc @robobot3000  or @DanReyLop for review since you're most familiar with this part of the code