### PR TITLE
Always fetching the label refund status

### DIFF
--- a/classes/class-wc-connect-api-client.php
+++ b/classes/class-wc-connect-api-client.php
@@ -247,8 +247,8 @@ if ( ! class_exists( 'WC_Connect_API_Client' ) ) {
 		 * @param $label_id integer
 		 * @return object|WP_Error
 		 */
-		public function get_label_status( $label_id, $get_refund ) {
-			return $this->request( 'GET', '/shipping/label/' . $label_id . '?get_refund=' . $get_refund );
+		public function get_label_status( $label_id ) {
+			return $this->request( 'GET', '/shipping/label/' . $label_id . '?get_refund=true' );
 		}
 
 		/**

--- a/classes/class-wc-rest-connect-shipping-label-status-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-status-controller.php
@@ -59,9 +59,7 @@ class WC_REST_Connect_Shipping_Label_Status_Controller extends WP_REST_Controlle
 	}
 
 	public function get_item( $request ) {
-		$get_refund = $request[ 'get_refund' ] ? 'true' : 'false';
-
-		$response = $this->api_client->get_label_status( $request[ 'label_id' ], $get_refund );
+		$response = $this->api_client->get_label_status( $request[ 'label_id' ] );
 
 		if ( is_wp_error( $response ) ) {
 			$error = new WP_Error(

--- a/client/shipping-label/state/actions.js
+++ b/client/shipping-label/state/actions.js
@@ -538,12 +538,7 @@ export const fetchLabelsStatus = () => ( dispatch, getState, { labelStatusURL, n
 			}
 		};
 
-		let url = sprintf( labelStatusURL, labelId );
-		if ( label.refund && 'pending' === label.refund.status ) {
-			url += '?get_refund=1';
-		}
-
-		saveForm( setIsSaving, setSuccess, _.noop, setError, url, nonce, 'GET' );
+		saveForm( setIsSaving, setSuccess, _.noop, setError, sprintf( labelStatusURL, labelId ), nonce, 'GET' );
 	} );
 };
 


### PR DESCRIPTION
Fixes #789

To test:
* purchase a new label in the client, do not request a refund on it
* in the server database, add a new row for that label's refund in `wcc_shipping_label_refund`
  * alternatively use the support tools to refund a label
* refresh the order page
* verify that the refund status has been updated