### PR TITLE
Added fallback rates to the client-side

### DIFF
--- a/classes/class-wc-connect-shipping-label.php
+++ b/classes/class-wc-connect-shipping-label.php
@@ -170,7 +170,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Label' ) ) {
 
 			foreach( $packages as $idx => $package ) {
 				// Abort if the package data is malformed
-				if ( ! $package[ 'id' ] || ! $package[ 'service_id' ] ) {
+				if ( ! isset( $package[ 'id' ] ) || ! isset( $package[ 'service_id' ] ) ) {
 					return array();
 				}
 

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -242,7 +242,7 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 
 			$rate_to_add = array(
 				'id'        => self::format_rate_id( 'fallback', $this->id, 0 ),
-				'label'     => self::format_rate_title( __( 'Fallback rate' ) ),
+				'label'     => self::format_rate_title( $this->service_schema->carrier_name ),
 				'cost'      => $service_settings->fallback_rate,
 				'calc_tax'  => 'per_item',
 			);

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -235,6 +235,21 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			return is_string( $preset_id );
 		}
 
+		private function add_fallback_rate( $service_settings ) {
+			if ( ! property_exists( $service_settings, 'fallback_rate' ) || 0 >= $service_settings->fallback_rate ) {
+				return;
+			}
+
+			$rate_to_add = array(
+				'id'        => self::format_rate_id( 'fallback', $this->id, 0 ),
+				'label'     => self::format_rate_title( __( 'Fallback rate' ) ),
+				'cost'      => $service_settings->fallback_rate,
+				'calc_tax'  => 'per_item',
+			);
+
+			$this->add_rate( $rate_to_add );
+		}
+
 		public function calculate_shipping( $package = array() ) {
 
 			if ( ! $this->is_valid_package_destination( $package ) ) {
@@ -284,14 +299,18 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 				$this->set_last_request_failed();
 
 				$this->log( $response_body, __FUNCTION__ );
+				$this->add_fallback_rate( $service_settings );
 				return;
 			}
 
 			if ( ! property_exists( $response_body, 'rates' ) ) {
 				$this->set_last_request_failed();
+				$this->add_fallback_rate( $service_settings );
 				return;
 			}
+
 			$instances = $response_body->rates;
+			$added_rates_count = 0;
 
 			foreach ( (array) $instances as $instance ) {
 				if ( ! property_exists( $instance, 'rates' ) ) {
@@ -339,7 +358,12 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 					);
 
 					$this->add_rate( $rate_to_add );
+					$added_rates_count++;
 				}
+			}
+
+			if ( 0 === $added_rates_count ) {
+				$this->add_fallback_rate( $service_settings );
 			}
 
 			$this->update_last_rate_request_timestamp();

--- a/classes/class-wc-connect-shipping-method.php
+++ b/classes/class-wc-connect-shipping-method.php
@@ -310,7 +310,6 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 			}
 
 			$instances = $response_body->rates;
-			$added_rates_count = 0;
 
 			foreach ( (array) $instances as $instance ) {
 				if ( ! property_exists( $instance, 'rates' ) ) {
@@ -358,11 +357,10 @@ if ( ! class_exists( 'WC_Connect_Shipping_Method' ) ) {
 					);
 
 					$this->add_rate( $rate_to_add );
-					$added_rates_count++;
 				}
 			}
 
-			if ( 0 === $added_rates_count ) {
+			if ( 0 === count( $this->rates ) ) {
 				$this->add_fallback_rate( $service_settings );
 			}
 


### PR DESCRIPTION
Fixes #807

Automattic/woocommerce-connect-server#748 will be useful during testing

To test:
* Configure the fallback rate in the shipping settings
* Stop the server (to trigger a request error)
  * Verify that you can get the fallback rate at the checkout
* Check that you still get the fallback rate if the server is running, not returning an error, but also not returning any rates
* Place an order and check that everything is ok on the admin order page