### PR TITLE
Fix Chrome MIME type warning

### DIFF
--- a/assets/stylesheets/shipping-label.scss
+++ b/assets/stylesheets/shipping-label.scss
@@ -148,7 +148,7 @@
 		justify-content:center;
 		align-items:center;
 
-		iframe {
+		embed {
 			max-height: 100%;
 			height: 100%;
 			width: 100%;

--- a/client/shipping-label/views/purchase/steps/preview/index.js
+++ b/client/shipping-label/views/purchase/steps/preview/index.js
@@ -9,7 +9,7 @@ const PreviewStep = ( { labelPreviewURL, canPurchase, paperSize, labelActions, e
 			<div className="preview-container">
 				<span className="preview-title">{ __( 'Preview' ) }</span>
 				<div className="preview-placeholder">
-					{ canPurchase && labelPreviewURL && <iframe src={ labelPreviewURL } /> }
+					{ canPurchase && labelPreviewURL && <embed src={ labelPreviewURL } type="application/pdf" /> }
 				</div>
 			</div>
 			<Dropdown


### PR DESCRIPTION
Fixes #718

I replaced `iframe` with `embed` element. Tested on Chrome, Opera, Firefox and Safari.