### PR TITLE
Make the PHP fail a rates request in the checkout if an item doesn't have weight

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -141,6 +141,10 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 			// each item needs to specify quantity, weight, length, width and height
 			$contents = $this->build_shipment_contents( $package );
 
+			if ( is_wp_error( $contents ) ) {
+				return $contents;
+			}
+
 			if ( empty( $contents ) ) {
 				return new WP_Error( 'nothing_to_ship', 'No shipping rate could be calculated. No items in the package are shippable.' );
 			}


### PR DESCRIPTION
Before, if you tried to get rates (from the checkout) for an item without weight, you got this error:
```wcc_server_error_response Error: The Connect for WooCommerce server returned: Bad Request child "contents" fails because ["contents" must be an array] ( 400 ) (calculate_shipping)```

The PHP side detects that an item doesn't have weight and "throws" a WP_Error instead of the serialized packages. The problem is, that WP_Error was being **sent** to the server instead of just failing early.

To test:
* Create a product with dimensions, but without weight.
* Configure a Connect USPS shipping method.
* Purchase that item, and try to get shipping rates for it.
* You shouldn't get any rate, that hasn't changed. But, in the debug log, instead of seeing the cryptic error above, you should see a more explicit error about an item not having weight.