### PR TITLE
Fixed the missing id when shipping items individually

### DIFF
--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -221,6 +221,7 @@ reducers[ MOVE_ITEM ] = ( state, { openedPackageId, movedItemIndex, targetPackag
 		const { height, length, width, weight } = movedItem;
 		newPackages[ addedPackageId ] = {
 			height, length, width, weight,
+			id: addedPackageId,
 			box_id: 'individual',
 			items: [ movedItem ],
 		};


### PR DESCRIPTION
Fixes #783 

To test:
* place an order
* open the order in the admin panel and open the labels UI and then the packaging section
* using the "move item" button next to one of the items, move it to the original packaging
* try to request rates