### PR TITLE
Clicking refund shows the wrong dialog box

### DIFF
--- a/client/shipping-label/views/refund/index.js
+++ b/client/shipping-label/views/refund/index.js
@@ -5,14 +5,14 @@ import ActionButtons from 'components/action-buttons';
 import { sprintf } from 'sprintf-js';
 import formatDate from 'lib/utils/format-date';
 
-const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refundable_amount } ) => {
+const RefundDialog = ( { refundDialog, labelActions, storeOptions, created, refundable_amount, label_id } ) => {
 	const getRefundableAmount = () => {
 		return storeOptions.currency_symbol + refundable_amount.toFixed( 2 );
 	};
 
 	return (
 		<Modal
-			isVisible={ Boolean( refundDialog ) }
+			isVisible={ refundDialog && refundDialog.labelId === label_id }
 			onClose={ labelActions.closeRefundDialog }
 			additionalClassNames="wcc-shipping-label-refund">
 			<div className="wcc-shipping-label-refund__content">

--- a/client/shipping-label/views/refund/index.js
+++ b/client/shipping-label/views/refund/index.js
@@ -53,6 +53,7 @@ RefundDialog.propTypes = {
 	storeOptions: PropTypes.object.isRequired,
 	created: PropTypes.number,
 	refundable_amount: PropTypes.number,
+	label_id: PropTypes.number,
 };
 
 export default RefundDialog;


### PR DESCRIPTION
closes #788

The logic for showing the refund dialog shows or hides all dialogs, resulting in the last one rendered showing on top of the rest.

To Test:
- Make a purchase with multiple packages
- Buy labels, preferably with different prices to easily distinguish them
- On master, open the refund dialog for each one. Only one of the two prices will show.
- In this branch, that should be fixed

@jeffstieler @DanReyLop @robobot3000 @v18  