### PR TITLE
	Make the label UI submit button keep being disabled while the PDF is being downloaded

### DIFF
--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -93,6 +93,7 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 
 		$label_ids = array();
 		$labels_order_meta = array();
+		$purchased_labels_meta = array();
 		$existing_labels_data = get_post_meta( $order_id, 'wc_connect_labels', true );
 		if ( $existing_labels_data ) {
 			$labels_order_meta = json_decode( $existing_labels_data, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
@@ -142,12 +143,13 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 			$label_meta[ 'product_names' ] = $product_names;
 
 			array_unshift( $labels_order_meta, $label_meta );
+			array_unshift( $purchased_labels_meta, $label_meta );
 		}
 
 		update_post_meta( $order_id, 'wc_connect_labels', json_encode( $labels_order_meta ) );
 
 		return array(
-			'labels' => $labels_order_meta,
+			'labels' => $purchased_labels_meta,
 			'success' => true,
 		);
 	}

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -450,16 +450,16 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 				console.error( error );
 				dispatch( NoticeActions.errorNotice( error.toString() ) );
 			} else {
-				const labelsToPrint = labels.map( ( label, index ) => ( {
-					caption: sprintf( __( 'PACKAGE %d (OF %d)' ), index + 1, labels.length ),
+				const labelsToPrint = response.map( ( label, index ) => ( {
+					caption: sprintf( __( 'PACKAGE %d (OF %d)' ), index + 1, response.length ),
 					labelId: label.label_id,
 				} ) );
 				const state = getState().shippingLabel;
 				printDocument( getPrintURL( state.paperSize, labelsToPrint, context ) )
 					.then( () => {
-						const noticeText = 1 === labels.length
+						const noticeText = 1 === response.length
 								? __( 'Your shipping label was purchased successfully' )
-								: sprintf( __( 'Your %d shipping labels were purchased successfully' ), labels.length );
+								: sprintf( __( 'Your %d shipping labels were purchased successfully' ), response.length );
 						dispatch( NoticeActions.successNotice( noticeText ) );
 						dispatch( exitPrintingFlow( true ) );
 					} )

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -435,8 +435,6 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 	let error = null;
 	let response = null;
 
-	const oldLabels = getState().shippingLabel.labels;
-
 	const setError = ( err ) => error = err;
 	const setSuccess = ( success, json ) => {
 		if ( success ) {
@@ -452,9 +450,8 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 				console.error( error );
 				dispatch( NoticeActions.errorNotice( error.toString() ) );
 			} else {
-				const purchasedLabels = _.differenceBy( response, oldLabels, 'label_id' );
-				const labelsToPrint = purchasedLabels.map( ( label, index ) => ( {
-					caption: sprintf( __( 'PACKAGE %d (OF %d)' ), index + 1, purchasedLabels.length ),
+				const labelsToPrint = labels.map( ( label, index ) => ( {
+					caption: sprintf( __( 'PACKAGE %d (OF %d)' ), index + 1, labels.length ),
 					labelId: label.label_id,
 				} ) );
 				const state = getState().shippingLabel;

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -456,7 +456,13 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 				} ) );
 				const state = getState().shippingLabel;
 				printDocument( getPrintURL( state.paperSize, labelsToPrint, context ) )
-					.then( () => dispatch( exitPrintingFlow( true ) ) )
+					.then( () => {
+						const noticeText = 1 === labels.length
+								? __( 'Your shipping label was purchased successfully' )
+								: sprintf( __( 'Your %d shipping labels were purchased successfully' ), labels.length );
+						dispatch( NoticeActions.successNotice( noticeText ) );
+						dispatch( exitPrintingFlow( true ) );
+					} )
 					.catch( ( err ) => {
 						console.error( err );
 						dispatch( NoticeActions.errorNotice( err.toString() ) );

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -190,8 +190,8 @@ export const openPrintingFlow = () => ( dispatch, getState, context ) => {
 	dispatch( { type: OPEN_PRINTING_FLOW } );
 };
 
-export const exitPrintingFlow = () => {
-	return { type: EXIT_PRINTING_FLOW };
+export const exitPrintingFlow = ( force ) => {
+	return { type: EXIT_PRINTING_FLOW, force };
 };
 
 export const updateAddressValue = ( group, name, value ) => {
@@ -459,7 +459,7 @@ export const purchaseLabel = () => ( dispatch, getState, context ) => {
 				} ) );
 				const state = getState().shippingLabel;
 				printDocument( getPrintURL( state.paperSize, labelsToPrint, context ) )
-					.then( () => dispatch( exitPrintingFlow() ) )
+					.then( () => dispatch( exitPrintingFlow( true ) ) )
 					.catch( ( err ) => {
 						console.error( err );
 						dispatch( NoticeActions.errorNotice( err.toString() ) );

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -62,6 +62,9 @@ reducers[ EXIT_PRINTING_FLOW ] = ( state, { force } ) => {
 	}
 	return { ...state,
 		showPurchaseDialog: false,
+		form: { ...state.form,
+			isSubmitting: false,
+		},
 	};
 };
 

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -56,7 +56,10 @@ reducers[ OPEN_PRINTING_FLOW ] = ( state ) => {
 	};
 };
 
-reducers[ EXIT_PRINTING_FLOW ] = ( state ) => {
+reducers[ EXIT_PRINTING_FLOW ] = ( state, { force } ) => {
+	if ( ! force && state.form.isSubmitting ) {
+		return state;
+	}
 	return { ...state,
 		showPurchaseDialog: false,
 	};

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -461,7 +461,12 @@ reducers[ PURCHASE_LABEL_RESPONSE ] = ( state, { response, error } ) => {
 	}
 
 	return { ...state,
-		labels: response.map( ( label ) => ( { ...label, statusUpdated: true } ) ),
+		labels: [
+			...response.map( ( label ) => ( { ...label,
+				statusUpdated: true,
+			} ) ),
+			...state.labels,
+		],
 	};
 };
 

--- a/client/shipping-label/state/reducer.js
+++ b/client/shipping-label/state/reducer.js
@@ -456,10 +456,6 @@ reducers[ PURCHASE_LABEL_RESPONSE ] = ( state, { response, error } ) => {
 
 	return { ...state,
 		labels: response.map( ( label ) => ( { ...label, statusUpdated: true } ) ),
-		form: {
-			...state.form,
-			isSubmitting: false,
-		},
 	};
 };
 

--- a/client/shipping-label/views/index.js
+++ b/client/shipping-label/views/index.js
@@ -163,7 +163,7 @@ class ShippingLabelRootView extends Component {
 		const purchased = timeAgo( label.created );
 
 		return (
-			<div key={ index } className="wcc-metabox-label-item" >
+			<div key={ label.label_id } className="wcc-metabox-label-item" >
 				<p className="wcc-metabox-label-item__created">{ this.renderLabelDetails( label, index ) } { __( 'purchased' ) } <span title={ formatDate( label.created ) }>{ purchased }</span></p>
 				<p className="wcc-metabox-label-item__tracking">{ __( 'Tracking #:' ) } <TrackingLink { ...label }/></p>
 				<p className="wcc-metabox-label-item__actions" >

--- a/client/shipping-label/views/purchase/index.js
+++ b/client/shipping-label/views/purchase/index.js
@@ -36,7 +36,7 @@ const PrintLabelDialog = ( props ) => {
 	return (
 		<Modal
 			isVisible={ props.showPurchaseDialog }
-			onClose={ props.labelActions.exitPrintingFlow } >
+			onClose={ () => props.labelActions.exitPrintingFlow( false ) } >
 			<div className="wcc-shipping-label-dialog__content">
 				<h3 className="form-section-heading">
 					{ 1 === props.form.packages.selected.length ? __( 'Create shipping label' ) : __( 'Create shipping labels' ) }
@@ -75,7 +75,7 @@ const PrintLabelDialog = ( props ) => {
 						label: getPurchaseButtonLabel(),
 					},
 					{
-						onClick: props.labelActions.exitPrintingFlow,
+						onClick: () => props.labelActions.exitPrintingFlow( false ),
 						label: __( 'Cancel' ),
 					},
 				] } />


### PR DESCRIPTION
Fixes #771 

To test:
* Go purchase a label.
* While the purchase button is in the "Purchasing..." style, note that you can't close the dialog or click the button.
* Note that the button keeps being in that state until the PDF print dialog appears.