### PR TITLE
Use wordpress table prefix for shipping zone query

### DIFF
--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -642,7 +642,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 
 			foreach ( $shipping_service_ids as $shipping_service_id ) {
 				$is_active = $wpdb->get_var( $wpdb->prepare(
-					"SELECT instance_id FROM wp_woocommerce_shipping_zone_methods WHERE is_enabled = 1 AND method_id = %s LIMIT 1;",
+					"SELECT instance_id FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE is_enabled = 1 AND method_id = %s LIMIT 1;",
 					$shipping_service_id
 				) );
 


### PR DESCRIPTION
Closes #798 

To Test:
- Use an installation with a custom table prefix
- See the error with master (see screen shot in issue)
- See there is no error with this fix