### PR TITLE
Add tooltip to explain what adjustments are

### DIFF
--- a/assets/stylesheets/shipping-services.scss
+++ b/assets/stylesheets/shipping-services.scss
@@ -64,18 +64,24 @@
 		padding-bottom: 8px;
 		margin-bottom: 4px;
 
-	  .wcc-shipping-service-header {
-		display: inline-block;
-		margin-left: 0;
-		font-weight: bold;
-	  }
-
-	  .price-adjustment {
-		float: right;
-		@include breakpoint( '>480px' ) {
-		  padding-right: 8px;
+		.wcc-shipping-service-header {
+			display: inline-block;
+			margin-left: 0;
+			font-weight: bold;
 		}
-	  }
+
+		.price-adjustment {
+			float: right;
+			@include breakpoint( '>480px' ) {
+				padding-right: 8px;
+			}
+		}
+
+		.price-adjustment-info {
+			float: right;
+			margin-left: 4px;
+			height: 0;
+		}
 	}
 
 	.form-checkbox {

--- a/assets/stylesheets/shipping-services.scss
+++ b/assets/stylesheets/shipping-services.scss
@@ -58,28 +58,24 @@
 	}
 
 	&.multi-select-header {
-		display: flex;
+		display: inline-block;
 		box-sizing: border-box;
 		border-bottom: 1px solid lighten( $gray, 30% );
 		padding-bottom: 8px;
 		margin-bottom: 4px;
 
-		.wcc-shipping-service-header-container {
-		  flex-grow: 1;
+	  .wcc-shipping-service-header {
+		display: inline-block;
+		margin-left: 0;
+		font-weight: bold;
+	  }
 
-		  .wcc-shipping-service-header {
-			display: inline-block;
-			margin-left: 0;
-			font-weight: bold;
-		  }
-
-		  .price-adjustment {
-			float: right;
-			@include breakpoint( '>480px' ) {
-			  padding-right: 8px;
-			}
-		  }
+	  .price-adjustment {
+		float: right;
+		@include breakpoint( '>480px' ) {
+		  padding-right: 8px;
 		}
+	  }
 	}
 
 	.form-checkbox {

--- a/client/components/info-tooltip/index.js
+++ b/client/components/info-tooltip/index.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react';
+
+import Tooltip from 'components/tooltip';
+import Gridicon from 'components/gridicon';
+
+export default class InfoTooltip extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.openTooltip = this.openTooltip.bind( this );
+		this.closeTooltip = this.closeTooltip.bind( this );
+
+		this.state = {
+			showTooltip: false,
+		};
+	}
+
+	openTooltip() {
+		this.setState( { showTooltip: true } );
+	}
+
+	closeTooltip() {
+		this.setState( { showTooltip: false } );
+	}
+
+	render() {
+		return (
+			<span
+				onMouseEnter={ this.openTooltip }
+				onMouseLeave={ this.closeTooltip }
+				className={ this.props.className }
+				style={ { cursor: 'help' } } >
+				<Gridicon ref="icon" icon="info-outline" size={ 18 } />
+				{ this.state.showTooltip &&
+					<Tooltip
+						className="wc-connect-popover"
+						isVisible
+						onClose={ this.closeTooltip }
+						position="top"
+						context={ this.refs && this.refs.icon }>
+						{ this.props.children }
+					</Tooltip>
+				}
+			</span>
+		);
+	}
+}

--- a/client/components/info-tooltip/index.js
+++ b/client/components/info-tooltip/index.js
@@ -1,9 +1,20 @@
-import React, { Component } from 'react';
+import React, { PropTypes, Component } from 'react';
 
 import Tooltip from 'components/tooltip';
 import Gridicon from 'components/gridicon';
 
 export default class InfoTooltip extends Component {
+	static propTypes = {
+		className: PropTypes.string,
+		position: PropTypes.string,
+		maxWidth: PropTypes.string,
+	};
+
+	static defaultProps = {
+		position: 'top',
+		maxWidth: 'auto',
+	};
+
 	constructor( props ) {
 		super( props );
 
@@ -35,10 +46,13 @@ export default class InfoTooltip extends Component {
 					<Tooltip
 						className="wc-connect-popover"
 						isVisible
+						showOnMobile
 						onClose={ this.closeTooltip }
-						position="top"
+						position={ this.props.position }
 						context={ this.refs && this.refs.icon }>
-						{ this.props.children }
+						<div style={ { maxWidth: this.props.maxWidth } } >
+							{ this.props.children }
+						</div>
 					</Tooltip>
 				}
 			</span>

--- a/client/settings/views/services/group.js
+++ b/client/settings/views/services/group.js
@@ -3,6 +3,7 @@ import ShippingServiceEntry from './entry';
 import FoldableCard from 'components/foldable-card';
 import CheckBox from 'components/forms/form-checkbox';
 import Gridicon from 'components/gridicon';
+import InfoTooltip from 'components/info-tooltip';
 import { translate as __ } from 'lib/mixins/i18n';
 import { sprintf } from 'sprintf-js';
 import _ from 'lodash';
@@ -66,7 +67,12 @@ const ShippingServiceGroup = ( props ) => {
 		>
 			<div className="wcc-shipping-service-entry multi-select-header">
 				<span className="wcc-shipping-service-header service-name">{ __( 'Service' ) }</span>
-				<span className="wcc-shipping-service-header price-adjustment">{ __( 'Price adjustment' ) }</span>
+				<span className="wcc-shipping-service-header price-adjustment">
+					{ __( 'Price adjustment' ) }
+					<InfoTooltip className="price-adjustment-info">
+						Lorem ipsum
+					</InfoTooltip>
+				</span>
 			</div>
 
 			{ services.map( ( service, idx ) => (

--- a/client/settings/views/services/group.js
+++ b/client/settings/views/services/group.js
@@ -69,8 +69,11 @@ const ShippingServiceGroup = ( props ) => {
 				<span className="wcc-shipping-service-header service-name">{ __( 'Service' ) }</span>
 				<span className="wcc-shipping-service-header price-adjustment">
 					{ __( 'Price adjustment' ) }
-					<InfoTooltip className="price-adjustment-info">
-						Lorem ipsum
+					<InfoTooltip
+						className="price-adjustment-info"
+						position="top left"
+						maxWidth={ 230 }>
+						{ __( 'Increase the rates calculated by the carrier to account for packaging and handling costs. You can also add a negative amount to save your customers money.' ) }
 					</InfoTooltip>
 				</span>
 			</div>

--- a/client/settings/views/services/group.js
+++ b/client/settings/views/services/group.js
@@ -65,10 +65,8 @@ const ShippingServiceGroup = ( props ) => {
 			expanded={ ! _.isEmpty( errors ) }
 		>
 			<div className="wcc-shipping-service-entry multi-select-header">
-				<label className="wcc-shipping-service-header-container">
-					<span className="wcc-shipping-service-header service-name">{ __( 'Service' ) }</span>
-					<span className="wcc-shipping-service-header price-adjustment">{ __( 'Price adjustment' ) }</span>
-				</label>
+				<span className="wcc-shipping-service-header service-name">{ __( 'Service' ) }</span>
+				<span className="wcc-shipping-service-header price-adjustment">{ __( 'Price adjustment' ) }</span>
 			</div>
 
 			{ services.map( ( service, idx ) => (


### PR DESCRIPTION
Fixes #822 

Added a tooltip to explain the merchant what the "Price adjustment" ptions are.

To test, just go to a shipping instance configuration, open a service group and hover over the `(i)` icon. In mobile, it works by clicking on it.

Screenshot:
![tooltip](https://cloud.githubusercontent.com/assets/1715800/22188374/defa2340-e0ea-11e6-9060-0c773c5ea3fb.png)

I think it's fine, even a longer text would be perfectly fine.