### PR TITLE
Make the State <select> the same size as its surrounding fields

### DIFF
--- a/assets/stylesheets/shipping-services.scss
+++ b/assets/stylesheets/shipping-services.scss
@@ -102,6 +102,7 @@
 	.form-select {
 		flex-basis: 20%;
 		padding: 6px 32px 5px 14px;
+		line-height: 22px;
 		font-size: 13px;
 		box-shadow: none;
 

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -326,7 +326,7 @@
 			height: auto;
 			box-shadow: none;
 			width: 100%;
-			line-height: 22px;
+			line-height: 18px;
 			padding: 9px 32px 12px 14px;
 		}
 	}


### PR DESCRIPTION
Fixes #828 

Screenshot:
![state](https://cloud.githubusercontent.com/assets/1715800/22189440/fa51f5ac-e0f2-11e6-94b3-36b29128ff62.png)
