### PR TITLE
Moved the labels metabox above order notes

### DIFF
--- a/woocommerce-connect-client.php
+++ b/woocommerce-connect-client.php
@@ -406,7 +406,7 @@ if ( ! class_exists( 'WC_Connect_Loader' ) ) {
 			add_action( 'wc_connect_fetch_service_schemas', array( $schemas_store, 'fetch_service_schemas_from_connect_server' ) );
 			add_filter( 'woocommerce_hidden_order_itemmeta', array( $this, 'hide_wc_connect_package_meta_data' ) );
 			add_filter( 'is_protected_meta', array( $this, 'hide_wc_connect_order_meta_data' ), 10, 3 );
-			add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 40 );
+			add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 5 );
 			add_filter( 'woocommerce_shipping_fields' , array( $this, 'add_shipping_phone_to_checkout' ) );
 			add_action( 'woocommerce_admin_shipping_fields', array( $this, 'add_shipping_phone_to_order_fields' ) );
 			add_filter( 'woocommerce_get_order_address', array( $this, 'get_shipping_phone_from_order' ), 10, 3 );


### PR DESCRIPTION
FIxes #799

To test:
* open the order page
* verify that the label box appears above the order notes