### PR TITLE
Store the origin address then label rates are requested, instead of when a purchase is made

### DIFF
--- a/classes/class-wc-rest-connect-shipping-label-controller.php
+++ b/classes/class-wc-rest-connect-shipping-label-controller.php
@@ -63,7 +63,6 @@ class WC_REST_Connect_Shipping_Label_Controller extends WP_REST_Controller {
 
 		$request_body = $request->get_body();
 		$settings = json_decode( $request_body, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
-		$this->settings_store->update_origin_address( $settings[ 'origin' ] );
 
 		$order_id = $settings[ 'order_id' ];
 

--- a/classes/class-wc-rest-connect-shipping-rates-controller.php
+++ b/classes/class-wc-rest-connect-shipping-rates-controller.php
@@ -67,6 +67,10 @@ class WC_REST_Connect_Shipping_Rates_Controller extends WP_REST_Controller {
 		$request_body = $request->get_body();
 		$payload      = json_decode( $request_body, true, WOOCOMMERCE_CONNECT_MAX_JSON_DECODE_DEPTH );
 
+		// This is the earliest point in the printing label flow where we are sure that
+		// the merchant wants to ship from this exact address (normalized or otherwise)
+		$this->settings_store->update_origin_address( $payload[ 'origin' ] );
+
 		// Hardcode USPS rates for now
 		$payload[ 'carrier' ] = 'usps';
 


### PR DESCRIPTION
When to store the origin address to be reused on the Purchase Label flow?

* Old-old way: As soon as the origin address is normalized. The problem with that is that, if we store the normalized version of the address, the merchant will see *that* address the next time, even if he decided to use the un-normalized one.
* Old way: When a label purchase request is made. Which means that, if the user has problems retrieving rates, he will have to input his address again the next time he tries.
* New-awesome way: Store the address when a label rates request is made. This is the best of both worlds.